### PR TITLE
Add decode_any through Visitor

### DIFF
--- a/crates/musli-common/src/reader.rs
+++ b/crates/musli-common/src/reader.rs
@@ -89,11 +89,11 @@ pub trait Reader<'de> {
 
             #[inline]
             fn visit_borrowed(self, bytes: &'de Self::Target) -> Result<Self::Ok, Self::Error> {
-                self.visit_any(bytes)
+                self.visit_ref(bytes)
             }
 
             #[inline]
-            fn visit_any(self, bytes: &Self::Target) -> Result<Self::Ok, Self::Error> {
+            fn visit_ref(self, bytes: &Self::Target) -> Result<Self::Ok, Self::Error> {
                 self.0.copy_from_slice(bytes);
                 Ok(())
             }
@@ -134,11 +134,11 @@ pub trait Reader<'de> {
 
             #[inline]
             fn visit_borrowed(self, bytes: &'de Self::Target) -> Result<Self::Ok, Self::Error> {
-                self.visit_any(bytes)
+                self.visit_ref(bytes)
             }
 
             #[inline]
-            fn visit_any(mut self, bytes: &Self::Target) -> Result<Self::Ok, Self::Error> {
+            fn visit_ref(mut self, bytes: &Self::Target) -> Result<Self::Ok, Self::Error> {
                 self.0.copy_from_slice(bytes);
                 Ok(self.0)
             }

--- a/crates/musli-json/src/reader/parser.rs
+++ b/crates/musli-json/src/reader/parser.rs
@@ -135,7 +135,7 @@ pub trait Parser<'de>: private::Sealed {
     #[doc(hidden)]
     fn parse_number<V>(&mut self, visitor: V) -> Result<V::Ok, ParseError>
     where
-        V: NumberVisitor<Error = ParseError>,
+        V: NumberVisitor<'de, Error = ParseError>,
     {
         let signed = integer::decode_signed::<i128, _>(self)?;
 

--- a/crates/musli-macros/src/lib.rs
+++ b/crates/musli-macros/src/lib.rs
@@ -108,6 +108,29 @@ pub fn encoder(attr: TokenStream, input: TokenStream) -> TokenStream {
     }
 }
 
+#[proc_macro_attribute]
+pub fn visitor(attr: TokenStream, input: TokenStream) -> TokenStream {
+    let attr = proc_macro2::TokenStream::from(attr);
+
+    if !attr.is_empty() {
+        return syn::Error::new_spanned(attr, "Arguments not supported")
+            .to_compile_error()
+            .into();
+    }
+
+    let input = syn::parse_macro_input!(input as types::Types);
+
+    match input.expand(
+        "visitor",
+        &types::VISITOR_TYPES,
+        ["Ok", "Error"],
+        "__UseMusliVisitorAttributeMacro",
+    ) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
 fn to_compile_errors(errors: Vec<syn::Error>) -> proc_macro2::TokenStream {
     let mut output = proc_macro2::TokenStream::new();
 

--- a/crates/musli-storage/src/de.rs
+++ b/crates/musli-storage/src/de.rs
@@ -7,7 +7,8 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 use musli::de::{
-    Decoder, PackDecoder, PairDecoder, PairsDecoder, SequenceDecoder, ValueVisitor, VariantDecoder,
+    Decoder, PackDecoder, PairDecoder, PairsDecoder, SequenceDecoder, SizeHint, ValueVisitor,
+    VariantDecoder,
 };
 use musli::error::Error;
 use musli_common::int::{IntegerEncoding, UsizeEncoding};
@@ -143,9 +144,9 @@ where
             }
 
             #[inline]
-            fn visit_any(self, bytes: &[u8]) -> Result<Self::Ok, Self::Error> {
+            fn visit_ref(self, bytes: &[u8]) -> Result<Self::Ok, Self::Error> {
                 let string = core::str::from_utf8(bytes).map_err(Self::Error::custom)?;
-                self.0.visit_any(string)
+                self.0.visit_ref(string)
             }
         }
     }
@@ -324,8 +325,8 @@ where
     type Decoder<'this> = StorageDecoder<R::PosMut<'this>, I, L> where Self: 'this;
 
     #[inline]
-    fn size_hint(&self) -> Option<usize> {
-        Some(self.remaining)
+    fn size_hint(&self) -> SizeHint {
+        SizeHint::Exact(self.remaining)
     }
 
     #[inline]
@@ -359,8 +360,8 @@ where
         Self: 'this;
 
     #[inline]
-    fn size_hint(&self) -> Option<usize> {
-        Some(self.remaining)
+    fn size_hint(&self) -> SizeHint {
+        SizeHint::Exact(self.remaining)
     }
 
     #[inline]

--- a/crates/musli-tests/tests/ui/visitor_attribute_ok.rs
+++ b/crates/musli-tests/tests/ui/visitor_attribute_ok.rs
@@ -1,0 +1,29 @@
+use core::fmt;
+use core::marker;
+
+use musli::de::Visitor;
+use musli::error::Error;
+
+struct AnyVisitor<E> {
+    _marker: marker::PhantomData<E>,
+}
+
+#[musli::visitor]
+impl<'de, E> Visitor<'de> for AnyVisitor<E>
+where
+    E: Error,
+{
+    type Ok = ();
+    type Error = E;
+
+    #[inline]
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "value that can be decoded into dynamic container"
+        )
+    }
+}
+
+fn main() {
+}

--- a/crates/musli-wire/src/de.rs
+++ b/crates/musli-wire/src/de.rs
@@ -10,7 +10,8 @@ use crate::integer_encoding::{WireIntegerEncoding, WireUsizeEncoding};
 use crate::tag::Kind;
 use crate::tag::Tag;
 use musli::de::{
-    Decoder, PackDecoder, PairDecoder, PairsDecoder, SequenceDecoder, ValueVisitor, VariantDecoder,
+    Decoder, PackDecoder, PairDecoder, PairsDecoder, SequenceDecoder, SizeHint, ValueVisitor,
+    VariantDecoder,
 };
 use musli::error::Error;
 use musli_common::reader::{Limit, PosReader};
@@ -251,9 +252,9 @@ where
             }
 
             #[inline]
-            fn visit_any(self, bytes: &[u8]) -> Result<Self::Ok, Self::Error> {
+            fn visit_ref(self, bytes: &[u8]) -> Result<Self::Ok, Self::Error> {
                 let string = core::str::from_utf8(bytes).map_err(Self::Error::custom)?;
-                self.0.visit_any(string)
+                self.0.visit_ref(string)
             }
         }
     }
