### PR TITLE
Implement endian-sensitive primitives

### DIFF
--- a/crates/asm/src/lib.rs
+++ b/crates/asm/src/lib.rs
@@ -115,3 +115,21 @@ pub mod zerocopy_store {
 
     tests::types!(build);
 }
+
+#[cfg(feature = "musli-zerocopy")]
+pub mod musli_zerocopy_swap {
+    use musli_zerocopy::endian::{BigEndian, LittleEndian};
+    use musli_zerocopy::{Ref, ZeroCopy};
+
+    pub fn array_little_endian(value: [u32; 16]) -> [u32; 16] {
+        value.swap_bytes::<LittleEndian>()
+    }
+
+    pub fn array_big_endian(value: [u32; 16]) -> [u32; 16] {
+        value.swap_bytes::<BigEndian>()
+    }
+
+    pub fn reference_noop(value: Ref<u32>) -> Ref<u32> {
+        value.swap_bytes::<BigEndian>()
+    }
+}

--- a/crates/musli-zerocopy/src/buf/bind.rs
+++ b/crates/musli-zerocopy/src/buf/bind.rs
@@ -2,28 +2,29 @@ use crate::buf::Buf;
 use crate::error::Error;
 
 mod sealed {
+    use crate::endian::ByteOrder;
     use crate::pointer::Size;
     use crate::traits::ZeroCopy;
 
     pub trait Sealed {}
 
-    impl<K, V, O: Size> Sealed for crate::phf::map::MapRef<K, V, O>
+    impl<K, V, O: Size, E: ByteOrder> Sealed for crate::phf::map::MapRef<K, V, O, E>
     where
         K: ZeroCopy,
         V: ZeroCopy,
     {
     }
 
-    impl<K, V, O: Size> Sealed for crate::swiss::map::MapRef<K, V, O>
+    impl<K, V, O: Size, E: ByteOrder> Sealed for crate::swiss::map::MapRef<K, V, O, E>
     where
         K: ZeroCopy,
         V: ZeroCopy,
     {
     }
 
-    impl<T, O: Size> Sealed for crate::phf::set::SetRef<T, O> where T: ZeroCopy {}
+    impl<T, O: Size, E: ByteOrder> Sealed for crate::phf::set::SetRef<T, O, E> where T: ZeroCopy {}
 
-    impl<T, O: Size> Sealed for crate::swiss::set::SetRef<T, O> where T: ZeroCopy {}
+    impl<T, O: Size, E: ByteOrder> Sealed for crate::swiss::set::SetRef<T, O, E> where T: ZeroCopy {}
 }
 
 /// Trait used for binding a reference to a [`Buf`] through [`Buf::bind()`].

--- a/crates/musli-zerocopy/src/buf/load.rs
+++ b/crates/musli-zerocopy/src/buf/load.rs
@@ -1,4 +1,5 @@
 use crate::buf::Buf;
+use crate::endian::ByteOrder;
 use crate::error::Error;
 use crate::pointer::{Pointee, Ref, Size};
 use crate::traits::ZeroCopy;
@@ -32,7 +33,7 @@ pub trait LoadMut: Load {
     fn load_mut<'buf>(&self, buf: &'buf mut Buf) -> Result<&'buf mut Self::Target, Error>;
 }
 
-impl<P, O: Size> Load for Ref<P, O>
+impl<P, O: Size, E: ByteOrder> Load for Ref<P, O, E>
 where
     P: ZeroCopy,
 {
@@ -44,7 +45,7 @@ where
     }
 }
 
-impl<T, O: Size> Load for Ref<[T], O>
+impl<T, O: Size, E: ByteOrder> Load for Ref<[T], O, E>
 where
     [T]: Pointee<O, Packed = O, Metadata = usize>,
     T: ZeroCopy,
@@ -66,7 +67,7 @@ impl<O: Size> Load for Ref<str, O> {
     }
 }
 
-impl<P, O: Size> LoadMut for Ref<P, O>
+impl<P, O: Size, E: ByteOrder> LoadMut for Ref<P, O, E>
 where
     P: ZeroCopy,
 {
@@ -76,7 +77,7 @@ where
     }
 }
 
-impl<T, O: Size> LoadMut for Ref<[T], O>
+impl<T, O: Size, E: ByteOrder> LoadMut for Ref<[T], O, E>
 where
     [T]: Pointee<O, Packed = O, Metadata = usize>,
     T: ZeroCopy,

