### PR TITLE
Introduce polyfill macros for associated type defaults

### DIFF
--- a/crates/musli-descriptive/src/de.rs
+++ b/crates/musli-descriptive/src/de.rs
@@ -11,7 +11,6 @@ use musli::de::{
     SequenceDecoder, TypeHint, ValueVisitor, VariantDecoder,
 };
 use musli::error::Error;
-use musli::never::Never;
 use musli_common::int::{continuation as c, UsizeEncoding, Variable};
 use musli_common::reader::PosReader;
 use musli_storage::de::StorageDecoder;
@@ -165,12 +164,12 @@ pub struct RemainingSelfDecoder<R> {
     decoder: SelfDecoder<R>,
 }
 
+#[musli::decoder]
 impl<'de, R> Decoder<'de> for SelfDecoder<R>
 where
     R: PosReader<'de>,
 {
     type Error = R::Error;
-    type Buffer = Never<R::Error>;
     type Pack = SelfPackDecoder<R>;
     type Some = Self;
     type Sequence = RemainingSelfDecoder<R>;

--- a/crates/musli-descriptive/src/en.rs
+++ b/crates/musli-descriptive/src/en.rs
@@ -48,6 +48,7 @@ where
     }
 }
 
+#[musli::encoder]
 impl<W, const P: usize> Encoder for SelfEncoder<W, P>
 where
     W: Writer,

--- a/crates/musli-json/src/de.rs
+++ b/crates/musli-json/src/de.rs
@@ -13,7 +13,6 @@ use musli::de::{
 use musli::error::Error;
 #[cfg(feature = "musli-value")]
 use musli::mode::Mode;
-use musli::never::Never;
 
 use crate::reader::integer::{Signed, Unsigned};
 use crate::reader::SliceParser;
@@ -107,13 +106,12 @@ where
     }
 }
 
+#[musli::decoder]
 impl<'de, 'a, P> Decoder<'de> for JsonDecoder<'a, P>
 where
     P: Parser<'de>,
 {
     type Error = ParseError;
-    #[cfg(not(feature = "musli-value"))]
-    type Buffer = Never<Self::Error>;
     #[cfg(feature = "musli-value")]
     type Buffer = musli_value::AsValueDecoder<Self::Error>;
     type Pack = JsonSequenceDecoder<'a, P>;
@@ -445,19 +443,13 @@ where
     }
 }
 
+#[musli::decoder]
 impl<'de, 'a, P> Decoder<'de> for JsonKeyDecoder<'a, P>
 where
     P: Parser<'de>,
 {
     type Error = ParseError;
-    type Buffer = Never<Self::Error>;
-    type Pack = Never<Self::Error>;
-    type Sequence = Never<Self::Error>;
-    type Tuple = Never<Self::Error>;
-    type Map = Never<Self::Error>;
-    type Some = Never<Self::Error>;
     type Struct = JsonObjectDecoder<'a, P>;
-    type Variant = Never<Self::Error>;
 
     #[inline]
     fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/musli-json/src/en.rs
+++ b/crates/musli-json/src/en.rs
@@ -2,7 +2,6 @@ use core::{fmt, marker};
 
 use musli::en::{Encoder, PairEncoder, PairsEncoder, SequenceEncoder, VariantEncoder};
 use musli::mode::Mode;
-use musli::never::Never;
 use musli_common::writer::Writer;
 
 /// A JSON encoder for Müsli.
@@ -22,6 +21,7 @@ impl<M, W> JsonEncoder<M, W> {
     }
 }
 
+#[musli::encoder]
 impl<M, W> Encoder for JsonEncoder<M, W>
 where
     M: Mode,
@@ -410,19 +410,13 @@ macro_rules! format_integer {
     }};
 }
 