@@ -479,8 +480,8 @@ where
     type Decoder<'this> = WireDecoder<R::PosMut<'this>, I, L> where Self: 'this;
 
     #[inline]
-    fn size_hint(&self) -> Option<usize> {
-        Some(self.remaining)
+    fn size_hint(&self) -> SizeHint {
+        SizeHint::Exact(self.remaining)
     }
 
     #[inline]
@@ -576,8 +577,8 @@ where
         Self: 'this;
 
     #[inline]
-    fn size_hint(&self) -> Option<usize> {
-        Some(self.remaining)
+    fn size_hint(&self) -> SizeHint {
+        SizeHint::Exact(self.remaining)
     }
 
     #[inline]

--- a/crates/musli/src/compat/alloc.rs
+++ b/crates/musli/src/compat/alloc.rs
@@ -60,7 +60,7 @@ where
             }
 
             #[inline]
-            fn visit_any(self, bytes: &[u8]) -> Result<Self::Ok, Self::Error> {
+            fn visit_ref(self, bytes: &[u8]) -> Result<Self::Ok, Self::Error> {
                 Ok(bytes.to_vec())
             }
         }

--- a/crates/musli/src/de.rs
+++ b/crates/musli/src/de.rs
@@ -21,14 +21,16 @@ mod decoder;
 mod number_visitor;
 mod type_hint;
 mod value_visitor;
+mod visitor;
 
 pub use self::decode::Decode;
 pub use self::decoder::{
     AsDecoder, Decoder, PackDecoder, PairDecoder, PairsDecoder, SequenceDecoder, VariantDecoder,
 };
 pub use self::number_visitor::NumberVisitor;
-pub use self::type_hint::{LengthHint, NumberHint, TypeHint};
+pub use self::type_hint::{NumberHint, SizeHint, TypeHint};
 pub use self::value_visitor::ValueVisitor;
+pub use self::visitor::Visitor;
 use crate::mode::Mode;
 
 /// Decode to a `'static` value.

--- a/crates/musli/src/de/number_visitor.rs
+++ b/crates/musli/src/de/number_visitor.rs
@@ -1,10 +1,11 @@
 use core::fmt;
 
+use crate::de::{Decoder, TypeHint};
 use crate::error::Error;
 use crate::expecting::{self, Expecting};
 
 /// A visitor capable of processing arbitrary number values.
-pub trait NumberVisitor: Sized {
+pub trait NumberVisitor<'de>: Sized {
     /// The output of the visitor.
     type Ok;
     /// An error type.
@@ -20,7 +21,7 @@ pub trait NumberVisitor: Sized {
     fn visit_u8(self, _: u8) -> Result<Self::Ok, Self::Error> {
         Err(Self::Error::message(expecting::bad_visitor_type(
             &expecting::Unsigned8,
-            &NumberExpecting(self),
+            &ExpectingWrapper(self),
         )))
     }
 
@@ -29,7 +30,7 @@ pub trait NumberVisitor: Sized {
     fn visit_u16(self, _: u16) -> Result<Self::Ok, Self::Error> {
         Err(Self::Error::message(expecting::bad_visitor_type(
             &expecting::Unsigned16,
-            &NumberExpecting(self),
+            &ExpectingWrapper(self),
         )))
     }
 
@@ -38,7 +39,7 @@ pub trait NumberVisitor: Sized {
     fn visit_u32(self, _: u32) -> Result<Self::Ok, Self::Error> {
         Err(Self::Error::message(expecting::bad_visitor_type(
             &expecting::Unsigned32,
-            &NumberExpecting(self),
+            &ExpectingWrapper(self),
         )))
     }
 
@@ -47,7 +48,7 @@ pub trait NumberVisitor: Sized {
     fn visit_u64(self, _: u64) -> Result<Self::Ok, Self::Error> {
         Err(Self::Error::message(expecting::bad_visitor_type(
             &expecting::Unsigned64,
-            &NumberExpecting(self),
+            &ExpectingWrapper(self),
         )))
     }
 
@@ -56,7 +57,7 @@ pub trait NumberVisitor: Sized {
     fn visit_u128(self, _: u128) -> Result<Self::Ok, Self::Error> {
         Err(Self::Error::message(expecting::bad_visitor_type(
             &expecting::Unsigned128,
-            &NumberExpecting(self),
+            &ExpectingWrapper(self),
         )))
     }
 
@@ -65,7 +66,7 @@ pub trait NumberVisitor: Sized {
     fn visit_i8(self, _: i8) -> Result<Self::Ok, Self::Error> {
         Err(Self::Error::message(expecting::bad_visitor_type(
             &expecting::Signed8,
-            &NumberExpecting(self),
+            &ExpectingWrapper(self),
         )))
     }
 
@@ -74,7 +75,7 @@ pub trait NumberVisitor: Sized {
     fn visit_i16(self, _: i16) -> Result<Self::Ok, Self::Error> {
         Err(Self::Error::message(expecting::bad_visitor_type(
             &expecting::Signed16,
-            &NumberExpecting(self),
+            &ExpectingWrapper(self),
         )))
     }
 
@@ -83,7 +84,7 @@ pub trait NumberVisitor: Sized {
     fn visit_i32(self, _: i32) -> Result<Self::Ok, Self::Error> {
         Err(Self::Error::message(expecting::bad_visitor_type(
             &expecting::Signed32,
-            &NumberExpecting(self),
+            &ExpectingWrapper(self),
         )))
     }
 
@@ -92,7 +93,7 @@ pub trait NumberVisitor: Sized {
     fn visit_i64(self, _: i64) -> Result<Self::Ok, Self::Error> {
         Err(Self::Error::message(expecting::bad_visitor_type(
             &expecting::Signed64,
-            &NumberExpecting(self),
+            &ExpectingWrapper(self),
         )))
     }
 
@@ -101,7 +102,7 @@ pub trait NumberVisitor: Sized {
     fn visit_i128(self, _: i128) -> Result<Self::Ok, Self::Error> {
         Err(Self::Error::message(expecting::bad_visitor_type(
             &expecting::Signed128,
-            &NumberExpecting(self),
+            &ExpectingWrapper(self),
         )))
     }
 
@@ -110,7 +111,7 @@ pub trait NumberVisitor: Sized {
     fn visit_f32(self, _: f32) -> Result<Self::Ok, Self::Error> {
         Err(Self::Error::message(expecting::bad_visitor_type(
             &expecting::Float32,
-            &NumberExpecting(self),
+            &ExpectingWrapper(self),
         )))
     }
 
@@ -119,7 +120,7 @@ pub trait NumberVisitor: Sized {
     fn visit_f64(self, _: f64) -> Result<Self::Ok, Self::Error> {
         Err(Self::Error::message(expecting::bad_visitor_type(
             &expecting::Float64,
-            &NumberExpecting(self),
+            &ExpectingWrapper(self),
         )))
     }
 
@@ -128,7 +129,7 @@ pub trait NumberVisitor: Sized {
     fn visit_usize(self, _: usize) -> Result<Self::Ok, Self::Error> {
         Err(Self::Error::message(expecting::bad_visitor_type(
             &expecting::Usize,
-            &NumberExpecting(self),
+            &ExpectingWrapper(self),
         )))
     }
 
@@ -137,18 +138,41 @@ pub trait NumberVisitor: Sized {
     fn visit_isize(self, _: isize) -> Result<Self::Ok, Self::Error> {
         Err(Self::Error::message(expecting::bad_visitor_type(
             &expecting::Isize,
-            &NumberExpecting(self),
+            &ExpectingWrapper(self),
+        )))
+    }
+
+    /// Visit bytes constituting a raw number.
+    #[inline]
+    fn visit_bytes(self, _: &'de [u8]) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::message(expecting::bad_visitor_type(
+            &expecting::Number,
+            &ExpectingWrapper(self),
+        )))
+    }
+
+    /// Fallback used when the type is either not implemented for this visitor
+    /// or the underlying format doesn't know which type to decode.
+    #[inline]
+    fn visit_any<D>(self, _: D, hint: TypeHint) -> Result<Self::Ok, Self::Error>
+    where
+        D: Decoder<'de, Error = Self::Error>,
+    {
+        Err(Self::Error::message(expecting::invalid_type(
+            &hint,
+            &ExpectingWrapper(self),
         )))
     }
 }
 
 #[repr(transparent)]
-struct NumberExpecting<T>(T);
+struct ExpectingWrapper<T>(T);
 
-impl<T> Expecting for NumberExpecting<T>
+impl<'de, T> Expecting for ExpectingWrapper<T>
 where
-    T: NumberVisitor,
+    T: NumberVisitor<'de>,
 {
+    #[inline]
     fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.expecting(f)
     }

--- a/crates/musli/src/de/type_hint.rs
+++ b/crates/musli/src/de/type_hint.rs
@@ -61,7 +61,7 @@ impl fmt::Display for NumberHint {
 /// A length hint.
 #[derive(Default, Debug, Clone, Copy)]
 #[non_exhaustive]
-pub enum LengthHint {
+pub enum SizeHint {
     /// The length isn't known.
     #[default]
     Any,
@@ -69,12 +69,41 @@ pub enum LengthHint {
     Exact(usize),
 }
 
-impl LengthHint {
+impl SizeHint {
+    /// Get a size hint or a default value.
+    pub fn or_default(self) -> usize {
+        match self {
+            SizeHint::Any => 0,
+            SizeHint::Exact(n) => n,
+        }
+    }
+}
+
+impl From<Option<usize>> for SizeHint {
+    fn from(value: Option<usize>) -> Self {
+        match value {
+            Some(n) => SizeHint::Exact(n),
+            None => SizeHint::Any,
+        }
+    }
+}
+
+impl fmt::Display for SizeHint {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SizeHint::Any => write!(f, "unknown length"),
+            SizeHint::Exact(length) => write!(f, "{length} items"),
+        }
+    }
+}
+
+impl SizeHint {
     /// Coerce into a size hint.
     pub fn size_hint(self) -> usize {
         match self {
-            LengthHint::Any => 0,
-            LengthHint::Exact(len) => len,
+            SizeHint::Any => 0,
+            SizeHint::Exact(len) => len,
         }
     }
 }
@@ -94,13 +123,13 @@ pub enum TypeHint {
     /// The type as a number.
     Number(NumberHint),
     /// A byte array.
-    Bytes(LengthHint),
+    Bytes(SizeHint),
     /// A string with the given length.
-    String(LengthHint),
+    String(SizeHint),
     /// A sequence with a length hint.
-    Sequence(LengthHint),
+    Sequence(SizeHint),
     /// A map with a length hint.
-    Map(LengthHint),
+    Map(SizeHint),
     /// A variant.
     Variant,
     /// An optional value.

--- a/crates/musli/src/de/visitor.rs
+++ b/crates/musli/src/de/visitor.rs
@@ -1,0 +1,291 @@
+use core::fmt;
+
+use crate::de::{
+    Decoder, NumberHint, NumberVisitor, PairsDecoder, SequenceDecoder, SizeHint, TypeHint,
+    VariantDecoder,
+};
+use crate::error::Error;
+use crate::expecting::{self, Expecting};
+
+use super::ValueVisitor;
+
+/// Visitor capable of decoding any type into a value [`Visitor::Ok`].
+///
+/// Each callback on this visitor indicates the type that should be decoded from
+/// the passed in decoder. A typical implementation would simply call the
+/// corresponding decoder function for the type being visited.
+pub trait Visitor<'de>: Sized {
+    /// The value produced by the visitor.
+    type Ok;
+    /// The error type produced.
+    type Error: Error;
+    /// String decoder to use.
+    type String: ValueVisitor<'de, Target = str, Ok = Self::Ok, Error = Self::Error>;
+    /// Bytes decoder to use.
+    type Bytes: ValueVisitor<'de, Target = [u8], Ok = Self::Ok, Error = Self::Error>;
+    /// Number decoder to use.
+    type Number: NumberVisitor<'de, Ok = Self::Ok, Error = Self::Error>;
+
+    /// This is a type argument used to hint to any future implementor that they
+    /// should be using the [`#[musli::visitor]`][crate::visitor] attribute
+    /// macro when implementing [`Visitor`].
+    #[doc(hidden)]
+    type __UseMusliVisitorAttributeMacro;
+
+    /// Format the human-readable message that should occur if the decoder was
+    /// expecting to decode some specific kind of value.
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
+
+    /// Fallback used when the type is either not implemented for this visitor
+    /// or the underlying format doesn't know which type to decode.
+    fn visit_any<D>(self, _: D, hint: TypeHint) -> Result<Self::Ok, Self::Error>
+    where
+        D: Decoder<'de, Error = Self::Error>,
+    {
+        Err(Self::Error::message(expecting::invalid_type(
+            &hint,
+            &ExpectingWrapper(self),
+        )))
+    }
+
+    /// Indicates that the visited type is a `unit`.
+    #[inline]
+    fn visit_unit(self) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::message(expecting::invalid_type(
+            &expecting::Unit,
+            &ExpectingWrapper(self),
+        )))
+    }
+
+    /// Indicates that the visited type is a `bool`.
+    #[inline]
+    fn visit_bool(self, _: bool) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::message(expecting::invalid_type(
+            &expecting::Bool,
+            &ExpectingWrapper(self),
+        )))
+    }
+
+    /// Indicates that the visited type is a `char`.
+    #[inline]
+    fn visit_char(self, _: char) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::message(expecting::invalid_type(
+            &expecting::Char,
+            &ExpectingWrapper(self),
+        )))
+    }
+
+    /// Indicates that the visited type is a `u8`.
+    #[inline]
+    fn visit_u8(self, _: u8) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::message(expecting::invalid_type(
+            &expecting::Unsigned8,
+            &ExpectingWrapper(self),
+        )))
+    }
+
+    /// Indicates that the visited type is a `u16`.
+    #[inline]
+    fn visit_u16(self, _: u16) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::message(expecting::invalid_type(
+            &expecting::Unsigned16,
+            &ExpectingWrapper(self),
+        )))
+    }
+
+    /// Indicates that the visited type is a `u32`.
+    #[inline]
+    fn visit_u32(self, _: u32) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::message(expecting::invalid_type(
+            &expecting::Unsigned32,
+            &ExpectingWrapper(self),
+        )))
+    }
+
+    /// Indicates that the visited type is a `u64`.
+    #[inline]
+    fn visit_u64(self, _: u64) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::message(expecting::invalid_type(
+            &expecting::Unsigned64,
+            &ExpectingWrapper(self),
+        )))
+    }
+
+    /// Indicates that the visited type is a `u128`.
+    #[inline]
+    fn visit_u128(self, _: u128) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::message(expecting::invalid_type(
+            &expecting::Unsigned128,
+            &ExpectingWrapper(self),
+        )))
+    }
+
+    /// Indicates that the visited type is a `i8`.
+    #[inline]
+    fn visit_i8(self, _: i8) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::message(expecting::invalid_type(
+            &expecting::Signed8,
+            &ExpectingWrapper(self),
+        )))
+    }
+
+    /// Indicates that the visited type is a `i16`.
+    #[inline]
+    fn visit_i16(self, _: i16) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::message(expecting::invalid_type(
+            &expecting::Signed16,
+            &ExpectingWrapper(self),
+        )))
+    }
+
+    /// Indicates that the visited type is a `i32`.
+    #[inline]
+    fn visit_i32(self, _: i32) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::message(expecting::invalid_type(
+            &expecting::Signed32,
+            &ExpectingWrapper(self),
+        )))
+    }
+
+    /// Indicates that the visited type is a `i64`.
+    #[inline]
+    fn visit_i64(self, _: i64) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::message(expecting::invalid_type(
+            &expecting::Signed64,
+            &ExpectingWrapper(self),
+        )))
+    }
+
+    /// Indicates that the visited type is a `i128`.
+    #[inline]
+    fn visit_i128(self, _: i128) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::message(expecting::invalid_type(
+            &expecting::Signed128,
+            &ExpectingWrapper(self),
+        )))
+    }
+
+    /// Indicates that the visited type is a `usize`.
+    #[inline]
+    fn visit_usize(self, _: usize) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::message(expecting::invalid_type(
+            &expecting::Usize,
+            &ExpectingWrapper(self),
+        )))
+    }
+
+    /// Indicates that the visited type is a `isize`.
+    #[inline]
+    fn visit_isize(self, _: isize) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::message(expecting::invalid_type(
+            &expecting::Isize,
+            &ExpectingWrapper(self),
+        )))
+    }
+
+    /// Indicates that the visited type is a `f32`.
+    #[inline]
+    fn visit_f32(self, _: f32) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::message(expecting::invalid_type(
+            &expecting::Float32,
+            &ExpectingWrapper(self),
+        )))
+    }
+
+    /// Indicates that the visited type is a `f64`.
+    #[inline]
+    fn visit_f64(self, _: f64) -> Result<Self::Ok, Self::Error> {
+        Err(Self::Error::message(expecting::invalid_type(
+            &expecting::Float64,
+            &ExpectingWrapper(self),
+        )))
+    }
+
+    /// Indicates that the visited type is an optional type.
+    #[inline]
+    fn visit_option<D>(self, _: Option<D>) -> Result<Self::Ok, Self::Error>
+    where
+        D: Decoder<'de, Error = Self::Error>,
+    {
+        Err(Self::Error::message(expecting::invalid_type(
+            &expecting::Option,
+            &ExpectingWrapper(self),
+        )))
+    }
+
+    /// Indicates that the visited type is a sequence.
+    #[inline]
+    fn visit_sequence<D>(self, decoder: D) -> Result<Self::Ok, Self::Error>
+    where
+        D: SequenceDecoder<'de, Error = Self::Error>,
+    {
+        Err(Self::Error::message(expecting::invalid_type(
+            &expecting::SequenceWith(decoder.size_hint()),
+            &ExpectingWrapper(self),
+        )))
+    }
+
+    /// Indicates that the visited type is a map.
+    #[inline]
+    fn visit_map<D>(self, decoder: D) -> Result<Self::Ok, Self::Error>
+    where
+        D: PairsDecoder<'de, Error = Self::Error>,
+    {
+        Err(Self::Error::message(expecting::invalid_type(
+            &expecting::MapWith(decoder.size_hint()),
+            &ExpectingWrapper(self),
+        )))
+    }
+
+    /// Indicates that the visited type is `string`.
+    #[inline]
+    fn visit_string(self, hint: SizeHint) -> Result<Self::String, Self::Error> {
+        Err(Self::Error::message(expecting::invalid_type(
+            &expecting::StringWith(hint),
+            &ExpectingWrapper(self),
+        )))
+    }
+
+    /// Indicates that the visited type is `bytes`.
+    #[inline]
+    fn visit_bytes(self, hint: SizeHint) -> Result<Self::Bytes, Self::Error> {
+        Err(Self::Error::message(expecting::invalid_type(
+            &expecting::BytesWith(hint),
+            &ExpectingWrapper(self),
+        )))
+    }
+
+    /// Indicates that the visited type is a number.
+    #[inline]
+    fn visit_number(self, hint: NumberHint) -> Result<Self::Number, Self::Error> {
+        Err(Self::Error::message(expecting::invalid_type(
+            &expecting::NumberWith(hint),
+            &ExpectingWrapper(self),
+        )))
+    }
+
+    /// Indicates that the visited type is a variant.
+    #[inline]
+    fn visit_variant<D>(self, _: D) -> Result<Self::Ok, Self::Error>
+    where
+        D: VariantDecoder<'de, Error = Self::Error>,
+    {
+        Err(Self::Error::message(expecting::invalid_type(
+            &expecting::Variant,
+            &ExpectingWrapper(self),
+        )))
+    }
+}
+
+#[repr(transparent)]
+struct ExpectingWrapper<T>(T);
+
+impl<'de, T> Expecting for ExpectingWrapper<T>
+where
+    T: Visitor<'de>,
+{
+    #[inline]
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.expecting(f)
+    }
+}

