### PR TITLE
Conditionally compile atomic implementations

### DIFF
--- a/crates/musli/Cargo.toml
+++ b/crates/musli/Cargo.toml
@@ -16,13 +16,9 @@ keywords = ["no_std", "serialization"]
 categories = ["encoding"]
 
 [features]
-default = ["std", "atomic-64"]
+default = ["std"]
 std = ["alloc"]
 alloc = []
-atomic-64 = ["atomic-32"]
-atomic-32 = ["atomic-16"]
-atomic-16 = ["atomic-8"]
-atomic-8 = []
 
 [dependencies]
 musli-macros = { version = "=0.0.49", path = "../musli-macros" }

--- a/crates/musli/Cargo.toml
+++ b/crates/musli/Cargo.toml
@@ -16,9 +16,13 @@ keywords = ["no_std", "serialization"]
 categories = ["encoding"]
 
 [features]
-default = ["std"]
+default = ["std", "atomic-64"]
 std = ["alloc"]
 alloc = []
+atomic-64 = ["atomic-32"]
+atomic-32 = ["atomic-16"]
+atomic-16 = ["atomic-8"]
+atomic-8 = []
 
 [dependencies]
 musli-macros = { version = "=0.0.49", path = "../musli-macros" }

--- a/crates/musli/src/impls.rs
+++ b/crates/musli/src/impls.rs
@@ -10,9 +10,16 @@ use core::num::{
     NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize, Wrapping,
 };
 use core::sync::atomic::{
-    AtomicBool, AtomicI16, AtomicI32, AtomicI64, AtomicI8, AtomicIsize, AtomicU16, AtomicU32,
-    AtomicU64, AtomicU8, AtomicUsize,
+    AtomicBool, AtomicUsize, AtomicIsize,
 };
+#[cfg(feature = "atomic-8")]
+use core::sync::atomic::{AtomicI8, AtomicU8};
+#[cfg(feature = "atomic-16")]
+use core::sync::atomic::{AtomicI16, AtomicU16};
+#[cfg(feature = "atomic-32")]
+use core::sync::atomic::{AtomicI32, AtomicU32};
+#[cfg(feature = "atomic-64")]
+use core::sync::atomic::{AtomicI64, AtomicU64};
 use core::{fmt, marker};
 
 use crate::de::{Decode, Decoder, ValueVisitor, VariantDecoder};
@@ -94,14 +101,22 @@ macro_rules! atomic_impl {
 }
 
 atomic_impl!(AtomicBool);
+#[cfg(feature = "atomic-16")]
 atomic_impl!(AtomicI16);
+#[cfg(feature = "atomic-32")]
 atomic_impl!(AtomicI32);
+#[cfg(feature = "atomic-64")]
 atomic_impl!(AtomicI64);
+#[cfg(feature = "atomic-8")]
 atomic_impl!(AtomicI8);
 atomic_impl!(AtomicIsize);
+#[cfg(feature = "atomic-16")]
 atomic_impl!(AtomicU16);
+#[cfg(feature = "atomic-32")]
 atomic_impl!(AtomicU32);
+#[cfg(feature = "atomic-64")]
 atomic_impl!(AtomicU64);
+#[cfg(feature = "atomic-8")]
 atomic_impl!(AtomicU8);
 atomic_impl!(AtomicUsize);
 


### PR DESCRIPTION
This enables compilation e.g. on 32-bit platforms where 64-bit atomics may be unavailable.