### PR TITLE
zerocopy: Deny structs which have sneaky fields

### DIFF
--- a/crates/musli-macros/Cargo.toml
+++ b/crates/musli-macros/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/lib.rs"
 
 [features]
 test = []
+sneaky-fields = []
 
 [dependencies]
 proc-macro2 = "1.0.69"

--- a/crates/musli-macros/src/lib.rs
+++ b/crates/musli-macros/src/lib.rs
@@ -17,6 +17,8 @@ mod de;
 mod en;
 mod expander;
 mod internals;
+#[cfg(feature = "sneaky-fields")]
+mod sneaky_fields;
 #[cfg(feature = "test")]
 mod test;
 mod types;
@@ -138,7 +140,7 @@ pub fn visitor(attr: TokenStream, input: TokenStream) -> TokenStream {
 #[proc_macro_derive(ZeroCopy, attributes(zero_copy))]
 pub fn zero_copy(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as syn::DeriveInput);
-    let expander = zero_copy::Expander::new(&input);
+    let expander = zero_copy::Expander::new(input);
 
     match expander.expand() {
         Ok(stream) => stream.into(),
@@ -155,6 +157,14 @@ pub fn visit(input: TokenStream) -> TokenStream {
         Ok(stream) => stream.into(),
         Err(errors) => to_compile_errors(errors).into(),
     }
+}
+
+// NB: Only used in UI tests.
+#[proc_macro_attribute]
+#[doc(hidden)]
+#[cfg(feature = "sneaky-fields")]
+pub fn sneaky_fields(attr: TokenStream, item: TokenStream) -> TokenStream {
+    sneaky_fields::expand(attr, item)
 }
 
 fn to_compile_errors(errors: Vec<syn::Error>) -> proc_macro2::TokenStream {

--- a/crates/musli-macros/src/sneaky_fields.rs
+++ b/crates/musli-macros/src/sneaky_fields.rs
@@ -1,0 +1,44 @@
+use proc_macro::TokenStream;
+use quote::ToTokens;
+
+/// Replace the fields of a struct.
+pub(super) fn expand(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let mut input = syn::parse_macro_input!(item as syn::Item);
+    let ty = syn::parse_macro_input!(attr as syn::Type);
+
+    match &mut input {
+        syn::Item::Enum(e) => {
+            for v in &mut e.variants {
+                match &mut v.fields {
+                    syn::Fields::Named(named) => {
+                        let extra: syn::FieldsNamed = syn::parse_quote!({ sneaky_field: #ty });
+                        named.named.extend(extra.named);
+                    }
+                    syn::Fields::Unnamed(unnamed) => {
+                        let extra: syn::FieldsUnnamed = syn::parse_quote!(( #ty ));
+                        unnamed.unnamed.extend(extra.unnamed);
+                    }
+                    syn::Fields::Unit => {
+                        v.fields = syn::Fields::Named(syn::parse_quote!({ sneaky_field: #ty }));
+                    }
+                }
+            }
+        }
+        syn::Item::Struct(st) => match &mut st.fields {
+            syn::Fields::Named(named) => {
+                let extra: syn::FieldsNamed = syn::parse_quote!({ sneaky_field: #ty });
+                named.named.extend(extra.named);
+            }
+            syn::Fields::Unnamed(unnamed) => {
+                let extra: syn::FieldsUnnamed = syn::parse_quote!(( #ty ));
+                unnamed.unnamed.extend(extra.unnamed);
+            }
+            syn::Fields::Unit => {
+                st.fields = syn::Fields::Named(syn::parse_quote!({ sneaky_field: #ty }));
+            }
+        },
+        _ => (),
+    }
+
+    input.to_token_stream().into()
+}

--- a/crates/musli-macros/src/zero_copy.rs
+++ b/crates/musli-macros/src/zero_copy.rs
@@ -6,7 +6,7 @@ use quote::{quote, ToTokens};
 use syn::meta::ParseNestedMeta;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
-use syn::{parenthesized, DeriveInput, Token};
+use syn::{parenthesized, Token};
 
 #[derive(Default)]
 struct Ctxt {
@@ -19,18 +19,18 @@ impl Ctxt {
     }
 }
 
-pub struct Expander<'a> {
-    input: &'a DeriveInput,
+pub struct Expander {
+    input: syn::DeriveInput,
 }
 
-impl<'a> Expander<'a> {
-    pub fn new(input: &'a DeriveInput) -> Self {
+impl Expander {
+    pub fn new(input: syn::DeriveInput) -> Self {
         Self { input }
     }
 }
 
-impl<'a> Expander<'a> {
-    pub fn expand(&self) -> Result<TokenStream, Vec<syn::Error>> {
+impl Expander {
+    pub fn expand(self) -> Result<TokenStream, Vec<syn::Error>> {
         let cx = Ctxt::default();
 
         let Ok(output) = expand(&cx, self.input) else {
@@ -45,6 +45,587 @@ impl<'a> Expander<'a> {
 
         Ok(output)
     }
+}
+
+fn expand(cx: &Ctxt, input: syn::DeriveInput) -> Result<TokenStream, ()> {
+    let (attrs, name, mut generics, data) = (input.attrs, input.ident, input.generics, input.data);
+
+    let mut r = ReprAttr::default();
+    let mut krate: syn::Path = syn::parse_quote!(musli_zerocopy);
+
+    for attr in &attrs {
+        if attr.path().is_ident("repr") {
+            r.parse_attr(cx, attr);
+        }
+
+        if attr.path().is_ident("zero_copy") {
+            let result = attr.parse_nested_meta(|meta: ParseNestedMeta| {
+                if meta.path.is_ident("bounds") {
+                    meta.input.parse::<Token![=]>()?;
+                    let content;
+                    syn::braced!(content in meta.input);
+
+                    let predicates =
+                        Punctuated::<syn::WherePredicate, Token![,]>::parse_terminated(&content)?;
+
+                    generics.make_where_clause().predicates.extend(predicates);
+                    return Ok(());
+                }
+
+                if meta.path.is_ident("crate") {
+                    if meta.input.parse::<Option<Token![=]>>()?.is_some() {
+                        krate = meta.input.parse()?;
+                    } else {
+                        krate = syn::parse_quote!(crate);
+                    }
+
+                    return Ok(());
+                }
+
+                Err(syn::Error::new(
+                    meta.input.span(),
+                    "ZeroCopy: Unsupported attribute",
+                ))
+            });
+
+            if let Err(error) = result {
+                cx.error(error);
+            }
+        }
+    }
+
+    let Some((repr_span, repr)) = r.repr else {
+        cx.error(syn::Error::new(
+            Span::call_site(),
+            "ZeroCopy: struct must be marked with repr(C), repr(transparent), repr(u*), or repr(i*)",
+        ));
+        return Err(());
+    };
+
+    let buf_mut: syn::Path = syn::parse_quote!(#krate::buf::BufMut);
+    let error: syn::Path = syn::parse_quote!(#krate::Error);
+    let mem: syn::Path = syn::parse_quote!(#krate::__private::mem);
+    let padder: syn::Path = syn::parse_quote!(#krate::buf::Padder);
+    let ptr: syn::Path = syn::parse_quote!(#krate::__private::ptr);
+    let result: syn::Path = syn::parse_quote!(#krate::__private::result::Result);
+    let validator: syn::Path = syn::parse_quote!(#krate::buf::Validator);
+    let zero_copy: syn::Path = syn::parse_quote!(#krate::traits::ZeroCopy);
+    let zero_sized: syn::Path = syn::parse_quote!(#krate::traits::ZeroSized);
+
+    let store_to;
+    let pad;
+    let validate;
+    let impl_zero_sized;
+    let any_bits;
+    let padded;
+    // Expands to an expression which is not executed, but ensures that the type
+    // expands only to the fields visible to the proc macro or causes a compile
+    // error.
+    let check_fields;
+    let mut check_zero_sized = Vec::new();
+
+    match &data {
+        syn::Data::Struct(st) => {
+            // Field types.
+            let mut output = process_fields(cx, &st.fields);
+            check_zero_sized.append(&mut output.check_zero_sized);
+
+            match (repr, &output.first_field) {
+                (Repr::Transparent, Some((ty, member))) => {
+                    store_to = quote! {
+                        <#ty as #zero_copy>::store_to(#ptr::addr_of!((*this).#member), buf);
+                    };
+
+                    pad = quote! {
+                        <#ty as #zero_copy>::pad(#ptr::addr_of!((*this).#member), #padder::transparent::<#ty>(padder));
+                    };
+
+                    validate = quote! {
+                        <#ty as #zero_copy>::validate(#validator::transparent::<#ty>(validator))?;
+                    };
+                }
+                _ => {
+                    let members = &output.members;
+                    let types = &output.types;
+
+                    match r.repr_packed {
+                        Some((_, align)) => {
+                            pad = quote! {
+                                #(#padder::pad_with(padder, #ptr::addr_of!((*this).#members), #align);)*
+                            };
+
+                            store_to = quote! {
+                                // SAFETY: We've systematically ensured to pad all
+                                // fields on the struct.
+                                let mut padder = #buf_mut::store_struct(buf, this);
+                                #(#padder::pad_with::<#types>(&mut padder, #ptr::addr_of!((*this).#members), #align);)*
+                                #padder::end(padder);
+                            };
+
+                            validate = quote! {
+                                // SAFETY: We've systematically ensured that we're
+                                // only validating over fields within the size of
+                                // this type.
+                                #(#validator::validate_with::<#types>(validator, #align)?;)*
+                            };
+                        }
+                        _ => {
+                            store_to = quote! {
+                                // SAFETY: We've systematically ensured to pad all
+                                // fields on the struct.
+                                let mut padder = #buf_mut::store_struct(buf, this);
+                                #(#padder::pad::<#types>(&mut padder, #ptr::addr_of!((*this).#members));)*
+                                #padder::end(padder);
+                            };
+
+                            pad = quote! {
+                                #(#padder::pad(padder, #ptr::addr_of!((*this).#members));)*
+                            };
+
+                            validate = quote! {
+                                // SAFETY: We've systematically ensured that we're
+                                // only validating over fields within the size of
+                                // this type.
+                                #(#validator::validate::<#types>(validator)?;)*
+                            };
+                        }
+                    }
+                }
+            }
+
+            let mut field_sizes = Vec::new();
+            let mut field_padded = Vec::new();
+
+            for ty in output.types.iter() {
+                field_sizes.push(quote!(#mem::size_of::<#ty>()));
+                field_padded.push(quote!(<#ty as #zero_copy>::PADDED));
+            }
+
+            // ZSTs are padded if their alignment is not 1, any other type is
+            // padded if the sum of all their field sizes does not match the
+            // size of the type itself.
+            padded = quote!((#mem::size_of::<Self>() == 0 && #mem::align_of::<Self>() > 1) || #mem::size_of::<Self>() != (0 #(+ #field_sizes)*) #(|| #field_padded)*);
+
+            let types = &output.types;
+
+            impl_zero_sized = types.is_empty().then(|| {
+                let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+                quote! {
+                    // SAFETY: Type has no fields and has the necessary `repr`.
+                    unsafe impl #impl_generics #zero_sized for #name #ty_generics #where_clause {}
+                }
+            });
+
+            any_bits = quote!(true #(&& <#types as #zero_copy>::ANY_BITS)*);
+
+            let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+            // NB: We go through a pointer here to allow for padded structs.
+            check_fields = {
+                let pat = build_field_exhaustive_pattern([name.clone()], &output, &st.fields);
+
+                quote!(
+                    const _: () = {
+                        #[allow(unused)]
+                        fn check_struct_fields #impl_generics(this: #name #ty_generics) #where_clause {
+                            let #pat = this;
+                        }
+                    };
+                )
+            };
+        }
+        syn::Data::Enum(en) => {
+            if let Some((span, _)) = r.repr_packed {
+                cx.error(syn::Error::new(
+                    span,
+                    "ZeroCopy: repr(packed) is only supported on structs",
+                ));
+
+                return Err(());
+            }
+
+            let Some((span, num)) = repr.as_numerical_repr() else {
+                cx.error(syn::Error::new(
+                    repr_span,
+                    "ZeroCopy: only supported for repr(i*) or repr(u*) enums",
+                ));
+
+                return Err(());
+            };
+
+            let ty = syn::Ident::new(num.as_ty(), span);
+
+            let mut validate_variants = Vec::new();
+            let mut store_to_variants = Vec::new();
+            let mut pad_variants = Vec::new();
+            let mut padded_variants = Vec::new();
+            let mut variant_fields = Vec::new();
+
+            let mut current = (
+                false,
+                syn::LitInt::new(&format!("0{}", num.as_ty()), ty.span()),
+            );
+            let mut first = true;
+
+            for variant in &en.variants {
+                let first = take(&mut first);
+
+                let mut output = process_fields(cx, &variant.fields);
+                check_zero_sized.append(&mut output.check_zero_sized);
+
+                fn as_int(expr: &syn::Expr) -> Option<(bool, &syn::LitInt)> {
+                    match expr {
+                        syn::Expr::Lit(syn::ExprLit {
+                            lit: syn::Lit::Int(int),
+                            ..
+                        }) => Some((false, int)),
+                        syn::Expr::Group(syn::ExprGroup { expr, .. }) => as_int(expr),
+                        syn::Expr::Unary(syn::ExprUnary {
+                            op: syn::UnOp::Neg(..),
+                            expr,
+                            ..
+                        }) => as_int(expr).map(|(neg, int)| (!neg, int)),
+                        _ => None,
+                    }
+                }
+
+                if let Some((_, expr)) = &variant.discriminant {
+                    let Some((neg, int)) = as_int(expr) else {
+                        cx.error(syn::Error::new_spanned(
+                            expr,
+                            format!("Only numerical discriminants are supported: {:?}", expr),
+                        ));
+                        continue;
+                    };
+
+                    current = (neg, int.clone());
+                } else if !first {
+                    current = match num.next_index(current) {
+                        Ok(out) => out,
+                        Err(error) => {
+                            cx.error(error);
+                            break;
+                        }
+                    };
+                }
+
+                let (neg, current) = &current;
+
+                let expr = syn::Expr::Lit(syn::ExprLit {
+                    attrs: Vec::new(),
+                    lit: syn::Lit::Int(current.clone()),
+                });
+
+                let discriminator = if *neg {
+                    syn::Expr::Unary(syn::ExprUnary {
+                        attrs: Vec::new(),
+                        op: syn::UnOp::Neg(<Token![-]>::default()),
+                        expr: Box::new(expr),
+                    })
+                } else {
+                    expr
+                };
+
+                let ident = &variant.ident;
+                let types = &output.types;
+                let variables = &output.variables;
+                let assigns = &output.assigns;
+
+                validate_variants.push(quote! {
+                    #discriminator => {
+                        #(#validator::validate::<#types>(validator)?;)*
+                    }
+                });
+
+                store_to_variants.push(quote! {
+                    Self::#ident { #(#assigns,)* .. } => {
+                        #(#padder::pad(&mut padder, #variables);)*
+                    }
+                });
+
+                pad_variants.push(quote! {
+                    Self::#ident { #(#assigns,)* .. } => {
+                        #(#padder::pad(padder, #variables);)*
+                    }
+                });
+
+                let mut field_sizes = Vec::new();
+                let mut field_padded = Vec::new();
+
+                for ty in output.types.iter() {
+                    field_sizes.push(quote!(#mem::size_of::<#ty>()));
+                    field_padded.push(quote!(<#ty as #zero_copy>::PADDED));
+                }
+
+                let base_size = num.size(&mem);
+
+                // Struct does not need to be padded if all elements are the
+                // same size and alignment.
+                padded_variants.push(quote!((#mem::size_of::<Self>() != (#base_size #(+ #field_sizes)*) #(|| #field_padded)*)));
+
+                variant_fields.push({
+                    let pat = build_field_exhaustive_pattern(
+                        [name.clone(), variant.ident.clone()],
+                        &output,
+                        &variant.fields,
+                    );
+                    quote!(#pat => ())
+                });
+            }
+
+            store_to = quote! {
+                // SAFETY: We've systematically ensured to pad all fields on the
+                // struct.
+                let mut padder = #buf_mut::store_struct(buf, this);
+                #padder::pad_primitive::<#ty>(&mut padder);
+
+                // NOTE: this is assumed to be properly, since enums cannot
+                // be packed.
+                match &*this {
+                    #(#store_to_variants,)*
+                }
+
+                #padder::end(padder);
+            };
+
+            pad = quote! {
+                #padder::pad_primitive::<#ty>(padder);
+
+                // NOTE: this is assumed to be properly, since enums cannot be
+                // packed.
+                match &*this {
+                    #(#pad_variants,)*
+                }
+            };
+
+            let illegal_enum = quote::format_ident!("__illegal_enum_{}", num.as_ty());
+
+            validate = quote! {
+                // SAFETY: We've systematically ensured that we're only
+                // validating over fields within the size of this type.
+                let discriminator = *#validator::field::<#ty>(validator)?;
+
+                match discriminator {
+                    #(#validate_variants,)*
+                    value => return #result::Err(#error::#illegal_enum::<Self>(value)),
+                }
+            };
+
+            impl_zero_sized = None;
+            any_bits = quote!(false);
+            padded = quote!(false #(|| #padded_variants)*);
+
+            let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+            // NB: Since enums can't be packed we can use a reference.
+            check_fields = quote!(
+                const _: () = {
+                    #[allow(unused)]
+                    fn check_variants_fields #impl_generics(this: &#name #ty_generics) #where_clause {
+                        match this {
+                            #(#variant_fields,)*
+                        }
+                    }
+                };
+            );
+        }
+        syn::Data::Union(data) => {
+            cx.error(syn::Error::new_spanned(
+                data.union_token,
+                "ZeroCopy: not supported for unions",
+            ));
+            return Err(());
+        }
+    };
+
+    let check_zero_sized = (!check_zero_sized.is_empty()).then(|| {
+        let (impl_generics, _, where_clause) = generics.split_for_impl();
+
+        quote! {
+            const _: () = {
+                fn ensure_zero_sized<T: #zero_sized>() {}
+
+                fn ensure_fields #impl_generics() #where_clause {
+                    #(ensure_zero_sized::<#check_zero_sized>();)*
+                }
+            };
+        }
+    });
+
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    Ok(quote! {
+        #check_zero_sized
+
+        #check_fields
+
+        #impl_zero_sized
+
+        unsafe impl #impl_generics #zero_copy for #name #ty_generics #where_clause {
+            const ANY_BITS: bool = #any_bits;
+            const PADDED: bool = #padded;
+
+            #[inline]
+            unsafe fn store_to<__B: ?Sized>(this: *const Self, buf: &mut __B)
+            where
+                __B: #buf_mut
+            {
+                #store_to
+            }
+
+            #[inline]
+            unsafe fn pad(this: *const Self, padder: &mut #padder<'_, Self>) {
+                #pad
+            }
+
+            #[inline]
+            unsafe fn validate(validator: &mut #validator<'_, Self>) -> #result<(), #error> {
+                #validate
+                #result::Ok(())
+            }
+        }
+    })
+}
+
+/// Construct a match pattern with carefully assigned spans to improve
+/// diagnostics as much as possible.
+fn build_field_exhaustive_pattern<const N: usize>(
+    steps: [syn::Ident; N],
+    output: &Fields<'_>,
+    fields: &syn::Fields,
+) -> syn::Pat {
+    let mut path = syn::Path {
+        leading_colon: None,
+        segments: syn::punctuated::Punctuated::default(),
+    };
+
+    for step in steps {
+        path.segments.push(syn::PathSegment::from(step));
+    }
+
+    match fields {
+        syn::Fields::Named(named) => {
+            let mut fields = syn::punctuated::Punctuated::new();
+
+            for member in &output.exhaustive {
+                fields.push(syn::FieldPat {
+                    attrs: Vec::new(),
+                    member: member.clone(),
+                    colon_token: None,
+                    pat: Box::new(syn::Pat::Verbatim(quote!(#member))),
+                });
+            }
+
+            syn::Pat::Struct(syn::PatStruct {
+                attrs: Vec::new(),
+                qself: None,
+                path: path.clone(),
+                brace_token: named.brace_token,
+                fields,
+                rest: None,
+            })
+        }
+        syn::Fields::Unnamed(unnamed) => {
+            let mut elems = syn::punctuated::Punctuated::new();
+
+            for _ in &output.exhaustive {
+                elems.push(syn::Pat::Wild(syn::PatWild {
+                    attrs: Vec::new(),
+                    underscore_token: <syn::Token![_]>::default(),
+                }));
+            }
+
+            syn::Pat::TupleStruct(syn::PatTupleStruct {
+                attrs: Vec::new(),
+                qself: None,
+                path: path.clone(),
+                paren_token: unnamed.paren_token,
+                elems,
+            })
+        }
+        syn::Fields::Unit => syn::Pat::Path(syn::ExprPath {
+            attrs: Vec::new(),
+            qself: None,
+            path: path.clone(),
+        }),
+    }
+}
+
+#[derive(Default)]
+struct Fields<'a> {
+    types: Vec<&'a syn::Type>,
+    members: Vec<syn::Member>,
+    exhaustive: Vec<syn::Member>,
+    variables: Vec<syn::Ident>,
+    assigns: Vec<syn::FieldValue>,
+    first_field: Option<(&'a syn::Type, syn::Member)>,
+    check_zero_sized: Vec<&'a syn::Type>,
+}
+
+fn process_fields<'a>(cx: &Ctxt, fields: &'a syn::Fields) -> Fields<'a> {
+    let mut output = Fields::default();
+
+    for (index, field) in fields.iter().enumerate() {
+        let mut ignore = None;
+
+        for attr in &field.attrs {
+            if attr.path().is_ident("zero_copy") {
+                let result = attr.parse_nested_meta(|meta: ParseNestedMeta| {
+                    if meta.path.is_ident("ignore") {
+                        ignore = Some(meta.path.span());
+                        return Ok(());
+                    }
+
+                    Err(syn::Error::new(
+                        meta.input.span(),
+                        "ZeroCopy: Unsupported attribute",
+                    ))
+                });
+
+                if let Err(error) = result {
+                    cx.error(error);
+                }
+            }
+        }
+
+        let ty = &field.ty;
+
+        let member = match &field.ident {
+            Some(ident) => syn::Member::Named(ident.clone()),
+            None => syn::Member::Unnamed(syn::Index::from(index)),
+        };
+
+        // Ignored fields are ignored in bindings.
+        output.exhaustive.push(member.clone());
+
+        if ignore.is_some() {
+            output.check_zero_sized.push(ty);
+            continue;
+        }
+
+        output.types.push(ty);
+        output.members.push(member.clone());
+
+        let variable = match &field.ident {
+            Some(ident) => ident.clone(),
+            None => quote::format_ident!("_{}", index),
+        };
+
+        if matches!(&member, syn::Member::Named(..)) {
+            output.assigns.push(syn::parse_quote!(#member));
+        } else {
+            output.assigns.push(syn::parse_quote!(#member: #variable));
+        }
+
+        output.variables.push(variable);
+
+        if output.first_field.is_none() {
+            output.first_field = Some((ty, member));
+        }
+    }
+
+    output
 }
 
 #[derive(Default)]
@@ -140,8 +721,8 @@ impl ToTokens for NumSize<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         match self {
             NumSize::Fixed(size) => size.to_tokens(tokens),
-            NumSize::Pointer(path) => {
-                tokens.extend(quote!(#path::<usize>()));
+            NumSize::Pointer(mem) => {
+                tokens.extend(quote!(#mem::size_of::<usize>()));
             }
         }
     }
@@ -164,7 +745,7 @@ enum Num {
 }
 
 impl Num {
-    fn size(self, size_of: &syn::Path) -> NumSize<'_> {
+    fn size(self, mem: &syn::Path) -> NumSize<'_> {
         match self {
             Num::U8 => NumSize::Fixed(1),
             Num::U16 => NumSize::Fixed(2),
@@ -176,8 +757,8 @@ impl Num {
             Num::I32 => NumSize::Fixed(4),
             Num::I64 => NumSize::Fixed(8),
             Num::I128 => NumSize::Fixed(16),
-            Num::Isize => NumSize::Pointer(size_of),
-            Num::Usize => NumSize::Pointer(size_of),
+            Num::Isize => NumSize::Pointer(mem),
+            Num::Usize => NumSize::Pointer(mem),
         }
     }
 
@@ -278,473 +859,4 @@ impl Repr {
             Repr::Num(span, num) => Some((span, num)),
         }
     }
-}
-
-fn expand(cx: &Ctxt, input: &DeriveInput) -> Result<TokenStream, ()> {
-    let mut generics = input.generics.clone();
-
-    let mut r = ReprAttr::default();
-    let mut krate: syn::Path = syn::parse_quote!(musli_zerocopy);
-
-    for attr in &input.attrs {
-        if attr.path().is_ident("repr") {
-            r.parse_attr(cx, attr);
-        }
-
-        if attr.path().is_ident("zero_copy") {
-            let result = attr.parse_nested_meta(|meta: ParseNestedMeta| {
-                if meta.path.is_ident("bounds") {
-                    meta.input.parse::<Token![=]>()?;
-                    let content;
-                    syn::braced!(content in meta.input);
-
-                    let predicates =
-                        Punctuated::<syn::WherePredicate, Token![,]>::parse_terminated(&content)?;
-
-                    generics.make_where_clause().predicates.extend(predicates);
-                    return Ok(());
-                }
-
-                if meta.path.is_ident("crate") {
-                    if meta.input.parse::<Option<Token![=]>>()?.is_some() {
-                        krate = meta.input.parse()?;
-                    } else {
-                        krate = syn::parse_quote!(crate);
-                    }
-
-                    return Ok(());
-                }
-
-                Err(syn::Error::new(
-                    meta.input.span(),
-                    "ZeroCopy: Unsupported attribute",
-                ))
-            });
-
-            if let Err(error) = result {
-                cx.error(error);
-            }
-        }
-    }
-
-    let Some((repr_span, repr)) = r.repr else {
-        cx.error(syn::Error::new_spanned(
-            input,
-            "ZeroCopy: struct must be marked with repr(C), repr(transparent), repr(u*), or repr(i*)",
-        ));
-        return Err(());
-    };
-
-    let buf_mut: syn::Path = syn::parse_quote!(#krate::buf::BufMut);
-    let error: syn::Path = syn::parse_quote!(#krate::Error);
-    let result: syn::Path = syn::parse_quote!(#krate::__private::result::Result);
-    let padder: syn::Path = syn::parse_quote!(#krate::buf::Padder);
-    let validator: syn::Path = syn::parse_quote!(#krate::buf::Validator);
-    let zero_copy: syn::Path = syn::parse_quote!(#krate::traits::ZeroCopy);
-    let zero_sized: syn::Path = syn::parse_quote!(#krate::traits::ZeroSized);
-    let size_of: syn::Path = syn::parse_quote!(core::mem::size_of);
-    let align_of: syn::Path = syn::parse_quote!(core::mem::align_of);
-    let ptr: syn::Path = syn::parse_quote!(core::ptr);
-
-    let store_to;
-    let pad;
-    let validate;
-    let impl_zero_sized;
-    let any_bits;
-    let padded;
-    let mut check_zero_sized = Vec::new();
-
-    match &input.data {
-        syn::Data::Struct(st) => {
-            // Field types.
-            let mut output = process_fields(cx, &st.fields);
-            check_zero_sized.append(&mut output.check_zero_sized);
-
-            match (repr, output.first_field) {
-                (Repr::Transparent, Some((ty, member))) => {
-                    store_to = quote! {
-                        <#ty as #zero_copy>::store_to(#ptr::addr_of!((*this).#member), buf);
-                    };
-
-                    pad = quote! {
-                        <#ty as #zero_copy>::pad(#ptr::addr_of!((*this).#member), #padder::transparent::<#ty>(padder));
-                    };
-
-                    validate = quote! {
-                        <#ty as #zero_copy>::validate(#validator::transparent::<#ty>(validator))?;
-                    };
-                }
-                _ => {
-                    let members = &output.members;
-                    let types = &output.types;
-
-                    match r.repr_packed {
-                        Some((_, align)) => {
-                            pad = quote! {
-                                #(#padder::pad_with(padder, #ptr::addr_of!((*this).#members), #align);)*
-                            };
-
-                            store_to = quote! {
-                                // SAFETY: We've systematically ensured to pad all
-                                // fields on the struct.
-                                let mut padder = #buf_mut::store_struct(buf, this);
-                                #(#padder::pad_with::<#types>(&mut padder, #ptr::addr_of!((*this).#members), #align);)*
-                                #padder::end(padder);
-                            };
-
-                            validate = quote! {
-                                // SAFETY: We've systematically ensured that we're
-                                // only validating over fields within the size of
-                                // this type.
-                                #(#validator::validate_with::<#types>(validator, #align)?;)*
-                            };
-                        }
-                        _ => {
-                            store_to = quote! {
-                                // SAFETY: We've systematically ensured to pad all
-                                // fields on the struct.
-                                let mut padder = #buf_mut::store_struct(buf, this);
-                                #(#padder::pad::<#types>(&mut padder, #ptr::addr_of!((*this).#members));)*
-                                #padder::end(padder);
-                            };
-
-                            pad = quote! {
-                                #(#padder::pad(padder, #ptr::addr_of!((*this).#members));)*
-                            };
-
-                            validate = quote! {
-                                // SAFETY: We've systematically ensured that we're
-                                // only validating over fields within the size of
-                                // this type.
-                                #(#validator::validate::<#types>(validator)?;)*
-                            };
-                        }
-                    }
-                }
-            }
-
-            let mut field_sizes = Vec::new();
-            let mut field_padded = Vec::new();
-
-            for ty in output.types.iter() {
-                field_sizes.push(quote!(#size_of::<#ty>()));
-                field_padded.push(quote!(<#ty as #zero_copy>::PADDED));
-            }
-
-            // Struct does not need to be padded if all elements are the
-            // same size and alignment.
-            padded = quote!((#size_of::<Self>() == 0 && #align_of::<Self>() > 1) || #size_of::<Self>() != (0 #(+ #field_sizes)*) #(|| #field_padded)*);
-
-            let name = &input.ident;
-            let types = &output.types;
-
-            impl_zero_sized = output.types.is_empty().then(|| {
-                let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-
-                quote! {
-                    // SAFETY: Type has no fields and has the necessary `repr`.
-                    unsafe impl #impl_generics #zero_sized for #name #ty_generics #where_clause {}
-                }
-            });
-
-            any_bits = quote!(true #(&& <#types as #zero_copy>::ANY_BITS)*);
-        }
-        syn::Data::Enum(en) => {
-            if let Some((span, _)) = r.repr_packed {
-                cx.error(syn::Error::new(
-                    span,
-                    "ZeroCopy: repr(packed) is only supported on structs",
-                ));
-
-                return Err(());
-            }
-
-            let Some((span, num)) = repr.as_numerical_repr() else {
-                cx.error(syn::Error::new(
-                    repr_span,
-                    "ZeroCopy: only supported for repr(i*) or repr(u*) enums",
-                ));
-
-                return Err(());
-            };
-
-            let ty = syn::Ident::new(num.as_ty(), span);
-
-            let mut validate_variants = Vec::new();
-            let mut store_to_variants = Vec::new();
-            let mut pad_variants = Vec::new();
-            let mut padded_variants = Vec::new();
-
-            let mut current = (
-                false,
-                syn::LitInt::new(&format!("0{}", num.as_ty()), ty.span()),
-            );
-            let mut first = true;
-
-            for variant in &en.variants {
-                let first = take(&mut first);
-
-                let mut output = process_fields(cx, &variant.fields);
-                check_zero_sized.append(&mut output.check_zero_sized);
-
-                fn as_int(expr: &syn::Expr) -> Option<(bool, &syn::LitInt)> {
-                    match expr {
-                        syn::Expr::Lit(syn::ExprLit {
-                            lit: syn::Lit::Int(int),
-                            ..
-                        }) => Some((false, int)),
-                        syn::Expr::Group(syn::ExprGroup { expr, .. }) => as_int(expr),
-                        syn::Expr::Unary(syn::ExprUnary {
-                            op: syn::UnOp::Neg(..),
-                            expr,
-                            ..
-                        }) => as_int(expr).map(|(neg, int)| (!neg, int)),
-                        _ => None,
-                    }
-                }
-
-                if let Some((_, expr)) = &variant.discriminant {
-                    let Some((neg, int)) = as_int(expr) else {
-                        cx.error(syn::Error::new_spanned(
-                            expr,
-                            format!("Only numerical discriminants are supported: {:?}", expr),
-                        ));
-                        continue;
-                    };
-
-                    current = (neg, int.clone());
-                } else if !first {
-                    current = match num.next_index(current) {
-                        Ok(out) => out,
-                        Err(error) => {
-                            cx.error(error);
-                            break;
-                        }
-                    };
-                }
-
-                let (neg, current) = &current;
-
-                let expr = syn::Expr::Lit(syn::ExprLit {
-                    attrs: Vec::new(),
-                    lit: syn::Lit::Int(current.clone()),
-                });
-
-                let discriminator = if *neg {
-                    syn::Expr::Unary(syn::ExprUnary {
-                        attrs: Vec::new(),
-                        op: syn::UnOp::Neg(<Token![-]>::default()),
-                        expr: Box::new(expr),
-                    })
-                } else {
-                    expr
-                };
-
-                let ident = &variant.ident;
-                let types = &output.types;
-                let variables = &output.variables;
-                let assigns = &output.assigns;
-
-                validate_variants.push(quote! {
-                    #discriminator => {
-                        #(#validator::validate::<#types>(validator)?;)*
-                    }
-                });
-
-                store_to_variants.push(quote! {
-                    Self::#ident { #(#assigns,)* .. } => {
-                        #(#padder::pad(&mut padder, #variables);)*
-                    }
-                });
-
-                pad_variants.push(quote! {
-                    Self::#ident { #(#assigns,)* .. } => {
-                        #(#padder::pad(padder, #variables);)*
-                    }
-                });
-
-                let mut field_sizes = Vec::new();
-                let mut field_padded = Vec::new();
-
-                for ty in output.types.iter() {
-                    field_sizes.push(quote!(#size_of::<#ty>()));
-                    field_padded.push(quote!(<#ty as #zero_copy>::PADDED));
-                }
-
-                let base_size = num.size(&size_of);
-
-                // Struct does not need to be padded if all elements are the
-                // same size and alignment.
-                padded_variants.push(quote!((#size_of::<Self>() != (#base_size #(+ #field_sizes)*) #(|| #field_padded)*)));
-            }
-
-            store_to = quote! {
-                // SAFETY: We've systematically ensured to pad all fields on the
-                // struct.
-                let mut padder = #buf_mut::store_struct(buf, this);
-                #padder::pad_primitive::<#ty>(&mut padder);
-
-                // NOTE: this is assumed to be properly, since enums cannot
-                // be packed.
-                match &*this {
-                    #(#store_to_variants,)*
-                }
-
-                #padder::end(padder);
-            };
-
-            pad = quote! {
-                #padder::pad_primitive::<#ty>(padder);
-
-                // NOTE: this is assumed to be properly, since enums cannot be
-                // packed.
-                match &*this {
-                    #(#pad_variants,)*
-                }
-            };
-
-            let illegal_enum = quote::format_ident!("__illegal_enum_{}", num.as_ty());
-
-            validate = quote! {
-                // SAFETY: We've systematically ensured that we're only
-                // validating over fields within the size of this type.
-                let discriminator = *#validator::field::<#ty>(validator)?;
-
-                match discriminator {
-                    #(#validate_variants,)*
-                    value => return #result::Err(#error::#illegal_enum::<Self>(value)),
-                }
-            };
-
-            impl_zero_sized = None;
-            any_bits = quote!(false);
-            padded = quote!(false #(|| #padded_variants)*);
-        }
-        syn::Data::Union(data) => {
-            cx.error(syn::Error::new_spanned(
-                data.union_token,
-                "ZeroCopy: not supported for unions",
-            ));
-            return Err(());
-        }
-    };
-
-    let check_zero_sized = (!check_zero_sized.is_empty()).then(|| {
-        let (impl_generics, _, where_clause) = generics.split_for_impl();
-
-        quote! {
-            const _: () = {
-                fn ensure_zero_sized<T: #zero_sized>() {}
-
-                fn ensure_fields #impl_generics() #where_clause {
-                    #(ensure_zero_sized::<#check_zero_sized>();)*
-                }
-            };
-        }
-    });
-
-    let name = &input.ident;
-    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-
-    Ok(quote::quote! {
-        #check_zero_sized
-
-        #impl_zero_sized
-
-        unsafe impl #impl_generics #zero_copy for #name #ty_generics #where_clause {
-            const ANY_BITS: bool = #any_bits;
-            const PADDED: bool = #padded;
-
-            #[inline]
-            unsafe fn store_to<__B: ?Sized>(this: *const Self, buf: &mut __B)
-            where
-                __B: #buf_mut
-            {
-                #store_to
-            }
-
-            #[inline]
-            unsafe fn pad(this: *const Self, padder: &mut #padder<'_, Self>) {
-                #pad
-            }
-
-            #[inline]
-            unsafe fn validate(validator: &mut #validator<'_, Self>) -> #result<(), #error> {
-                #validate
-                #result::Ok(())
-            }
-        }
-    })
-}
-
-#[derive(Default)]
-struct Fields<'a> {
-    types: Vec<&'a syn::Type>,
-    members: Vec<syn::Member>,
-    variables: Vec<syn::Ident>,
-    assigns: Vec<syn::FieldValue>,
-    first_field: Option<(&'a syn::Type, syn::Member)>,
-    check_zero_sized: Vec<&'a syn::Type>,
-}
-
-fn process_fields<'a>(cx: &Ctxt, fields: &'a syn::Fields) -> Fields<'a> {
-    let mut output = Fields::default();
-
-    for (index, field) in fields.iter().enumerate() {
-        let mut ignore = None;
-
-        for attr in &field.attrs {
-            if attr.path().is_ident("zero_copy") {
-                let result = attr.parse_nested_meta(|meta: ParseNestedMeta| {
-                    if meta.path.is_ident("ignore") {
-                        ignore = Some(meta.path.span());
-                        return Ok(());
-                    }
-
-                    Err(syn::Error::new(
-                        meta.input.span(),
-                        "ZeroCopy: Unsupported attribute",
-                    ))
-                });
-
-                if let Err(error) = result {
-                    cx.error(error);
-                }
-            }
-        }
-
-        let ty = &field.ty;
-
-        let member = match &field.ident {
-            Some(ident) => syn::Member::Named(ident.clone()),
-            None => syn::Member::Unnamed(syn::Index::from(index)),
-        };
-
-        if ignore.is_some() {
-            output.check_zero_sized.push(ty);
-            continue;
-        }
-
-        output.types.push(ty);
-        output.members.push(member.clone());
-
-        let variable = match &field.ident {
-            Some(ident) => ident.clone(),
-            None => quote::format_ident!("_{}", index),
-        };
-
-        if matches!(&member, syn::Member::Named(..)) {
-            output.assigns.push(syn::parse_quote!(#member));
-        } else {
-            output.assigns.push(syn::parse_quote!(#member: #variable));
-        }
-
-        output.variables.push(variable);
-
-        if output.first_field.is_none() {
-            output.first_field = Some((ty, member));
-        }
-    }
-
-    output
 }

--- a/crates/musli-zerocopy/Cargo.toml
+++ b/crates/musli-zerocopy/Cargo.toml
@@ -28,3 +28,4 @@ rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }
 [dev-dependencies]
 anyhow = "1.0.75"
 trybuild = "1.0.85"
+musli-macros = { version = "=0.0.71", path = "../musli-macros", features = ["sneaky-fields"] }

--- a/crates/musli-zerocopy/src/lib.rs
+++ b/crates/musli-zerocopy/src/lib.rs
@@ -593,5 +593,15 @@ mod tests;
 
 #[doc(hidden)]
 pub mod __private {
-    pub use ::core::result;
+    pub mod result {
+        pub use ::core::result::Result;
+    }
+
+    pub mod mem {
+        pub use ::core::mem::{align_of, size_of};
+    }
+
+    pub mod ptr {
+        pub use ::core::ptr::addr_of;
+    }
 }

--- a/crates/musli-zerocopy/tests/ui/deny_sneaky_field_error.rs
+++ b/crates/musli-zerocopy/tests/ui/deny_sneaky_field_error.rs
@@ -1,0 +1,59 @@
+//! This test ensures that the derive can correctly see fields which were
+//! sneakily introduced by an attribute macro.
+
+use musli_zerocopy::ZeroCopy;
+use musli_macros::sneaky_fields;
+
+#[derive(ZeroCopy)]
+#[repr(C)]
+struct Sneaky(u64);
+
+#[derive(ZeroCopy)]
+#[repr(C)]
+#[sneaky_fields(Sneaky)]
+struct SneakyNamed {
+    field: u32,
+}
+
+#[sneaky_fields(Sneaky)]
+#[derive(ZeroCopy)]
+#[repr(C)]
+struct SneakyNamed2 {
+    field: u32,
+}
+
+#[derive(ZeroCopy)]
+#[repr(C)]
+#[sneaky_fields(Sneaky)]
+struct SneakyUnnamed(u32);
+
+#[sneaky_fields(Sneaky)]
+#[derive(ZeroCopy)]
+#[repr(C)]
+struct SneakyUnnamed2(u32);
+
+#[derive(ZeroCopy)]
+#[repr(u8)]
+#[sneaky_fields(Sneaky)]
+enum SneakyEnumNamed {
+    Named {
+        field: u32,
+    },
+}
+
+#[derive(ZeroCopy)]
+#[repr(u8)]
+#[sneaky_fields(Sneaky)]
+enum SneakyEnumUnnamed {
+    Unnamed(u32)
+}
+
+#[derive(ZeroCopy)]
+#[repr(u8)]
+#[sneaky_fields(Sneaky)]
+enum SneakyEnumUnit {
+    Unit
+}
+
+fn main() {
+}

--- a/crates/musli-zerocopy/tests/ui/deny_sneaky_field_error.stderr
+++ b/crates/musli-zerocopy/tests/ui/deny_sneaky_field_error.stderr
@@ -1,0 +1,93 @@
+error[E0027]: pattern does not mention field `sneaky_field`
+  --> tests/ui/deny_sneaky_field_error.rs:14:8
+   |
+14 |   struct SneakyNamed {
+   |  ________^
+15 | |     field: u32,
+16 | | }
+   | |_^ missing field `sneaky_field`
+   |
+help: include the missing field in the pattern
+   |
+15 |     field, sneaky_field }
+   |          ~~~~~~~~~~~~~~~~
+help: if you don't care about this missing field, you can explicitly ignore it
+   |
+15 |     field, .. }
+   |          ~~~~~~
+
+error[E0023]: this pattern has 1 field, but the corresponding tuple struct has 2 fields
+  --> tests/ui/deny_sneaky_field_error.rs:25:10
+   |
+25 | #[derive(ZeroCopy)]
+   |          ^^^^^^^^ expected 2 fields, found 1
+26 | #[repr(C)]
+27 | #[sneaky_fields(Sneaky)]
+   |                 ------ tuple struct has 2 fields
+28 | struct SneakyUnnamed(u32);
+   |        ------------- ---
+   |        |
+   |        tuple struct defined here
+   |
+   = note: this error originates in the derive macro `ZeroCopy` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: use `_` to explicitly ignore each field
+   |
+28 | struct SneakyUnnamed(u32, _);
+   |                         +++
+help: use `..` to ignore all fields
+   |
+25 | #[derive(..)]
+   |          ~~
+
+error[E0027]: pattern does not mention field `sneaky_field`
+  --> tests/ui/deny_sneaky_field_error.rs:38:6
+   |
+38 |   enum SneakyEnumNamed {
+   |  ______^
+39 | |     Named {
+40 | |         field: u32,
+41 | |     },
+   | |_____^ missing field `sneaky_field`
+   |
+help: include the missing field in the pattern
+   |
+40 |         field, sneaky_field },
+   |              ~~~~~~~~~~~~~~~~
+help: if you don't care about this missing field, you can explicitly ignore it
+   |
+40 |         field, .. },
+   |              ~~~~~~
+
+error[E0023]: this pattern has 1 field, but the corresponding tuple variant has 2 fields
+  --> tests/ui/deny_sneaky_field_error.rs:44:10
+   |
+44 |   #[derive(ZeroCopy)]
+   |            ^^^^^^^^ expected 2 fields, found 1
+45 |   #[repr(u8)]
+46 |   #[sneaky_fields(Sneaky)]
+   |                   ------ tuple variant has 2 fields
+47 |   enum SneakyEnumUnnamed {
+   |  ______-
+48 | |     Unnamed(u32)
+   | |     ------- ---
+   | |_____|_____|
+   |       |
+   |       tuple variant defined here
+   |
+   = note: this error originates in the derive macro `ZeroCopy` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: use `_` to explicitly ignore each field
+   |
+48 |     Unnamed(u32, _)
+   |                +++
+help: use `..` to ignore all fields
+   |
+44 | #[derive(..)]
+   |          ~~
+
+error[E0533]: expected unit struct, unit variant or constant, found struct variant `SneakyEnumUnit::Unit`
+  --> tests/ui/deny_sneaky_field_error.rs:54:6
+   |
+54 |   enum SneakyEnumUnit {
+   |  ______^
+55 | |     Unit
+   | |________^ not a unit struct, unit variant or constant


### PR DESCRIPTION
This prevents other macros from introducing fields which are not visible to the `ZeroCopy` derive, or if they are visible they have to exactly math the definition in the `ZeroCopy` type maintaining soundness.