+#[musli::encoder]
 impl<W> Encoder for JsonObjectKeyEncoder<W>
 where
     W: Writer,
 {
     type Ok = ();
     type Error = W::Error;
-    type Pack = Never<Self>;
-    type Some = Never<Self>;
-    type Sequence = Never<Self>;
-    type Tuple = Never<Self>;
-    type Map = Never<Self>;
-    type Struct = Never<Self>;
-    type Variant = Never<Self>;
 
     #[inline]
     fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/musli-macros/src/lib.rs
+++ b/crates/musli-macros/src/lib.rs
@@ -16,6 +16,7 @@ mod de;
 mod en;
 mod expander;
 mod internals;
+mod types;
 
 /// Please refer to the main [musli documentation](https://docs.rs/musli).
 #[proc_macro_derive(Encode, attributes(musli))]
@@ -58,6 +59,52 @@ pub fn derive_decode(input: TokenStream) -> TokenStream {
             tokens.into()
         }
         Err(()) => to_compile_errors(expander.into_errors()).into(),
+    }
+}
+
+#[proc_macro_attribute]
+pub fn decoder(attr: TokenStream, input: TokenStream) -> TokenStream {
+    let attr = proc_macro2::TokenStream::from(attr);
+
+    if !attr.is_empty() {
+        return syn::Error::new_spanned(attr, "Arguments not supported")
+            .to_compile_error()
+            .into();
+    }
+
+    let input = syn::parse_macro_input!(input as types::Types);
+
+    match input.expand(
+        "decoder",
+        &types::DECODER_TYPES,
+        ["Error"],
+        "__UseMusliDecoderAttributeMacro",
+    ) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+#[proc_macro_attribute]
+pub fn encoder(attr: TokenStream, input: TokenStream) -> TokenStream {
+    let attr = proc_macro2::TokenStream::from(attr);
+
+    if !attr.is_empty() {
+        return syn::Error::new_spanned(attr, "Arguments not supported")
+            .to_compile_error()
+            .into();
+    }
+
+    let input = syn::parse_macro_input!(input as types::Types);
+
+    match input.expand(
+        "encoder",
+        &types::ENCODER_TYPES,
+        ["Ok", "Error"],
+        "__UseMusliEncoderAttributeMacro",
+    ) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
     }
 }
 

