### PR TITLE
Build Generate proc macro and reduce boilerplate in models

### DIFF
--- a/crates/musli-macros/Cargo.toml
+++ b/crates/musli-macros/Cargo.toml
@@ -19,6 +19,9 @@ categories = ["encoding"]
 proc-macro = true
 path = "src/lib.rs"
 
+[features]
+test = []
+
 [dependencies]
 proc-macro2 = "1.0.58"
 quote = "1.0.27"

--- a/crates/musli-macros/src/test.rs
+++ b/crates/musli-macros/src/test.rs
@@ -1,0 +1,173 @@
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use syn::punctuated::Punctuated;
+use syn::Token;
+
+#[derive(Default)]
+pub(super) struct Ctxt {
+    pub(super) errors: Vec<syn::Error>,
+}
+
+pub(super) fn expand(cx: &mut Ctxt, input: &syn::DeriveInput) -> Result<TokenStream, ()> {
+    let rng = syn::Ident::new("__rng", Span::call_site());
+    let generate = syn::Ident::new("Generate", Span::call_site());
+
+    let ident = &input.ident;
+
+    let out = match &input.data {
+        syn::Data::Struct(st) => {
+            let fields = build_fields(cx, &st.fields, &rng, &generate)?;
+
+            quote! {
+                Self {
+                    #(#fields,)*
+                }
+            }
+        }
+        syn::Data::Enum(en) => {
+            let mut variants = Vec::new();
+            let mut totals = Vec::new();
+            let mut count = 0usize;
+
+            for (n, variant) in en.variants.iter().enumerate() {
+                let mut attrs = Vec::new();
+                let mut all = Punctuated::<_, Token![,]>::new();
+
+                // Transport cfg attributes, so we don't have to do that.
+                for a in &variant.attrs {
+                    if a.path().is_ident("cfg") {
+                        attrs.push(a.clone());
+
+                        if let syn::Meta::List(list) = &a.meta {
+                            all.push(list.clone());
+                        }
+                    }
+                }
+
+                if !all.is_empty() {
+                    totals.push(quote! {
+                        total += usize::from(cfg!(all(#all)));
+                    })
+                } else {
+                    count += 1;
+                }
+
+                let fields = build_fields(cx, &variant.fields, &rng, &generate)?;
+                let variant = &variant.ident;
+
+                variants.push(quote! {
+                    #(#attrs)*
+                    #n => #ident::#variant {
+                        #(#fields,)*
+                    }
+                })
+            }
+
+            quote! {
+                let mut total = #count;
+                #(#totals;)*
+
+                match #rng.gen_range(0..total) {
+                    #(#variants,)*
+                    _ => unreachable!(),
+                }
+            }
+        }
+        syn::Data::Union(un) => {
+            cx.errors.push(syn::Error::new_spanned(
+                un.union_token,
+                "Unions are not supported",
+            ));
+            return Err(());
+        }
+    };
+
+    let (impl_generics, type_generics, where_generics) = input.generics.split_for_impl();
+
+    Ok(quote! {
+        impl #impl_generics #generate for #ident #type_generics #where_generics {
+            fn generate<T>(#rng: &mut T) -> Self where T: rand::Rng {
+                #out
+            }
+        }
+    })
+}
+
+fn build_fields(
+    cx: &mut Ctxt,
+    fields: &syn::Fields,
+    rng: &syn::Ident,
+    generate: &proc_macro2::Ident,
+) -> Result<Vec<syn::FieldValue>, ()> {
+    let mut out = Vec::new();
+
+    for (n, field) in fields.iter().enumerate() {
+        let attr = parse_attr(cx, &field.attrs)?;
+
+        let member = match &field.ident {
+            Some(ident) => syn::Member::Named(ident.clone()),
+            None => syn::Member::Unnamed(syn::Index::from(n)),
+        };
+
+        let mut attrs = Vec::new();
+
+        // Transport cfg attributes, so we don't have to do that.
+        for a in &field.attrs {
+            if a.path().is_ident("cfg") {
+                attrs.push(a.clone());
+            }
+        }
+
+        let ty = &field.ty;
+
+        let generate = if let Some(range) = attr.range {
+            quote!(<#ty as #generate>::generate_range(#rng, #range))
+        } else {
+            quote!(<#ty as #generate>::generate(#rng))
+        };
+
+        out.push(syn::FieldValue {
+            attrs,
+            member,
+            colon_token: Some(<Token![:]>::default()),
+            expr: syn::Expr::Verbatim(generate),
+        })
+    }
+
+    Ok(out)
+}
+
+#[derive(Default)]
+struct Attr {
+    range: Option<syn::Expr>,
+}
+
+fn parse_attr(cx: &mut Ctxt, attrs: &[syn::Attribute]) -> Result<Attr, ()> {
+    let mut attr = Attr::default();
+
+    for a in attrs {
+        if !a.path().is_ident("generate") {
+            continue;
+        }
+
+        let result = a.parse_nested_meta(|meta| {
+            if meta.path.is_ident("range") {
+                meta.input.parse::<Token![=]>()?;
+                attr.range = Some(meta.input.parse()?);
+                Ok(())
+            } else {
+                Err(syn::Error::new_spanned(meta.path, "Unsupported attribute"))
+            }
+        });
+
+        if let Err(error) = result {
+            cx.errors.push(error);
+        }
+    }
+
+    if !cx.errors.is_empty() {
+        return Err(());
+    }
+
+    Ok(attr)
+}

--- a/crates/musli-tests/Cargo.toml
+++ b/crates/musli-tests/Cargo.toml
@@ -59,6 +59,7 @@ musli-descriptive = { path = "../musli-descriptive", version = "0.0.49", default
 musli-storage = { path = "../musli-storage", version = "0.0.49", default-features = false, features = ["alloc", "test"], optional = true }
 musli-json = { path = "../musli-json", version = "0.0.49", default-features = false, features = ["alloc", "test",], optional = true }
 musli-value = { path = "../musli-value", version = "0.0.49", default-features = false, features = ["alloc", "test"], optional = true }
+musli-macros = { path = "../musli-macros", version = "0.0.49", features = ["test"] }
 
 anyhow = "1.0.71"
 serde = { version = "1.0.163", default-features = false, optional = true, features = ["derive"] }

--- a/crates/musli-tests/benches/comparison.rs
+++ b/crates/musli-tests/benches/comparison.rs
@@ -26,7 +26,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     macro_rules! setup {
         ($($var:ident, $ty:ty, $num:expr),*) => {
             $({
-                let $var: $ty = rng.generate();
+                let $var: $ty = Generate::generate(&mut rng);
 
                 macro_rules! it {
                     ($b:expr, $base:ident, $buf:ident) => {{

--- a/crates/musli-tests/src/bin/fuzz.rs
+++ b/crates/musli-tests/src/bin/fuzz.rs
@@ -23,12 +23,12 @@ musli_tests::miri! {
 
 fn generate<T>(rng: &mut StdRng, count: usize) -> Vec<(usize, T)>
 where
-    StdRng: Generate<T>,
+    T: Generate,
 {
     let mut out = Vec::with_capacity(count);
 
     for index in 0..count {
-        out.push((index, rng.generate()));
+        out.push((index, T::generate(rng)));
     }
 
     out
@@ -84,7 +84,7 @@ fn main() -> Result<()> {
 
     if random {
         for _ in 0..iter {
-            random_bytes.push(rng.generate_range(0..256));
+            random_bytes.push(Generate::generate_range(&mut rng, 0..256));
         }
     }
 

--- a/crates/musli-tests/src/models.rs
+++ b/crates/musli-tests/src/models.rs
@@ -14,6 +14,7 @@ use alloc::vec::Vec;
 
 #[cfg(feature = "musli")]
 use musli::{Decode, Encode};
+use musli_macros::Generate;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -28,7 +29,7 @@ miri! {
     const MEDIUM_RANGE: Range<usize> = 10..100, 1..3;
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Generate)]
 #[cfg_attr(feature = "musli", derive(Encode, Decode))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
@@ -72,36 +73,7 @@ impl PartialEq<Primitives> for &ArchivedPrimitives {
     }
 }
 
-impl Generate<Primitives> for StdRng {
-    fn generate(&mut self) -> Primitives {
-        Primitives {
-            boolean: self.generate(),
-            character: self.generate(),
-            unsigned8: self.generate(),
-            unsigned16: self.generate(),
-            unsigned32: self.generate(),
-            unsigned64: self.generate(),
-            #[cfg(feature = "model_128")]
-            unsigned128: self.generate(),
-            signed8: self.generate(),
-            signed16: self.generate(),
-            signed32: self.generate(),
-            signed64: self.generate(),
-            #[cfg(feature = "model_128")]
-            signed128: self.generate(),
-            #[cfg(feature = "model_usize")]
-            unsignedsize: self.generate(),
-            #[cfg(feature = "model_usize")]
-            signedsize: self.generate(),
-            #[cfg(feature = "model_float")]
-            float32: self.generate(),
-            #[cfg(feature = "model_float")]
-            float64: self.generate(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Generate)]
 #[cfg_attr(feature = "musli", derive(Encode, Decode))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
@@ -127,18 +99,7 @@ impl PartialEq<Allocated> for &ArchivedAllocated {
     }
 }
 
-impl Generate<Allocated> for StdRng {
-    fn generate(&mut self) -> Allocated {
-        Allocated {
-            string: self.generate(),
-            bytes: self.generate(),
-            #[cfg(feature = "model_cstring")]
-            c_string: self.generate(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Generate)]
 #[cfg_attr(feature = "musli", derive(Encode, Decode))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
@@ -178,32 +139,7 @@ impl PartialEq<Tuples> for &ArchivedTuples {
     }
 }
 
-impl Generate<Tuples> for StdRng {
-    fn generate(&mut self) -> Tuples {
-        Tuples {
-            u0: self.generate(),
-            u1: self.generate(),
-            u2: self.generate(),
-            u3: self.generate(),
-            u4: self.generate(),
-            #[cfg(feature = "model_float")]
-            u5: self.generate(),
-            #[cfg(feature = "model_float")]
-            u6: self.generate(),
-            i0: self.generate(),
-            i1: self.generate(),
-            i2: self.generate(),
-            i3: self.generate(),
-            i4: self.generate(),
-            #[cfg(feature = "model_float")]
-            i5: self.generate(),
-            #[cfg(feature = "model_float")]
-            i6: self.generate(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Generate)]
 #[cfg_attr(feature = "musli", derive(Encode, Decode))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
@@ -218,7 +154,7 @@ pub enum MediumEnum {
     #[cfg_attr(feature = "musli", musli(transparent))]
     StringVariant(String),
     #[cfg_attr(feature = "musli", musli(transparent))]
-    NumbereVariant(u64),
+    NumberedVariant(u64),
     EmptyTupleVariant(),
     NamedEmptyVariant {},
     NamedVariant {
@@ -237,24 +173,7 @@ impl PartialEq<MediumEnum> for &ArchivedMediumEnum {
     }
 }
 
-impl Generate<MediumEnum> for StdRng {
-    fn generate(&mut self) -> MediumEnum {
-        match self.gen_range(0..=5) {
-            0 => MediumEnum::StringVariant(self.generate()),
-            1 => MediumEnum::NumbereVariant(self.generate()),
-            2 => MediumEnum::EmptyTupleVariant(),
-            3 => MediumEnum::NamedEmptyVariant {},
-            4 => MediumEnum::NamedVariant {
-                a: self.generate(),
-                primitives: self.generate(),
-                b: self.generate(),
-            },
-            _ => MediumEnum::UnnamedVariant,
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Generate)]
 #[cfg_attr(feature = "musli", derive(Encode, Decode))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
@@ -266,11 +185,15 @@ impl Generate<MediumEnum> for StdRng {
 )]
 #[cfg_attr(feature = "musli", musli(mode = Packed, packed))]
 pub struct LargeStruct {
+    #[generate(range = PRIMITIVES_RANGE)]
     primitives: Vec<Primitives>,
     #[cfg(all(feature = "model_vec", feature = "model_tuple"))]
+    #[generate(range = PRIMITIVES_RANGE)]
     tuples: Vec<(Tuples, Tuples)>,
+    #[generate(range = MEDIUM_RANGE)]
     medium_vec: Vec<MediumEnum>,
     #[cfg(feature = "model_map_string_key")]
+    #[generate(range = MEDIUM_RANGE)]
     medium_map: HashMap<String, MediumEnum>,
     #[cfg(feature = "model_map_string_key")]
     string_keys: HashMap<String, u64>,
@@ -284,23 +207,5 @@ impl PartialEq<LargeStruct> for &ArchivedLargeStruct {
     #[inline]
     fn eq(&self, other: &LargeStruct) -> bool {
         *other == **self
-    }
-}
-
-impl Generate<LargeStruct> for StdRng {
-    fn generate(&mut self) -> LargeStruct {
-        LargeStruct {
-            primitives: self.generate_range(PRIMITIVES_RANGE),
-            #[cfg(all(feature = "model_vec", feature = "model_tuple"))]
-            tuples: self.generate_range(PRIMITIVES_RANGE),
-            medium_vec: self.generate_range(MEDIUM_RANGE),
-            #[cfg(feature = "model_map_string_key")]
-            medium_map: self.generate_range(MEDIUM_RANGE),
-            #[cfg(feature = "model_map_string_key")]
-            string_keys: self.generate(),
-            #[cfg(feature = "model_map")]
-            number_keys: self.generate(),
-            number_vec: self.generate(),
-        }
     }
 }


### PR DESCRIPTION
With this, building the `Generate` implementation of a model is as simple as:

```rust
#[derive(Debug, Clone, PartialEq, Generate)]
pub struct LargeStruct {
    #[generate(range = PRIMITIVES_RANGE)]
    primitives: Vec<Primitives>,
    #[cfg(all(feature = "model_vec", feature = "model_tuple"))]
    #[generate(range = PRIMITIVES_RANGE)]
    tuples: Vec<(Tuples, Tuples)>,
    #[generate(range = MEDIUM_RANGE)]
    medium_vec: Vec<MediumEnum>,
    #[cfg(feature = "model_map_string_key")]
    #[generate(range = MEDIUM_RANGE)]
    medium_map: HashMap<String, MediumEnum>,
    #[cfg(feature = "model_map_string_key")]
    string_keys: HashMap<String, u64>,
    #[cfg(feature = "model_map")]
    number_keys: HashMap<u32, u64>,
    number_vec: Vec<(u32, u64)>,
}
```

`#[cfg(..)]` attributes are automatically propagated where appropriate, for enums that means that there's no longer an issue with variant bias because the count takes into account the current configuration.