--- a/crates/musli-zerocopy/src/endian.rs
+++ b/crates/musli-zerocopy/src/endian.rs
@@ -1,0 +1,208 @@
+//! Marker types which define a [`ByteOrder`] to use.
+
+/// Default [`Endianness`].
+pub type DefaultEndian = NativeEndian;
+
+/// Alias for the native endian [`ByteOrder`].
+#[cfg(target_endian = "little")]
+pub type NativeEndian = LittleEndian;
+
+/// Alias for the native endian [`ByteOrder`].
+#[cfg(target_endian = "big")]
+pub type NativeEndian = BigEndian;
+
+/// Marker type indicating that the big endian [`ByteOrder`] is in use.
+#[non_exhaustive]
+pub struct BigEndian;
+
+/// Marker type indicating that the little endian [`ByteOrder`] is in use.
+#[non_exhaustive]
+pub struct LittleEndian;
+
+mod sealed {
+    use super::{BigEndian, LittleEndian};
+
+    pub trait Sealed {}
+
+    impl Sealed for BigEndian {}
+    impl Sealed for LittleEndian {}
+}
+
+/// Defines a byte order to use.
+///
+/// This trait is implemented by two marker types [`BigEndian`] and
+/// [`LittleEndian`], and its internals are intentionally hidden. Do not attempt
+/// to use them yourself.
+pub trait ByteOrder: 'static + Sized + self::sealed::Sealed {
+    /// Swap the bytes for a `usize` with the current byte order.
+    #[doc(hidden)]
+    fn swap_usize(value: usize) -> usize;
+
+    /// Swap the bytes for a `isize` with the current byte order.
+    #[doc(hidden)]
+    fn swap_isize(value: isize) -> isize;
+
+    /// Swap the bytes of a `u16` with the current byte order.
+    #[doc(hidden)]
+    fn swap_u16(value: u16) -> u16;
+
+    /// Swap the bytes of a `i16` with the current byte order.
+    #[doc(hidden)]
+    fn swap_i16(value: i16) -> i16;
+
+    /// Swap the bytes for a `u32` with the current byte order.
+    #[doc(hidden)]
+    fn swap_u32(value: u32) -> u32;
+
+    /// Swap the bytes for a `i32` with the current byte order.
+    #[doc(hidden)]
+    fn swap_i32(value: i32) -> i32;
+
+    /// Swap the bytes for a `u64` with the current byte order.
+    #[doc(hidden)]
+    fn swap_u64(value: u64) -> u64;
+
+    /// Swap the bytes for a `i64` with the current byte order.
+    #[doc(hidden)]
+    fn swap_i64(value: i64) -> i64;
+
+    /// Swap the bytes for a `u128` with the current byte order.
+    #[doc(hidden)]
+    fn swap_u128(value: u128) -> u128;
+
+    /// Swap the bytes for a `i128` with the current byte order.
+    #[doc(hidden)]
+    fn swap_i128(value: i128) -> i128;
+
+    /// Swap the bytes for a `f32` with the current byte order.
+    #[doc(hidden)]
+    fn swap_f32(value: f32) -> f32;
+
+    /// Swap the bytes for a `f64` with the current byte order.
+    #[doc(hidden)]
+    fn swap_f64(value: f64) -> f64;
+}
+
+impl ByteOrder for LittleEndian {
+    #[inline]
+    fn swap_usize(value: usize) -> usize {
+        usize::from_le(value)
+    }
+
+    #[inline]
+    fn swap_isize(value: isize) -> isize {
+        isize::from_le(value)
+    }
+
+    #[inline]
+    fn swap_u16(value: u16) -> u16 {
+        u16::to_le(value)
+    }
+
+    #[inline]
+    fn swap_i16(value: i16) -> i16 {
+        i16::to_le(value)
+    }
+
+    #[inline]
+    fn swap_u32(value: u32) -> u32 {
+        u32::from_le(value)
+    }
+
+    #[inline]
+    fn swap_i32(value: i32) -> i32 {
+        i32::from_le(value)
+    }
+
+    #[inline]
+    fn swap_u64(value: u64) -> u64 {
+        u64::from_le(value)
+    }
+
+    #[inline]
+    fn swap_i64(value: i64) -> i64 {
+        i64::from_le(value)
+    }
+
+    #[inline]
+    fn swap_u128(value: u128) -> u128 {
+        u128::from_le(value)
+    }
+
+    #[inline]
+    fn swap_i128(value: i128) -> i128 {
+        i128::from_le(value)
+    }
+
+    #[inline]
+    fn swap_f32(value: f32) -> f32 {
+        f32::from_bits(u32::from_le(value.to_bits()))
+    }
+
+    #[inline]
+    fn swap_f64(value: f64) -> f64 {
+        f64::from_bits(u64::from_le(value.to_bits()))
+    }
+}
+
+impl ByteOrder for BigEndian {
+    #[inline]
+    fn swap_usize(value: usize) -> usize {
+        usize::from_be(value)
+    }
+
+    #[inline]
+    fn swap_isize(value: isize) -> isize {
+        isize::from_be(value)
+    }
+
+    #[inline]
+    fn swap_u16(value: u16) -> u16 {
+        u16::to_be(value)
+    }
+
+    #[inline]
+    fn swap_i16(value: i16) -> i16 {
+        i16::to_be(value)
+    }
+
+    #[inline]
+    fn swap_u32(value: u32) -> u32 {
+        u32::from_be(value)
+    }
+
+    #[inline]
+    fn swap_i32(value: i32) -> i32 {
+        i32::from_be(value)
+    }
+
+    #[inline]
+    fn swap_u64(value: u64) -> u64 {
+        u64::from_be(value)
+    }
+
+    #[inline]
+    fn swap_i64(value: i64) -> i64 {
+        i64::from_be(value)
+    }
+
+    #[inline]
+    fn swap_u128(value: u128) -> u128 {
+        u128::from_be(value)
+    }
+
+    #[inline]
+    fn swap_i128(value: i128) -> i128 {
+        i128::from_be(value)
+    }
+
+    #[inline]
+    fn swap_f32(value: f32) -> f32 {
+        f32::from_bits(u32::from_be(value.to_bits()))
+    }
+
+    #[inline]
+    fn swap_f64(value: f64) -> f64 {
+        f64::from_bits(u64::from_be(value.to_bits()))
+    }
+}