--- a/crates/musli-macros/src/types.rs
+++ b/crates/musli-macros/src/types.rs
@@ -1,0 +1,220 @@
+use std::collections::BTreeSet;
+
+use proc_macro2::{Span, TokenStream};
+use quote::ToTokens;
+use syn::parse::Parse;
+use syn::punctuated::Punctuated;
+use syn::Token;
+
+pub(super) const ENCODER_TYPES: [&str; 8] = [
+    "Error", "Some", "Pack", "Sequence", "Tuple", "Map", "Struct", "Variant",
+];
+
+pub(super) const DECODER_TYPES: [&str; 9] = [
+    "Error", "Buffer", "Some", "Pack", "Sequence", "Tuple", "Map", "Struct", "Variant",
+];
+
+pub(super) struct Types {
+    item_impl: syn::ItemImpl,
+}
+
+impl Parse for Types {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        Ok(Self {
+            item_impl: input.parse()?,
+        })
+    }
+}
+
+impl Types {
+    /// Expand encoder types.
+    pub(crate) fn expand<const N: usize>(
+        mut self,
+        what: &str,
+        types: &[&str],
+        arguments: [&str; N],
+        hint: &str,
+    ) -> syn::Result<TokenStream> {
+        let mut missing = types
+            .iter()
+            .map(|ident| syn::Ident::new(ident, Span::call_site()))
+            .collect::<BTreeSet<_>>();
+
+        // List of associated types which are specified, but under a `cfg`
+        // attribute so its conditions need to be inverted.
+        let mut not_attribute_ty = Vec::new();
+
+        for item in &self.item_impl.items {
+            match item {
+                syn::ImplItem::Type(ty) => {
+                    missing.remove(&ty.ident);
+
+                    let mut has_cfg = false;
+
+                    for attr in &ty.attrs {
+                        if !attr.path().is_ident("cfg") {
+                            continue;
+                        }
+
+                        if has_cfg {
+                            return Err(syn::Error::new_spanned(
+                                attr,
+                                format_args!(
+                                    "#[rune::{what}]: only one cfg attribute is supported"
+                                ),
+                            ));
+                        }
+
+                        not_attribute_ty.push(ty.clone());
+                        has_cfg = true;
+                    }
+                }
+                _ => continue,
+            }
+        }
+
+        let never = never_type(arguments);
+
+        for mut ty in not_attribute_ty {
+            for attr in &mut ty.attrs {
+                if !attr.path().is_ident("cfg") {
+                    continue;
+                }
+
+                if let syn::Meta::List(m) = &mut attr.meta {
+                    let tokens = syn::Meta::List(syn::MetaList {
+                        path: not_path(),
+                        delimiter: syn::MacroDelimiter::Paren(syn::token::Paren::default()),
+                        tokens: m.tokens.clone(),
+                    })
+                    .into_token_stream();
+
+                    m.tokens = tokens;
+                }
+            }
+
+            ty.ty = syn::Type::Path(syn::TypePath {
+                qself: None,
+                path: never.clone(),
+            });
+
+            self.item_impl.items.push(syn::ImplItem::Type(ty));
+        }
+
+        for ident in missing {
+            let ty = syn::ImplItemType {
+                attrs: Vec::new(),
+                vis: syn::Visibility::Inherited,
+                defaultness: None,
+                type_token: <Token![type]>::default(),
+                ident,
+                generics: syn::Generics::default(),
+                eq_token: <Token![=]>::default(),
+                ty: syn::Type::Path(syn::TypePath {
+                    qself: None,
+                    path: never.clone(),
+                }),
+                semi_token: <Token![;]>::default(),
+            };
+
+            self.item_impl.items.push(syn::ImplItem::Type(ty));
+        }
+
+        self.item_impl
+            .items
+            .push(syn::ImplItem::Type(syn::ImplItemType {
+                attrs: Vec::new(),
+                vis: syn::Visibility::Inherited,
+                defaultness: None,
+                type_token: <Token![type]>::default(),
+                ident: syn::Ident::new(hint, Span::call_site()),
+                generics: syn::Generics::default(),
+                eq_token: <Token![=]>::default(),
+                ty: syn::Type::Tuple(syn::TypeTuple {
+                    paren_token: <syn::token::Paren>::default(),
+                    elems: Punctuated::default(),
+                }),
+                semi_token: <Token![;]>::default(),
+            }));
+
+        Ok(self.item_impl.into_token_stream())
+    }
+}
+
+fn not_path() -> syn::Path {
+    let mut not_path = syn::Path {
+        leading_colon: None,
+        segments: Punctuated::default(),
+    };
+
+    not_path
+        .segments
+        .push(syn::PathSegment::from(syn::Ident::new(
+            "not",
+            Span::call_site(),
+        )));
+
+    not_path
+}
+
+fn never_type<const N: usize>(arguments: [&str; N]) -> syn::Path {
+    let mut never = syn::Path {
+        leading_colon: None,
+        segments: Punctuated::default(),
+    };
+
+    never.segments.push(syn::PathSegment::from(syn::Ident::new(
+        "musli",
+        Span::call_site(),
+    )));
+    never.segments.push(syn::PathSegment::from(syn::Ident::new(
+        "never",
+        Span::call_site(),
+    )));
+
+    never.segments.push({
+        let mut s = syn::PathSegment::from(syn::Ident::new("Never", Span::call_site()));
+
+        let mut args = Punctuated::default();
+
+        for arg in arguments {
+            args.push(syn::GenericArgument::Type(syn::Type::Path(syn::TypePath {
+                qself: None,
+                path: self_type(arg),
+            })));
+        }
+
+        s.arguments = syn::PathArguments::AngleBracketed(syn::AngleBracketedGenericArguments {
+            colon2_token: None,
+            lt_token: <Token![<]>::default(),
+            args,
+            gt_token: <Token![>]>::default(),
+        });
+
+        s
+    });
+    never
+}
+
+fn self_type(what: &str) -> syn::Path {
+    let mut self_error = syn::Path {
+        leading_colon: None,
+        segments: Punctuated::default(),
+    };
+
+    self_error
+        .segments
+        .push(syn::PathSegment::from(syn::Ident::new(
+            "Self",
+            Span::call_site(),
+        )));
+
+    self_error
+        .segments
+        .push(syn::PathSegment::from(syn::Ident::new(
+            what,
+            Span::call_site(),
+        )));
+
+    self_error
+}

