### PR TITLE
Remove extra usize from size benchmark

### DIFF
--- a/crates/musli-tests/src/bin/fuzz.rs
+++ b/crates/musli-tests/src/bin/fuzz.rs
@@ -21,14 +21,14 @@ musli_tests::miri! {
     const ALLOCATED: usize = 100, 2;
 }
 
-fn generate<T>(rng: &mut StdRng, count: usize) -> Vec<(usize, T)>
+fn generate<T>(rng: &mut StdRng, count: usize) -> Vec<T>
 where
     T: Generate,
 {
     let mut out = Vec::with_capacity(count);
 
-    for index in 0..count {
-        out.push((index, T::generate(rng)));
+    for _ in 0..count {
+        out.push(T::generate(rng));
     }
 
     out
@@ -149,7 +149,7 @@ fn main() -> Result<()> {
                         samples: Vec::new(),
                     };
 
-                    for (_, var) in &$name {
+                    for var in &$name {
                         utils::$base::reset(&mut buf, $size_hint, var);
 
                         match utils::$base::encode(&mut buf, var) {
@@ -188,7 +188,7 @@ fn main() -> Result<()> {
                             o.flush()?;
                         }
 
-                        for &(index, ref var) in &$name {
+                        for (index, var) in $name.iter().enumerate() {
                             utils::$base::reset(&mut buf, $size_hint, var);
 
                             let out = match utils::$base::encode(&mut buf, var) {

--- a/crates/musli-tests/src/bin/fuzz.rs
+++ b/crates/musli-tests/src/bin/fuzz.rs
@@ -149,7 +149,7 @@ fn main() -> Result<()> {
                         samples: Vec::new(),
                     };
 
-                    for var in &$name {
+                    for (_, var) in &$name {
                         utils::$base::reset(&mut buf, $size_hint, var);
 
                         match utils::$base::encode(&mut buf, var) {


### PR DESCRIPTION
While reading [Size comparisons](https://github.com/udoprog/musli#size-comparisons) in README.md, I noticed that `derive_bitcode` was behind `musli_storage_packed` in `prim`. This really confused me since based on my understanding of `musli_storage_packed`, I couldn't tell how it could encode random primitives better than bitcode. After debugging the testing code, I noticed that an extra usize is encoded during the size benchmark. Since the values in the usize are small, `musli_storage_packed`'s use of varint encoding makes it encode to fewer bytes than `derive_bitcode` which doesn't use varint by default.