--- a/crates/musli-zerocopy/src/lib.rs
+++ b/crates/musli-zerocopy/src/lib.rs
@@ -363,14 +363,15 @@
 //! let unsize = Ref::<str, usize>::with_metadata(0, 1usize << 32);
 //! ```
 //!
-//! To initialize an [`OwnedBuf`] with a custom [`Size`] you use this
-//! constructor with a custom parameter and :
+//! To initialize an [`OwnedBuf`] with a custom [`Size`], you can use
+//! [`OwnedBuf::with_size`]:
 //!
 //! ```
 //! use musli_zerocopy::OwnedBuf;
 //! use musli_zerocopy::buf::DefaultAlignment;
 //!
-//! let mut buf = OwnedBuf::<usize>::with_capacity_and_alignment::<DefaultAlignment>(0);
+//! let mut buf = OwnedBuf::with_capacity_and_alignment::<DefaultAlignment>(0)
+//!     .with_size::<usize>();
 //! ```
 //!
 //! The [`Size`] you've specified during construction of an [`OwnedBuf`] will
@@ -384,7 +385,8 @@
 //! #[repr(C)]
 //! struct Custom { reference: Ref<u32, usize>, slice: Ref::<[u32], usize>, unsize: Ref::<str, usize> }
 //!
-//! let mut buf = OwnedBuf::with_capacity_and_alignment::<DefaultAlignment>(0);
+//! let mut buf = OwnedBuf::with_capacity_and_alignment::<DefaultAlignment>(0)
+//!     .with_size::<usize>();
 //!
 //! let reference = buf.store(&42u32);
 //! let slice = buf.store_slice(&[1, 2, 3, 4]);
@@ -393,6 +395,8 @@
 //! buf.store(&Custom { reference, slice, unsize });
 //! # Ok::<_, musli_zerocopy::Error>(())
 //! ```
+//!
+//! <br>
 //!
 //! [`swiss`]: https://docs.rs/musli-zerocopy/latest/musli_zerocopy/swiss/index.html
 //! [`phf`]: https://docs.rs/musli-zerocopy/latest/musli_zerocopy/phf/index.html
@@ -405,6 +409,7 @@
 //! [ref-u32]: https://docs.rs/musli-zerocopy/latest/musli_zerocopy/pointer/struct.Ref.html
 //! [`Ref<str>`]: https://docs.rs/musli-zerocopy/latest/musli_zerocopy/pointer/struct.Ref.html
 //! [`OwnedBuf`]: https://docs.rs/musli-zerocopy/latest/musli_zerocopy/buf/struct.OwnedBuf.html
+//! [`OwnedBuf::with_size`]: https://docs.rs/musli-zerocopy/latest/musli_zerocopy/buf/struct.OwnedBuf.html#method.with_size
 //! [`Size`]: https://docs.rs/musli-zerocopy/latest/musli_zerocopy/pointer/trait.Size.html
 //! [`aligned_buf(bytes, align)`]: https://docs.rs/musli-zerocopy/latest/musli_zerocopy/pointer/trait.Size.html
 