--- a/crates/musli/src/en/encoder.rs
+++ b/crates/musli/src/en/encoder.rs
@@ -1080,6 +1080,7 @@ impl<T> Expecting for ExpectingWrapper<T>
 where
     T: Encoder,
 {
+    #[inline]
     fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.expecting(f)
     }

--- a/crates/musli/src/impls/alloc.rs
+++ b/crates/musli/src/impls/alloc.rs
@@ -66,11 +66,11 @@ where
 
             #[inline]
             fn visit_borrowed(self, string: &'de str) -> Result<Self::Ok, Self::Error> {
-                self.visit_any(string)
+                self.visit_ref(string)
             }
 
             #[inline]
-            fn visit_any(self, string: &str) -> Result<Self::Ok, Self::Error> {
+            fn visit_ref(self, string: &str) -> Result<Self::Ok, Self::Error> {
                 Ok(string.to_owned())
             }
         }
@@ -153,7 +153,7 @@ where
             }
 
             #[inline]
-            fn visit_any(self, string: &str) -> Result<Self::Ok, Self::Error> {
+            fn visit_ref(self, string: &str) -> Result<Self::Ok, Self::Error> {
                 Ok(Cow::Owned(string.to_owned()))
             }
         }

--- a/crates/musli/src/internal/size_hint.rs
+++ b/crates/musli/src/internal/size_hint.rs
@@ -1,5 +1,13 @@
+use crate::de::SizeHint;
+
 #[cfg(any(feature = "std", feature = "alloc"))]
 #[inline]