--- a/crates/musli-storage/src/de.rs
+++ b/crates/musli-storage/src/de.rs
@@ -10,7 +10,6 @@ use musli::de::{
     Decoder, PackDecoder, PairDecoder, PairsDecoder, SequenceDecoder, ValueVisitor, VariantDecoder,
 };
 use musli::error::Error;
-use musli::never::Never;
 use musli_common::int::{IntegerEncoding, UsizeEncoding};
 use musli_common::reader::PosReader;
 
@@ -53,6 +52,7 @@ where
     decoder: StorageDecoder<R, I, L>,
 }
 
+#[musli::decoder]
 impl<'de, R, I, L> Decoder<'de> for StorageDecoder<R, I, L>
 where
     R: PosReader<'de>,
@@ -60,7 +60,6 @@ where
     L: UsizeEncoding,
 {
     type Error = R::Error;
-    type Buffer = Never<R::Error>;
     type Pack = Self;
     type Some = Self;
     type Sequence = LimitedStorageDecoder<R, I, L>;

--- a/crates/musli-storage/src/en.rs
+++ b/crates/musli-storage/src/en.rs
@@ -33,6 +33,7 @@ where
     }
 }
 
+#[musli::encoder]
 impl<W, I, L> Encoder for StorageEncoder<W, I, L>
 where
     W: Writer,

--- a/crates/musli-value/src/de.rs
+++ b/crates/musli-value/src/de.rs
@@ -48,6 +48,7 @@ macro_rules! ensure {
     };
 }
 
+#[musli::decoder]
 impl<'de, E> Decoder<'de> for ValueDecoder<'de, E>
 where
     E: Error + From<ValueError>,

--- a/crates/musli-value/src/en.rs
+++ b/crates/musli-value/src/en.rs
@@ -6,8 +6,6 @@ use alloc::vec::Vec;
 use musli::en::Encoder;
 #[cfg(feature = "alloc")]
 use musli::en::{PairEncoder, PairsEncoder, SequenceEncoder, VariantEncoder};
-#[cfg(not(feature = "alloc"))]
-use musli::never::Never;
 
 use crate::error::ValueError;
 use crate::value::{Number, Value};
@@ -60,6 +58,7 @@ impl<O> ValueEncoder<O> {
     }
 }
 
+#[musli::encoder]
 impl<O> Encoder for ValueEncoder<O>
 where
     O: ValueOutput,
@@ -68,32 +67,18 @@ where
     type Error = ValueError;
     #[cfg(feature = "alloc")]
     type Some = ValueEncoder<SomeValueWriter<O>>;
-    #[cfg(not(feature = "alloc"))]
-    type Some = Never<Self>;
     #[cfg(feature = "alloc")]
     type Pack = SequenceValueEncoder<O>;
-    #[cfg(not(feature = "alloc"))]
-    type Pack = Never<Self>;
     #[cfg(feature = "alloc")]
     type Sequence = SequenceValueEncoder<O>;
-    #[cfg(not(feature = "alloc"))]
-    type Sequence = Never<Self>;
     #[cfg(feature = "alloc")]
     type Tuple = SequenceValueEncoder<O>;
-    #[cfg(not(feature = "alloc"))]
-    type Tuple = Never<Self>;
     #[cfg(feature = "alloc")]
     type Map = MapValueEncoder<O>;
-    #[cfg(not(feature = "alloc"))]
-    type Map = Never<Self>;
     #[cfg(feature = "alloc")]
     type Struct = MapValueEncoder<O>;
-    #[cfg(not(feature = "alloc"))]
-    type Struct = Never<Self>;
     #[cfg(feature = "alloc")]
     type Variant = VariantValueEncoder<O>;