@@ -448,6 +453,11 @@ pub mod swiss;
 #[doc(inline)]
 pub use self::pointer::Ref;
 pub mod pointer;
+
+mod ordered;
+pub use self::ordered::Ordered;
+
+pub mod endian;
 
 /// Derive macro to implement [`ZeroCopy`].
 ///
@@ -713,6 +723,8 @@ pub mod __private {
     pub mod mem {
         pub use ::core::mem::{align_of, size_of};
     }
+
+    pub use crate::endian::ByteOrder;
 
     #[inline(always)]
     pub fn unknown_discriminant<D>(discriminant: D)

--- a/crates/musli-zerocopy/src/ordered.rs
+++ b/crates/musli-zerocopy/src/ordered.rs
@@ -1,0 +1,128 @@
+use core::marker::PhantomData;
+use core::{any, fmt};
+
+use crate::buf::{Padder, Validator};
+use crate::endian::ByteOrder;
+use crate::ZeroCopy;
+
+/// A value capable of enforcing a custom [`ByteOrder`].
+///
+/// This can be used to store values in a zero-copy container in a portable
+/// manner, which is especially important to transfer types such as `char` which
+/// have a limited supported bit-pattern.
+///
+/// # Examples
+///
+/// ```
+/// use musli_zerocopy::{Ordered, ZeroCopy};
+/// use musli_zerocopy::endian::{BigEndian, LittleEndian};
+///
+/// let mut a: Ordered<_, BigEndian> = Ordered::new('a' as u32);
+/// let mut b: Ordered<_, LittleEndian> = Ordered::new('a' as u32);
+///
+/// assert_eq!(a.into_value(), 'a' as u32);
+/// assert_eq!(a.to_bytes(), &[0, 0, 0, 97]);
+///
+/// assert_eq!(b.into_value(), 'a' as u32);
+/// assert_eq!(b.to_bytes(), &[97, 0, 0, 0]);
+/// ```
+#[repr(transparent)]
+pub struct Ordered<T, E: ByteOrder> {
+    value: T,
+    _marker: PhantomData<E>,
+}
+
+impl<T: ZeroCopy, E: ByteOrder> Ordered<T, E> {
+    /// Construct new value wrapper with the specified [`ByteOrder`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if we try to use this with a `ZeroCopy` type that cannot be
+    /// byte-ordered.
+    ///
+    /// ```should_panic
+    /// use musli_zerocopy::Ordered;
+    /// use musli_zerocopy::endian::LittleEndian;
+    ///
+    /// let _: Ordered<_, LittleEndian> = Ordered::new('a');
+    /// ```
+    #[inline]
+    pub fn new(value: T) -> Self {
+        assert!(
+            T::CAN_SWAP_BYTES,
+            "Type `{}` cannot be byte-ordered since it would not inhabit valid types",
+            any::type_name::<T>()
+        );
+
+        Self {
+            value: T::swap_bytes::<E>(value),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Get interior value with the desired native alignment.
+    #[inline]
+    pub fn into_value(self) -> T {
+        T::swap_bytes::<E>(self.value)
+    }
+}
+
+unsafe impl<T, E> ZeroCopy for Ordered<T, E>
+where
+    T: ZeroCopy,
+    E: ByteOrder,
+{
+    const ANY_BITS: bool = T::ANY_BITS;
+    const PADDED: bool = T::PADDED;
+    const CAN_SWAP_BYTES: bool = true;
+
+    #[inline]
+    unsafe fn pad(padder: &mut Padder<'_, Self>) {
+        T::pad(padder.transparent())
+    }
+
+    #[inline]
+    unsafe fn validate(validator: &mut Validator<'_, Self>) -> Result<(), crate::Error> {
+        T::validate(validator.transparent())
+    }
+
+    #[inline]
+    fn swap_bytes<__E: ByteOrder>(self) -> Self {
+        // NB: This is a no-op, since the byte-ordering is recorded at the type
+        // level and doesn't change no matter what ordering is requested.
+        self
+    }
+}
+
+impl<T, E> fmt::Debug for Ordered<T, E>
+where
+    T: fmt::Debug + ZeroCopy,
+    E: ByteOrder,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Ordered")
+            .field("value", &self.value)
+            .field("_marker", &self._marker)
+            .finish()
+    }
+}
+
+impl<T, E> Clone for Ordered<T, E>
+where
+    T: Clone + ZeroCopy,
+    E: ByteOrder,
+{
+    fn clone(&self) -> Self {
+        Self {
+            value: self.value.clone(),
+            _marker: self._marker,
+        }
+    }
+}
+
+impl<T, E> Copy for Ordered<T, E>
+where
+    T: Copy + ZeroCopy,
+    E: ByteOrder,
+{
+}

--- a/crates/musli-zerocopy/src/phf/factory.rs
+++ b/crates/musli-zerocopy/src/phf/factory.rs
@@ -3,6 +3,7 @@ use core::hash::Hash;
 use alloc::vec::Vec;
 
 use crate::buf::Visit;
+use crate::endian::ByteOrder;
 use crate::error::Error;
 use crate::phf::{Entry, MapRef, SetRef};
 use crate::pointer::Size;
@@ -61,10 +62,10 @@ use crate::ZeroCopy;
 /// assert_eq!(map.get(&30u64)?, None);
 /// # Ok::<_, musli_zerocopy::Error>(())
 /// ```
-pub fn store_map<K, V, I, O: Size>(
-    buf: &mut OwnedBuf<O>,
+pub fn store_map<K, V, I, O: Size, E: ByteOrder>(
+    buf: &mut OwnedBuf<O, E>,
     entries: I,
-) -> Result<MapRef<K, V, O>, Error>
+) -> Result<MapRef<K, V, O, E>, Error>
 where
     K: Visit + ZeroCopy,
     V: ZeroCopy,
@@ -162,7 +163,10 @@ where
 /// assert!(!set.contains(&3)?);
 /// # Ok::<_, musli_zerocopy::Error>(())
 /// ```
-pub fn store_set<T, I, O: Size>(buf: &mut OwnedBuf<O>, iter: I) -> Result<SetRef<T, O>, Error>
+pub fn store_set<T, I, O: Size, E: ByteOrder>(
+    buf: &mut OwnedBuf<O, E>,
+    iter: I,
+) -> Result<SetRef<T, O, E>, Error>
 where
     T: Visit + ZeroCopy,
     T::Target: Hash,

--- a/crates/musli-zerocopy/src/swiss/map.rs
+++ b/crates/musli-zerocopy/src/swiss/map.rs
@@ -2,15 +2,15 @@
 //! up by keys.
 //!
 //! This map are implemented using a perfect hash functions, and are inserted
-//! into a buffering using [`phf::store_map`].
+//! into a buffering using [`swiss::store_map`].
 //!
 //! There's two types provided by this module:
 //! * [`Map<K, V>`] which is a *bound* reference to a map, providing a
 //!   convenient map-like access.
 //! * [`MapRef<K, V>`] which is the *pointer* of the map. This is what you store
-//!   in [`ZeroCopy`] types and is what is returned by [`phf::store_map`].
+//!   in [`ZeroCopy`] types and is what is returned by [`swiss::store_map`].
 //!
-//! [`phf::store_map`]: crate::phf::store_map
+//! [`swiss::store_map`]: crate::swiss::store_map
 
 use core::borrow::Borrow;
 use core::convert::identity as likely;
@@ -32,11 +32,11 @@ use crate::{Ordered, ZeroCopy};
 ///
 /// ```
 /// use musli_zerocopy::OwnedBuf;
-/// use musli_zerocopy::phf;
+/// use musli_zerocopy::swiss;
 ///
 /// let mut buf = OwnedBuf::new();
 ///
-/// let map = phf::store_map(&mut buf, [(1, 2), (2, 3)])?;
+/// let map = swiss::store_map(&mut buf, [(1, 2), (2, 3)])?;
 /// let buf = buf.into_aligned();
 /// let map = buf.bind(map)?;
 ///
@@ -65,11 +65,11 @@ where
     ///
     /// ```
     /// use musli_zerocopy::OwnedBuf;
-    /// use musli_zerocopy::phf;
+    /// use musli_zerocopy::swiss;
     ///
     /// let mut buf = OwnedBuf::new();
     ///
-    /// let map = phf::store_map(&mut buf, [(1, 2), (2, 3)])?;
+    /// let map = swiss::store_map(&mut buf, [(1, 2), (2, 3)])?;
     /// let buf = buf.into_aligned();
     /// let map = buf.bind(map)?;
     ///
@@ -98,17 +98,61 @@ where
         }
     }
 