-pub(crate) fn cautious(hint: Option<usize>) -> usize {
-    hint.unwrap_or(0).min(4096)
+pub(crate) fn cautious<S>(hint: S) -> usize
+where
+    SizeHint: From<S>,
+{
+    match SizeHint::from(hint) {
+        SizeHint::Any => 0,
+        SizeHint::Exact(n) => n.min(4096),
+    }
 }

--- a/crates/musli/src/lib.rs
+++ b/crates/musli/src/lib.rs
@@ -386,3 +386,48 @@ pub use musli_macros::encoder;
 /// ```
 #[doc(inline)]
 pub use musli_macros::decoder;
+
+/// This is an attribute macro that must be used when implementing a
+/// [`Visitor`].
+///
+/// It is required to use because a [`Visitor`] implementation might introduce
+/// new associated types in the future, and this is [not yet supported] on a
+/// language level in Rust. So this attribute macro polyfills any missing types
+/// automatically.
+///
+/// [not yet supported]:
+///     https://rust-lang.github.io/rfcs/2532-associated-type-defaults.html
+/// [`Visitor`]: crate::de::Visitor
+///
+/// # Examples
+///
+/// ```
+/// use core::fmt;
+/// use core::marker;
+///
+/// use musli::de::Visitor;
+/// use musli::error::Error;
+///
+/// struct AnyVisitor<E> {
+///     _marker: marker::PhantomData<E>,
+/// }
+///
+/// #[musli::visitor]
+/// impl<'de, E> Visitor<'de> for AnyVisitor<E>
+/// where
+///     E: Error,
+/// {
+///     type Ok = ();
+///     type Error = E;
+///
+///     #[inline]
+///     fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+///         write!(
+///             f,
+///             "value that can be decoded into dynamic container"
+///         )
+///     }
+/// }
+/// ```
+#[doc(inline)]
+pub use musli_macros::visitor;

--- a/crates/musli/src/never.rs
+++ b/crates/musli/src/never.rs
@@ -11,8 +11,11 @@ use core::convert::Infallible;
 use core::fmt;
 use core::marker;
 
+use crate::no_std::ToOwned;
+
 use crate::de::{
-    AsDecoder, Decoder, PackDecoder, PairDecoder, PairsDecoder, SequenceDecoder, VariantDecoder,
+    AsDecoder, Decoder, NumberVisitor, PackDecoder, PairDecoder, PairsDecoder, SequenceDecoder,
+    SizeHint, ValueVisitor, VariantDecoder,
 };
 use crate::en::{Encoder, PairEncoder, PairsEncoder, SequenceEncoder, VariantEncoder};
 use crate::error::Error;
@@ -43,10 +46,10 @@ enum NeverMarker {}
 ///     }
 /// }
 /// ```
-pub struct Never<A, B = Infallible> {
+pub struct Never<A, B = Infallible, C: ?Sized = Infallible> {
     // Field makes type uninhabitable.
     _never: NeverMarker,
-    _marker: marker::PhantomData<(A, B)>,
+    _marker: marker::PhantomData<(A, B, C)>,
 }
 
 impl<'de, E> Decoder<'de> for Never<E>
@@ -158,7 +161,7 @@ where
         Self: 'this;
 
     #[inline]
-    fn size_hint(&self) -> Option<usize> {
+    fn size_hint(&self) -> SizeHint {
         match self._never {}
     }
 
@@ -184,7 +187,7 @@ where
         Self: 'this;
 
     #[inline]
-    fn size_hint(&self) -> Option<usize> {
+    fn size_hint(&self) -> SizeHint {
         match self._never {}
     }
 
@@ -236,6 +239,32 @@ where
     type __UseMusliEncoderAttributeMacro = ();
 
     #[inline]
+    fn expecting(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self._never {}
+    }
+}
+
+impl<'de, O, E> NumberVisitor<'de> for Never<O, E>
+where
+    E: Error,
+{
+    type Ok = O;
+    type Error = E;
+
+    fn expecting(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self._never {}
+    }
+}
+
+impl<'de, O, E, T> ValueVisitor<'de> for Never<O, E, T>
+where
+    T: ?Sized + ToOwned,
+    E: Error,
+{
+    type Target = T;
+    type Ok = O;
+    type Error = E;
+
     fn expecting(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self._never {}
     }

--- a/crates/musli/src/utils/visit_bytes_fn.rs
+++ b/crates/musli/src/utils/visit_bytes_fn.rs
@@ -38,7 +38,7 @@ where
     }
 
     #[inline]
-    fn visit_any(self, string: &Self::Target) -> Result<Self::Ok, Self::Error> {
+    fn visit_ref(self, string: &Self::Target) -> Result<Self::Ok, Self::Error> {
         (self.function)(string)
     }
 }

--- a/crates/musli/src/utils/visit_string_fn.rs
+++ b/crates/musli/src/utils/visit_string_fn.rs
@@ -38,7 +38,7 @@ where
     }
 
     #[inline]
-    fn visit_any(self, string: &Self::Target) -> Result<Self::Ok, Self::Error> {
+    fn visit_ref(self, string: &Self::Target) -> Result<Self::Ok, Self::Error> {
         (self.function)(string)
     }
 }


### PR DESCRIPTION
This is the last missing API piece I can think of:

A thing decoding might want to ask the decoder if it knows what type is being decoded.

Previously this was handled through `Decoder::type_hint`, but this has a runtime penalty: The returned `TypeHint` needs to be matched over.

Instead for this we adopt a modified Visitor pattern from serde, the twist being that the visitor can produce its own sub-visitors: `type String`, `type Bytes` and `type Number`. This makes visitors more composable since it's a more granular set of traits you need to implement and use instead of one big `Visitor` trait.

The `#[musli::visitor]` attribute also has to be added to allow for API evolution.

This is what its use looks like in `musli-value`:

```rust
#[musli::visitor]
impl<'de, M, E> Visitor<'de> for AnyVisitor<M, E>
where
    M: Mode,
    E: Error,
{
    type Ok = Value;
    type Error = E;

    type String = StringVisitor<E>;
    type Bytes = BytesVisitor<E>;
    type Number = ValueNumberVisitor<E>;

    /* ... */
}
```