-    #[cfg(not(feature = "alloc"))]
-    type Variant = Never<Self>;
 
     #[inline]
     fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/crates/musli-wire/src/de.rs
+++ b/crates/musli-wire/src/de.rs
@@ -13,7 +13,6 @@ use musli::de::{
     Decoder, PackDecoder, PairDecoder, PairsDecoder, SequenceDecoder, ValueVisitor, VariantDecoder,
 };
 use musli::error::Error;
-use musli::never::Never;
 use musli_common::reader::{Limit, PosReader};
 use musli_storage::de::StorageDecoder;
 use musli_storage::int::{continuation as c, Variable};
@@ -156,6 +155,7 @@ where
     decoder: WireDecoder<R, I, L>,
 }
 
+#[musli::decoder]
 impl<'de, R, I, L> Decoder<'de> for WireDecoder<R, I, L>
 where
     R: PosReader<'de>,
@@ -163,7 +163,6 @@ where
     L: WireUsizeEncoding,
 {
     type Error = R::Error;
-    type Buffer = Never<R::Error>;
     type Pack = WireDecoder<Limit<R>, I, L>;
     type Some = Self;
     type Sequence = RemainingWireDecoder<R, I, L>;

--- a/crates/musli-wire/src/en.rs
+++ b/crates/musli-wire/src/en.rs
@@ -62,6 +62,7 @@ where
     }
 }
 
+#[musli::encoder]
 impl<W, I, L, const P: usize> Encoder for WireEncoder<W, I, L, P>
 where
     W: Writer,

--- a/crates/musli/src/de/decoder.rs
+++ b/crates/musli/src/de/decoder.rs
@@ -183,6 +183,12 @@ pub trait Decoder<'de>: Sized {
     /// [PairDecoder::second] is the content of the variant.
     type Variant: VariantDecoder<'de, Error = Self::Error>;
 
+    /// This is a type argument used to hint to any future implementor that they
+    /// should be using the [`#[musli::decoder]`][crate::decoder] attribute
+    /// macro when implementing [`Decoder`].
+    #[doc(hidden)]
+    type __UseMusliDecoderAttributeMacro;
+
     /// Format the human-readable message that should occur if the decoder was
     /// expecting to decode some specific kind of value.
     ///
@@ -190,20 +196,12 @@ pub trait Decoder<'de>: Sized {
     /// use std::fmt;
     ///
     /// use musli::de::Decoder;
-    /// use musli::never::Never;
     ///
     /// struct MyDecoder;
     ///
+    /// #[musli::decoder]
     /// impl Decoder<'_> for MyDecoder {
     ///     type Error = String;
-    ///     type Buffer = Never<Self::Error>;
-    ///     type Pack = Never<Self::Error>;
-    ///     type Sequence = Never<Self::Error>;
-    ///     type Tuple = Never<Self::Error>;
-    ///     type Map = Never<Self::Error>;
-    ///     type Some = Never<Self::Error>;
-    ///     type Struct = Never<Self::Error>;
-    ///     type Variant = Never<Self::Error>;
     ///
     ///     fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     ///         write!(f, "32-bit unsigned integers")