+    /// Get the length of the map.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use musli_zerocopy::OwnedBuf;
+    /// use musli_zerocopy::swiss;
+    ///
+    /// let mut buf = OwnedBuf::new();
+    ///
+    /// let map = swiss::store_map(&mut buf, [(1, 2), (2, 3)])?;
+    /// let buf = buf.into_aligned();
+    /// let map = buf.bind(map)?;
+    ///
+    /// assert_eq!(map.len(), 2);
+    /// # Ok::<_, musli_zerocopy::Error>(())
+    /// ```
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.table.len
+    }
+
+    /// Test if the map is empty.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use musli_zerocopy::OwnedBuf;
+    /// use musli_zerocopy::swiss;
+    ///
+    /// let mut buf = OwnedBuf::new();
+    ///
+    /// let map = swiss::store_map(&mut buf, [(1, 2), (2, 3)])?;
+    /// let buf = buf.into_aligned();
+    /// let map = buf.bind(map)?;
+    ///
+    /// assert!(!map.is_empty());
+    /// # Ok::<_, musli_zerocopy::Error>(())
+    /// ```
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.table.len == 0
+    }
+
     /// Test if the map contains the given `key`.
     ///
     /// ## Examples
     ///
     /// ```
     /// use musli_zerocopy::OwnedBuf;
