### PR TITLE
Fixed dlhn benchmark to work properly

### DIFF
--- a/crates/musli-tests/benches/comparison.rs
+++ b/crates/musli-tests/benches/comparison.rs
@@ -56,9 +56,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     benches!(musli_descriptive);
     benches!(musli_storage);
     benches!(musli_value);
-    // fixme:
-    // benches!(serde_dlhn);
-    // benches!(serde_cbor);
+    #[cfg(not(any(model_128, model_all)))]
+    benches!(serde_dlhn);
+    benches!(serde_cbor);
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/crates/musli-tests/src/models.rs
+++ b/crates/musli-tests/src/models.rs
@@ -47,7 +47,7 @@ pub enum MediumEnum {
 pub struct LargeStruct {
     elements: Vec<Primitives>,
     medium: Vec<MediumEnum>,
-    map: HashMap<u32, u64>,
+    map: HashMap<String, u64>,
 }
 
 pub fn generate_primitives(rng: &mut StdRng) -> Primitives {
@@ -122,7 +122,7 @@ pub fn generate_large_struct(rng: &mut StdRng) -> LargeStruct {
     let mut map = HashMap::new();
 
     for _ in 0..342 {
-        map.insert(rng.gen(), rng.gen());
+        map.insert(generate_string(rng), rng.gen());
     }
 
     LargeStruct {


### PR DESCRIPTION
Thank you for choosing dlhn as a benchmark target. I have made the following changes to make the dlhn benchmark work:

1. Changed the type of the `LargeStruct` map field from `HashMap<u32, u64>`, to `HashMap<String, u64>`. This is because dlhn can only use strings as Map types.
2. In Rust, floating-point numbers cannot be used as keys for HashMap or BTreeMap, so we made a bold decision to design dlhn to only allow strings as keys for Maps.
3. Currently, dlhn does not support 128-bit integers, so I have made changes to disable the dlhn benchmark when the model_128 option is enabled.
4. Lastly, I fixed the code to work by uncommenting `benches!(serde_cbor);`, which was commented out along with the fixme comment.

I hope that these changes will help improve the benchmarking process for musli. Thank you for your support and understanding.