--- a/crates/musli/src/en/encoder.rs
+++ b/crates/musli/src/en/encoder.rs
@@ -177,6 +177,12 @@ pub trait Encoder: Sized {
     /// Encoder for a struct variant.
     type Variant: VariantEncoder<Ok = Self::Ok, Error = Self::Error>;
 
+    /// This is a type argument used to hint to any future implementor that they
+    /// should be using the [`#[musli::encoder]`][crate::encoder] attribute
+    /// macro when implementing [`Encoder`].
+    #[doc(hidden)]
+    type __UseMusliEncoderAttributeMacro;
+
     /// An expectation error. Every other implementation defers to this to
     /// report that something unexpected happened.
     fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;

--- a/crates/musli/src/lib.rs
+++ b/crates/musli/src/lib.rs
@@ -300,6 +300,7 @@ mod expecting;
 mod impls;
 mod internal;
 pub mod mode;
+#[doc(hidden)]
 pub mod never;
 #[cfg(not(feature = "alloc"))]
 mod no_std;
@@ -311,3 +312,77 @@ pub mod utils;
 pub use self::de::{Decode, Decoder};
 pub use self::en::{Encode, Encoder};
 pub use self::mode::Mode;
+
+/// This is an attribute macro that must be used when implementing a
+/// [`Encoder`].
+///
+/// It is required to use because a [`Encoder`] implementation might introduce
+/// new associated types in the future, and this [not yet supported] on a
+/// language level in Rust. So this attribute macro polyfills any missing types
+/// automatically.
+///
+/// [not yet supported]: https://rust-lang.github.io/rfcs/2532-associated-type-defaults.html
+///
+/// # Examples
+///
+/// ```
+/// use std::fmt;
+///
+/// use musli::en::Encoder;
+///
+/// struct MyEncoder<'a> {
+///     value: &'a mut Option<u32>,
+/// }
+///
+/// #[musli::encoder]
+/// impl Encoder for MyEncoder<'_> {
+///     type Ok = ();
+///     type Error = String;
+///
+///     fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+///         write!(f, "32-bit unsigned integers")
+///     }
+///
+///     fn encode_u32(self, value: u32) -> Result<(), Self::Error> {
+///         *self.value = Some(value);
+///         Ok(())
+///     }
+/// }
+/// ```
+#[doc(inline)]
+pub use musli_macros::encoder;
+
+/// This is an attribute macro that must be used when implementing a
+/// [`Decoder`].
+///
+/// It is required to use because a [`Decoder`] implementation might introduce
+/// new associated types in the future, and this is [not yet supported] on a
+/// language level in Rust. So this attribute macro polyfills any missing types
+/// automatically.
+///
+/// [not yet supported]: https://rust-lang.github.io/rfcs/2532-associated-type-defaults.html
+///
+/// # Examples
+///
+/// ```
+/// use std::fmt;
+///
+/// use musli::de::Decoder;
+///
+/// struct MyDecoder;
+///
+/// #[musli::decoder]
+/// impl Decoder<'_> for MyDecoder {
+///     type Error = String;
+///
+///     fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+///         write!(f, "32-bit unsigned integers")
+///     }
+///
+///     fn decode_u32(self) -> Result<u32, Self::Error> {
+///         Ok(42)
+///     }
+/// }
+/// ```
+#[doc(inline)]
+pub use musli_macros::decoder;

--- a/crates/musli/src/never.rs
+++ b/crates/musli/src/never.rs
@@ -1,7 +1,15 @@
 //! Module that provides a never type which conveniently implements all the
 //! encoder and decoder traits so that it can be used as a placeholder.
+//!
+//! This is a private module of musli, and is not intended for use outside of
+//! the implementation attributes:
+//!
+//! * [`#[musli::encoder]`][crate::encoder].
+//! * [`#[musli::decoder]`][crate::decoder].
 
-use core::{fmt, marker};
+use core::convert::Infallible;
+use core::fmt;
+use core::marker;
 
 use crate::de::{
     AsDecoder, Decoder, PackDecoder, PairDecoder, PairsDecoder, SequenceDecoder, VariantDecoder,
@@ -19,20 +27,12 @@ enum NeverMarker {}
 /// use std::fmt;
 ///
 /// use musli::de::Decoder;
-/// use musli::never::Never;
 ///
 /// struct MyDecoder;
 ///
+/// #[musli::decoder]
 /// impl Decoder<'_> for MyDecoder {
 ///     type Error = String;
-///     type Buffer = Never<Self::Error>;
-///     type Pack = Never<Self::Error>;
-///     type Sequence = Never<Self::Error>;
-///     type Tuple = Never<Self::Error>;
-///     type Map = Never<Self::Error>;
-///     type Some = Never<Self::Error>;
-///     type Struct = Never<Self::Error>;
-///     type Variant = Never<Self::Error>;
 ///
 ///     fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 ///         write!(f, "32-bit unsigned integers")
@@ -43,10 +43,10 @@ enum NeverMarker {}
 ///     }
 /// }
 /// ```
-pub struct Never<T> {
+pub struct Never<A, B = Infallible> {
     // Field makes type uninhabitable.
     _never: NeverMarker,
-    _marker: marker::PhantomData<T>,
+    _marker: marker::PhantomData<(A, B)>,
 }
 
 impl<'de, E> Decoder<'de> for Never<E>
@@ -62,6 +62,7 @@ where
     type Some = Self;
     type Struct = Self;
     type Variant = Self;
+    type __UseMusliDecoderAttributeMacro = ();
 
     #[inline]
     fn expecting(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -219,12 +220,12 @@ where
     }
 }
 
-impl<T> Encoder for Never<T>
+impl<O, E> Encoder for Never<O, E>
 where
-    T: Encoder,
+    E: Error,
 {
-    type Ok = T::Ok;
-    type Error = T::Error;
+    type Ok = O;
+    type Error = E;
     type Pack = Self;
     type Some = Self;
     type Sequence = Self;
@@ -232,6 +233,7 @@ where
     type Map = Self;
     type Struct = Self;
     type Variant = Self;
+    type __UseMusliEncoderAttributeMacro = ();
 
     #[inline]
     fn expecting(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -239,12 +241,12 @@ where
     }
 }
 
-impl<T> SequenceEncoder for Never<T>
+impl<O, E> SequenceEncoder for Never<O, E>
 where
-    T: Encoder,
+    E: Error,
 {
-    type Ok = T::Ok;
-    type Error = T::Error;
+    type Ok = O;
+    type Error = E;
 
     type Encoder<'this> = Self
     where
@@ -261,12 +263,12 @@ where
     }
 }
 
-impl<T> PairsEncoder for Never<T>
+impl<O, E> PairsEncoder for Never<O, E>
 where
-    T: Encoder,
+    E: Error,
 {
-    type Ok = T::Ok;
-    type Error = T::Error;
+    type Ok = O;
+    type Error = E;
     type Encoder<'this> = Self where Self: 'this;
 
     #[inline]
@@ -279,12 +281,12 @@ where
     }
 }
 