-    /// use musli_zerocopy::phf;
+    /// use musli_zerocopy::swiss;
     ///
     /// let mut buf = OwnedBuf::new();
     ///
-    /// let map = phf::store_map(&mut buf, [(1, 2), (2, 3)])?;
+    /// let map = swiss::store_map(&mut buf, [(1, 2), (2, 3)])?;
     /// let buf = buf.into_aligned();
     /// let map = buf.bind(map)?;
     ///
@@ -168,20 +212,20 @@ where
 /// [`bind()`] is used and might result in better performance if the data is
 /// infrequently accessed.
 ///
-/// Constructed through [`phf::store_map`].
+/// Constructed through [`swiss::store_map`].
 ///
-/// [`phf::store_map`]: crate::phf::store_map
+/// [`swiss::store_map`]: crate::swiss::store_map
 /// [`bind()`]: crate::buf::Buf::bind
 ///
 /// ## Examples
 ///
 /// ```
 /// use musli_zerocopy::OwnedBuf;
-/// use musli_zerocopy::phf;
+/// use musli_zerocopy::swiss;
 ///
 /// let mut buf = OwnedBuf::new();
 ///
-/// let map = phf::store_map(&mut buf, [(1, 2), (2, 3)])?;
+/// let map = swiss::store_map(&mut buf, [(1, 2), (2, 3)])?;
 ///
 /// assert_eq!(map.get(&buf, &1)?, Some(&2));
 /// assert_eq!(map.get(&buf, &2)?, Some(&3));
@@ -222,11 +266,11 @@ where
     ///
     /// ```
     /// use musli_zerocopy::OwnedBuf;
-    /// use musli_zerocopy::phf;
+    /// use musli_zerocopy::swiss;
     ///
     /// let mut buf = OwnedBuf::new();
     ///
-    /// let map = phf::store_map(&mut buf, [(1, 2), (2, 3)])?;
+    /// let map = swiss::store_map(&mut buf, [(1, 2), (2, 3)])?;
     ///
     /// assert_eq!(map.get(&buf, &1)?, Some(&2));
     /// assert_eq!(map.get(&buf, &2)?, Some(&3));
@@ -251,6 +295,46 @@ where
         } else {
             Ok(None)
         }
+    }
+
+    /// Get the length of the map.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use musli_zerocopy::OwnedBuf;
+    /// use musli_zerocopy::swiss;
+    ///
+    /// let mut buf = OwnedBuf::new();
+    ///
+    /// let map = swiss::store_map(&mut buf, [(1, 2), (2, 3)])?;
+    ///
+    /// assert_eq!(map.len(), 2);
+    /// # Ok::<_, musli_zerocopy::Error>(())
+    /// ```
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.table.len.into_value()
+    }
+
+    /// Test if the map is empty.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use musli_zerocopy::OwnedBuf;
+    /// use musli_zerocopy::swiss;
+    ///
+    /// let mut buf = OwnedBuf::new();
+    ///
+    /// let map = swiss::store_map(&mut buf, [(1, 2), (2, 3)])?;
+    ///
+    /// assert!(!map.is_empty());
+    /// # Ok::<_, musli_zerocopy::Error>(())
+    /// ```
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.table.len.into_value() == 0
     }
 
     /// Test if the map contains the given `key`.
@@ -301,6 +385,7 @@ pub(crate) struct RawTable<'a, T> {
     ctrl: &'a [u8],
     entries: &'a [T],
     bucket_mask: usize,
+    len: usize,
 }
 
 impl<'a, T> RawTable<'a, T> {
@@ -387,6 +472,7 @@ where
     ctrl: Ref<[u8], O, E>,
     entries: Ref<[T], O, E>,
     bucket_mask: Ordered<usize, E>,
+    len: Ordered<usize, E>,
 }
 
 impl<T, O: Size, E: ByteOrder> RawTableRef<T, O, E>
