### PR TITLE
Remove checked_shr that will never fail.

### DIFF
--- a/crates/musli-common/src/int/continuation.rs
+++ b/crates/musli-common/src/int/continuation.rs
@@ -77,7 +77,7 @@ where
     }
 
     loop {
-        value >>= 7;
+        value = value >> 7;
 
         if value.is_zero() {
             w.write_byte(cx, b & MASK_BYTE)?;

--- a/crates/musli-common/src/int/continuation.rs
+++ b/crates/musli-common/src/int/continuation.rs
@@ -77,9 +77,7 @@ where
     }
 
     loop {
-        value = value
-            .checked_shr(7)
-            .ok_or_else(|| cx.custom("length underflow"))?;
+        value >>= 7;
 
         if value.is_zero() {
             w.write_byte(cx, b & MASK_BYTE)?;


### PR DESCRIPTION
[`u32::checked_shr`](https://doc.rust-lang.org/std/primitive.u32.html#method.checked_shr) documentation states that it will never fail as long as rhs is less than u32::BITS.