-impl<T> PairEncoder for Never<T>
+impl<O, E> PairEncoder for Never<O, E>
 where
-    T: Encoder,
+    E: Error,
 {
-    type Ok = T::Ok;
-    type Error = T::Error;
+    type Ok = O;
+    type Error = E;
     type First<'this> = Self
     where
         Self: 'this;
@@ -306,12 +308,12 @@ where
     }
 }
 
-impl<T> VariantEncoder for Never<T>
+impl<O, E> VariantEncoder for Never<O, E>
 where
-    T: Encoder,
+    E: Error,
 {
-    type Ok = T::Ok;
-    type Error = T::Error;
+    type Ok = O;
+    type Error = E;
     type Tag<'this> = Self
     where
         Self: 'this;


### PR DESCRIPTION
This introduces the following polyfill macros which must be used when implementing an `Encoder` or a `Decoder`:
* `#[musli::encoder]`.
* `#[musli::decoder]`.

It is required to use because an `Encoder` or a `Decoder` implementation might introduce new associated types in the future, and this [not yet supported] on a language level in Rust. So this attribute macro polyfills any missing types automatically.

This is the last necessary step before this library can start approaching stabilization. Since we want to reserve the ability to introduce new associated types in the future in case they are needed.

[not yet supported]: https://rust-lang.github.io/rfcs/2532-associated-type-defaults.html

Using this, this is what an example `Decoder` looks like:

```rust
use std::fmt;
use musli::de::Decoder;

struct MyDecoder;

#[musli::decoder]
impl Decoder<'_> for MyDecoder {
    type Error = String;

    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
        write!(f, "32-bit unsigned integers")
    }

    fn decode_u32(self) -> Result<u32, Self::Error> {
        Ok(42)
    }
}
```