@@ -395,11 +481,17 @@ where
 {
     #[cfg(feature = "alloc")]
     #[inline]
-    pub(crate) fn new(ctrl: Ref<[u8], O, E>, entries: Ref<[T], O, E>, bucket_mask: usize) -> Self {
+    pub(crate) fn new(
+        ctrl: Ref<[u8], O, E>,
+        entries: Ref<[T], O, E>,
+        bucket_mask: usize,
+        len: usize,
+    ) -> Self {
         Self {
             ctrl,
             entries,
             bucket_mask: Ordered::new(bucket_mask),
+            len: Ordered::new(len),
         }
     }
 
@@ -409,6 +501,7 @@ where
             ctrl: buf.load(self.ctrl)?,
             entries: buf.load(self.entries)?,
             bucket_mask: self.bucket_mask.into_value(),
+            len: self.len.into_value(),
         })
     }
 }

--- a/crates/musli-zerocopy/src/swiss/set.rs
+++ b/crates/musli-zerocopy/src/swiss/set.rs
@@ -16,6 +16,7 @@ use core::borrow::Borrow;
 use core::hash::{Hash, Hasher};
 
 use crate::buf::{Bindable, Buf, Visit};
+use crate::endian::{ByteOrder, DefaultEndian};
 use crate::error::Error;
 use crate::pointer::{DefaultSize, Size};
 use crate::sip::SipHasher13;
@@ -97,12 +98,13 @@ where
 }
 
 /// Bind a [`SetRef`] into a [`Set`].
-impl<T, O: Size> Bindable for SetRef<T, O>
+impl<T, O: Size, E: ByteOrder> Bindable for SetRef<T, O, E>
 where
     T: ZeroCopy,
 {
     type Bound<'a> = Set<'a, T> where Self: 'a;
 
+    #[inline]
     fn bind(self, buf: &Buf) -> Result<Self::Bound<'_>, Error> {
         Ok(Set {
             key: self.key,
@@ -141,20 +143,20 @@ where
 #[derive(Debug, ZeroCopy)]
 #[repr(C)]
 #[zero_copy(crate)]
-pub struct SetRef<T, O: Size = DefaultSize>
+pub struct SetRef<T, O: Size = DefaultSize, E: ByteOrder = DefaultEndian>
 where
     T: ZeroCopy,
 {
     key: u64,
-    table: RawTableRef<T, O>,
+    table: RawTableRef<T, O, E>,
 }
 
-impl<T, O: Size> SetRef<T, O>
+impl<T, O: Size, E: ByteOrder> SetRef<T, O, E>
 where
     T: ZeroCopy,
 {
     #[cfg(feature = "alloc")]
-    pub(crate) fn new(key: u64, table: RawTableRef<T, O>) -> Self {
+    pub(crate) fn new(key: u64, table: RawTableRef<T, O, E>) -> Self {
         Self { key, table }
     }
 

--- a/crates/musli-zerocopy/tests/ui/deny_sneaky_field_error.stderr
+++ b/crates/musli-zerocopy/tests/ui/deny_sneaky_field_error.stderr
@@ -16,6 +16,14 @@ help: if you don't care about this missing field, you can explicitly ignore it
 15 |     field, .. }
    |          ~~~~~~
 
+error[E0063]: missing field `sneaky_field` in initializer of `SneakyNamed`
+  --> tests/ui/deny_sneaky_field_error.rs:11:10
+   |
+11 | #[derive(ZeroCopy)]
+   |          ^^^^^^^^ missing `sneaky_field`
+   |
+   = note: this error originates in the derive macro `ZeroCopy` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0023]: this pattern has 1 field, but the corresponding tuple struct has 2 fields
   --> tests/ui/deny_sneaky_field_error.rs:25:10
    |
@@ -39,6 +47,14 @@ help: use `..` to ignore all fields
 25 | #[derive(..)]
    |          ~~
 
+error[E0063]: missing field `1` in initializer of `SneakyUnnamed`
+  --> tests/ui/deny_sneaky_field_error.rs:25:10
+   |
+25 | #[derive(ZeroCopy)]
+   |          ^^^^^^^^ missing `1`
+   |
+   = note: this error originates in the derive macro `ZeroCopy` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0027]: pattern does not mention field `sneaky_field`
   --> tests/ui/deny_sneaky_field_error.rs:38:6
    |
@@ -57,6 +73,30 @@ help: if you don't care about this missing field, you can explicitly ignore it
    |
 40 |         field, .. },
    |              ~~~~~~
+
+error[E0027]: pattern does not mention field `sneaky_field`
+  --> tests/ui/deny_sneaky_field_error.rs:35:10
+   |
+35 | #[derive(ZeroCopy)]
+   |          ^^^^^^^^ missing field `sneaky_field`
+   |
+   = note: this error originates in the derive macro `ZeroCopy` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: include the missing field in the pattern
+   |
+35 | #[derive(ZeroCopy, sneaky_field }: u32,
+   |                  ~~~~~~~~~~~~~~~~
+help: if you don't care about this missing field, you can explicitly ignore it
+   |
+35 | #[derive(ZeroCopy, .. }: u32,
+   |                  ~~~~~~
+
+error[E0063]: missing field `sneaky_field` in initializer of `SneakyEnumNamed`
+  --> tests/ui/deny_sneaky_field_error.rs:35:10
+   |
+35 | #[derive(ZeroCopy)]
+   |          ^^^^^^^^ missing `sneaky_field`
+   |
+   = note: this error originates in the derive macro `ZeroCopy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0023]: this pattern has 1 field, but the corresponding tuple variant has 2 fields
   --> tests/ui/deny_sneaky_field_error.rs:44:10
@@ -84,6 +124,30 @@ help: use `..` to ignore all fields
 44 | #[derive(..)]
    |          ~~
 
+error[E0027]: pattern does not mention field `1`
+  --> tests/ui/deny_sneaky_field_error.rs:44:10
+   |
+44 | #[derive(ZeroCopy)]
+   |          ^^^^^^^^ missing field `1`
+   |
+   = note: this error originates in the derive macro `ZeroCopy` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: include the missing field in the pattern
+   |
+44 | #[derive(ZeroCopy, 1: _ })]
+   |                  ++++++++
+help: if you don't care about this missing field, you can explicitly ignore it
+   |
+44 | #[derive(ZeroCopy, .. })]
+   |                  ++++++
+
+error[E0063]: missing field `1` in initializer of `SneakyEnumUnnamed`
+  --> tests/ui/deny_sneaky_field_error.rs:44:10
+   |
+44 | #[derive(ZeroCopy)]
+   |          ^^^^^^^^ missing `1`
+   |
+   = note: this error originates in the derive macro `ZeroCopy` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0533]: expected unit struct, unit variant or constant, found struct variant `SneakyEnumUnit::Unit`
   --> tests/ui/deny_sneaky_field_error.rs:54:6
    |
@@ -91,3 +155,27 @@ error[E0533]: expected unit struct, unit variant or constant, found struct varia
    |  ______^
 55 | |     Unit
    | |________^ not a unit struct, unit variant or constant
+
+error[E0027]: pattern does not mention field `sneaky_field`
+  --> tests/ui/deny_sneaky_field_error.rs:51:10
+   |
+51 | #[derive(ZeroCopy)]
+   |          ^^^^^^^^ missing field `sneaky_field`
+   |
+   = note: this error originates in the derive macro `ZeroCopy` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: include the missing field in the pattern
+   |
+51 | #[derive(ZeroCopy { sneaky_field })]
+   |                   ++++++++++++++++
+help: if you don't care about this missing field, you can explicitly ignore it
+   |
+51 | #[derive(ZeroCopy { .. })]
+   |                   ++++++
+
+error[E0063]: missing field `sneaky_field` in initializer of `SneakyEnumUnit`
+  --> tests/ui/deny_sneaky_field_error.rs:51:10
+   |
+51 | #[derive(ZeroCopy)]
+   |          ^^^^^^^^ missing `sneaky_field`
+   |
+   = note: this error originates in the derive macro `ZeroCopy` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/tests/src/utils/mod.rs
+++ b/crates/tests/src/utils/mod.rs
@@ -254,7 +254,7 @@ pub mod musli_zerocopy {
     #[inline(always)]
     pub fn new() -> Benchmarker {
         Benchmarker {
-            buf: OwnedBuf::with_capacity_and_alignment::<DefaultAlignment>(4096),
+            buf: OwnedBuf::with_capacity(4096).with_size(),
         }
     }
 


### PR DESCRIPTION
This introduces the ability for `ZeroCopy` types to be byte-swapped using `ZeroCopy::swap_bytes`.

This method is `unsafe` and must only be called on types which can be safely byte-reordered. This excludes e.g. `char`. Byte types such as `NonZero*` are covered because byte swapping can't cause it to inhabit an illegal bit pattern.

The safe API for this is the `Ordered<T, E>` type, which can be used to enforce byte ordering of a field.