### PR TITLE
Clean up Endian handling

### DIFF
--- a/crates/musli-zerocopy/README.md
+++ b/crates/musli-zerocopy/README.md
@@ -324,9 +324,9 @@ specify a "sticky" [`ByteOrder`] to use in types which interact with it
 during construction:
 
 ```rust
-use musli_zerocopy::{BigEndian, LittleEndian, Order, OwnedBuf};
+use musli_zerocopy::{Big, Little, Order, OwnedBuf};
 
-let mut buf = OwnedBuf::new().with_byte_order::<LittleEndian>();
+let mut buf = OwnedBuf::new().with_byte_order::<Little>();
 
 let first = buf.store(&Order::le(42u16));
 let portable = Archive {
@@ -345,7 +345,7 @@ assert_eq!(&buf[..], &[
 
 let portable = buf.load(portable)?;
 
-let mut buf = OwnedBuf::new().with_byte_order::<BigEndian>();
+let mut buf = OwnedBuf::new().with_byte_order::<Big>();
 
 let first = buf.store(&Order::be(42u16));
 let portable = Archive {
@@ -406,9 +406,9 @@ The available [`Size`] implementations are:
 
 ```rust
 // These no longer panic:
-let reference = Ref::<Custom, NativeEndian, usize>::new(1usize << 32);
-let slice = Ref::<[Custom], NativeEndian, usize>::with_metadata(0, 1usize << 32);
-let unsize = Ref::<str, NativeEndian, usize>::with_metadata(0, 1usize << 32);
+let reference = Ref::<Custom, Native, usize>::new(1usize << 32);
+let slice = Ref::<[Custom], Native, usize>::with_metadata(0, 1usize << 32);
+let unsize = Ref::<str, Native, usize>::with_metadata(0, 1usize << 32);
 ```
 
 To initialize an [`OwnedBuf`] with a custom [`Size`], you can use
@@ -426,15 +426,15 @@ The [`Size`] you've specified during construction of an [`OwnedBuf`] will
 then carry into any pointers it return:
 
 ```rust
-use musli_zerocopy::{OwnedBuf, Ref, ZeroCopy, NativeEndian};
+use musli_zerocopy::{OwnedBuf, Ref, ZeroCopy, Native};
 use musli_zerocopy::buf::DefaultAlignment;
 
 #[derive(ZeroCopy)]
 #[repr(C)]
 struct Custom {
-    reference: Ref<u32, NativeEndian, usize>,
-    slice: Ref::<[u32], NativeEndian, usize>,
-    unsize: Ref::<str, NativeEndian, usize>,
+    reference: Ref<u32, Native, usize>,
+    slice: Ref::<[u32], Native, usize>,
+    unsize: Ref::<str, Native, usize>,
 }
 
 let mut buf = OwnedBuf::with_capacity_and_alignment::<DefaultAlignment>(0)

--- a/crates/musli-zerocopy/examples/dual_archive.rs
+++ b/crates/musli-zerocopy/examples/dual_archive.rs
@@ -1,0 +1,57 @@
+//! Example showcasing how to build an archive which contains mixed endian data.
+
+use anyhow::Result;
+use musli_zerocopy::endian::{Big, Little};
+use musli_zerocopy::{ByteOrder, Endian, OwnedBuf, Ref, ZeroCopy};
+
+#[derive(ZeroCopy)]
+#[repr(C)]
+struct Header {
+    big: Ref<Data<Big>, Little>,
+    little: Ref<Data<Little>, Little>,
+}
+
+#[derive(ZeroCopy)]
+#[repr(C)]
+struct Data<E>
+where
+    E: ByteOrder,
+{
+    name: Ref<str, E>,
+    age: Endian<u32, E>,
+}
+
+fn main() -> Result<()> {
+    let mut buf = OwnedBuf::new();
+
+    let header = buf.store_uninit::<Header>();
+
+    // Byte-oriented data has no alignment, so we can re-use the string
+    // allocation.
+    let name = buf.store_unsized("John Doe");
+
+    let big = buf.store(&Data {
+        name: name.to_endian(),
+        age: Endian::new(35),
+    });
+
+    let little = buf.store(&Data {
+        name: name.to_endian(),
+        age: Endian::new(35),
+    });
+
+    buf.load_uninit_mut(header).write(&Header { big, little });
+
+    buf.align_in_place();
+
+    let header = buf.load_at::<Header>(0)?;
+    let little = buf.load(header.little)?;
+    let big = buf.load(header.big)?;
+
+    dbg!(buf.load(little.name)?);
+    dbg!(little.age.to_ne(), little.age.to_raw());
+
+    dbg!(buf.load(big.name)?);
+    dbg!(big.age.to_ne(), big.age.to_raw());
+    Ok(())
+}

--- a/crates/musli-zerocopy/src/buf/owned_buf.rs
+++ b/crates/musli-zerocopy/src/buf/owned_buf.rs
@@ -9,7 +9,7 @@ use core::slice::{self, SliceIndex};
 use alloc::alloc;
 
 use crate::buf::{Buf, DefaultAlignment, Padder, StoreBuf};
-use crate::endian::{ByteOrder, NativeEndian};
+use crate::endian::{ByteOrder, Native};
 use crate::error::Error;
 use crate::mem::MaybeUninit;
 use crate::pointer::{DefaultSize, Pointee, Ref, Size};
@@ -33,7 +33,7 @@ use crate::traits::{UnsizedZeroCopy, ZeroCopy};
 /// let mut buf = OwnedBuf::new();
 /// buf.store(&Custom { field: 10 });
 /// ```
-pub struct OwnedBuf<E: ByteOrder = NativeEndian, O: Size = DefaultSize> {
+pub struct OwnedBuf<E: ByteOrder = Native, O: Size = DefaultSize> {
     data: NonNull<u8>,
     /// The initialized length of the buffer.
     len: usize,
@@ -82,10 +82,10 @@ impl OwnedBuf {
     /// ```should_panic
     /// use std::mem::align_of;
     ///
-    /// use musli_zerocopy::{NativeEndian, DefaultAlignment, OwnedBuf};
+    /// use musli_zerocopy::{endian, DefaultAlignment, OwnedBuf};
     ///
     /// let max = isize::MAX as usize - (align_of::<DefaultAlignment>() - 1);
-    /// OwnedBuf::<NativeEndian, u32>::with_capacity(max);
+    /// OwnedBuf::<endian::Native, u32>::with_capacity(max);
     /// ```
     ///
     /// # Examples
@@ -194,10 +194,10 @@ impl<E: ByteOrder, O: Size> OwnedBuf<E, O> {
     /// # Examples
     ///
     /// ```
-    /// use musli_zerocopy::{LittleEndian, OwnedBuf};
+    /// use musli_zerocopy::{endian, OwnedBuf};
     ///
     /// let mut buf = OwnedBuf::with_capacity(1024)
-    ///     .with_byte_order::<LittleEndian>();
+    ///     .with_byte_order::<endian::Little>();
     /// ```
     #[inline]
     pub fn with_byte_order<U: ByteOrder>(self) -> OwnedBuf<U, O> {
@@ -919,8 +919,8 @@ impl<E: ByteOrder, O: Size> OwnedBuf<E, O> {
     /// if a reallocation is triggered due to reaching its [`capacity()`].
     ///
     /// ```
-    /// use musli_zerocopy::{NativeEndian, OwnedBuf};
-    /// let mut buf = OwnedBuf::<NativeEndian, u32>::with_capacity_and_alignment::<u16>(32);
+    /// use musli_zerocopy::{endian, OwnedBuf};
+    /// let mut buf = OwnedBuf::<endian::Native, u32>::with_capacity_and_alignment::<u16>(32);
     ///
     /// buf.extend_from_slice(&[1, 2]);
     /// assert!(buf.alignment() >= 2);
@@ -1194,11 +1194,11 @@ impl<E: ByteOrder, O: Size> Borrow<Buf> for OwnedBuf<E, O> {
 /// ```
 /// use std::mem::align_of;
 ///
-/// use musli_zerocopy::{NativeEndian, OwnedBuf};
+/// use musli_zerocopy::{endian, OwnedBuf};
 ///
 /// assert_ne!(align_of::<u16>(), align_of::<u32>());
 ///
-/// let mut buf = OwnedBuf::<NativeEndian, u32>::with_capacity_and_alignment::<u16>(32);
+/// let mut buf = OwnedBuf::<endian::Native, u32>::with_capacity_and_alignment::<u16>(32);
 /// buf.extend_from_slice(&[1, 2, 3, 4]);
 /// buf.request_align::<u32>();
 ///

--- a/crates/musli-zerocopy/src/buf/slice_mut.rs
+++ b/crates/musli-zerocopy/src/buf/slice_mut.rs
@@ -9,7 +9,7 @@ use core::slice::{self, SliceIndex};
 use alloc::borrow::Cow;
 
 use crate::buf::{Buf, DefaultAlignment, Padder, StoreBuf};
-use crate::endian::{ByteOrder, NativeEndian};
+use crate::endian::{ByteOrder, Native};
 use crate::error::Error;
 use crate::mem::MaybeUninit;
 use crate::pointer::{DefaultSize, Pointee, Ref, Size};
@@ -34,7 +34,7 @@ use crate::traits::{UnsizedZeroCopy, ZeroCopy};
 /// let mut buf = SliceMut::new(&mut buf);
 /// buf.store(&Custom { field: 10 });
 /// ```
-pub struct SliceMut<'a, E: ByteOrder = NativeEndian, O: Size = DefaultSize> {
+pub struct SliceMut<'a, E: ByteOrder = Native, O: Size = DefaultSize> {
     /// Base data pointer.
     data: NonNull<u8>,
     /// The initialized length of the buffer.
@@ -125,11 +125,11 @@ impl<'a, E: ByteOrder, O: Size> SliceMut<'a, E, O> {
     /// # Examples
     ///
     /// ```
-    /// use musli_zerocopy::{LittleEndian, SliceMut};
+    /// use musli_zerocopy::{endian, SliceMut};
     ///
     /// let mut buf = [0; 1024];
     /// let mut buf = SliceMut::new(&mut buf)
-    ///     .with_byte_order::<LittleEndian>();
+    ///     .with_byte_order::<endian::Little>();
     /// ```
     #[inline]
     pub fn with_byte_order<U: ByteOrder>(self) -> SliceMut<'a, U, O> {

--- a/crates/musli-zerocopy/src/endian/mod.rs
+++ b/crates/musli-zerocopy/src/endian/mod.rs
@@ -1,34 +1,38 @@
 //! Marker types which define a [`ByteOrder`] to use.
 
+#[doc(inline)]
+pub use self::endian::Endian;
+mod endian;
+
 /// Alias for the native endian [`ByteOrder`].
 #[cfg(target_endian = "little")]
-pub type NativeEndian = LittleEndian;
+pub type Native = Little;
 
 /// Alias for the native endian [`ByteOrder`].
 #[cfg(target_endian = "big")]
-pub type NativeEndian = BigEndian;
+pub type Native = Big;
 
 /// Marker type indicating that the big endian [`ByteOrder`] is in use.
 #[non_exhaustive]
-pub struct BigEndian;
+pub struct Big;
 
 /// Marker type indicating that the little endian [`ByteOrder`] is in use.
 #[non_exhaustive]
-pub struct LittleEndian;
+pub struct Little;
 
 mod sealed {
-    use super::{BigEndian, LittleEndian};
+    use super::{Big, Little};
 
     pub trait Sealed {}
 
-    impl Sealed for BigEndian {}
-    impl Sealed for LittleEndian {}
+    impl Sealed for Big {}
+    impl Sealed for Little {}
 }
 
 /// Defines a byte order to use.
 ///
-/// This trait is implemented by two marker types [`BigEndian`] and
-/// [`LittleEndian`], and its internals are intentionally hidden. Do not attempt
+/// This trait is implemented by two marker types [`Big`] and
+/// [`Little`], and its internals are intentionally hidden. Do not attempt
 /// to use them yourself.
 pub trait ByteOrder: 'static + Sized + self::sealed::Sealed {
     /// Swap the bytes for a `usize` with the current byte order.
@@ -80,7 +84,7 @@ pub trait ByteOrder: 'static + Sized + self::sealed::Sealed {
     fn swap_f64(value: f64) -> f64;
 }
 
-impl ByteOrder for LittleEndian {
+impl ByteOrder for Little {
     #[inline]
     fn swap_usize(value: usize) -> usize {
         usize::from_le(value)
@@ -142,7 +146,7 @@ impl ByteOrder for LittleEndian {
     }
 }
 
-impl ByteOrder for BigEndian {
+impl ByteOrder for Big {
     #[inline]
     fn swap_usize(value: usize) -> usize {
         usize::from_be(value)

--- a/crates/musli-zerocopy/src/lib.rs
+++ b/crates/musli-zerocopy/src/lib.rs
@@ -330,13 +330,13 @@
 //! maximally flexible as an example:
 //!
 //! ```
-//! use musli_zerocopy::{Size, ByteOrder, Ref, Order, ZeroCopy};
+//! use musli_zerocopy::{Size, ByteOrder, Ref, Endian, ZeroCopy};
 //!
 //! #[derive(ZeroCopy)]
 //! #[repr(C)]
 //! struct Archive<E, O> where E: ByteOrder, O: Size {
 //!     string: Ref<str, E, O>,
-//!     number: Order<u32, E>,
+//!     number: Endian<u32, E>,
 //! }
 //! ```
 //!
@@ -346,21 +346,21 @@
 //! during construction:
 //!
 //! ```
-//! use musli_zerocopy::{BigEndian, LittleEndian, Order, OwnedBuf};
+//! use musli_zerocopy::{endian, Endian, OwnedBuf};
 //! # use musli_zerocopy::{Size, ByteOrder, Ref, ZeroCopy};
 //! # #[derive(ZeroCopy)]
 //! # #[repr(C)]
 //! # struct Archive<E, O> where E: ByteOrder, O: Size {
 //! #     string: Ref<str, E, O>,
-//! #     number: Order<u32, E>
+//! #     number: Endian<u32, E>
 //! # }
+//! let mut buf = OwnedBuf::new()
+//!     .with_byte_order::<endian::Little>();
 //!
-//! let mut buf = OwnedBuf::new().with_byte_order::<LittleEndian>();
-//!
-//! let first = buf.store(&Order::le(42u16));
+//! let first = buf.store(&Endian::le(42u16));
 //! let portable = Archive {
 //!     string: buf.store_unsized("Hello World!"),
-//!     number: Order::new(10),
+//!     number: Endian::new(10),
 //! };
 //! let portable = buf.store(&portable);
 //!
@@ -377,12 +377,13 @@
 //! # assert_eq!(buf.load(portable.string)?, "Hello World!");
 //! # assert_eq!(portable.number.to_ne(), 10);
 //!
-//! let mut buf = OwnedBuf::new().with_byte_order::<BigEndian>();
+//! let mut buf = OwnedBuf::new()
+//!     .with_byte_order::<endian::Big>();
 //!
-//! let first = buf.store(&Order::be(42u16));
+//! let first = buf.store(&Endian::be(42u16));
 //! let portable = Archive {
 //!     string: buf.store_unsized("Hello World!"),
-//!     number: Order::new(10),
+//!     number: Endian::new(10),
 //! };
 //! let portable = buf.store(&portable);
 //!
@@ -450,14 +451,15 @@
 //! * `usize` for target-dependently sized pointers.
 //!
 //! ```
-//! # use musli_zerocopy::{Ref, NativeEndian, ZeroCopy};
+//! # use musli_zerocopy::{Ref, ZeroCopy};
+//! # use musli_zerocopy::endian::Native;
 //! # #[derive(ZeroCopy)]
 //! # #[repr(C)]
 //! # struct Custom;
 //! // These no longer panic:
-//! let reference = Ref::<Custom, NativeEndian, usize>::new(1usize << 32);
-//! let slice = Ref::<[Custom], NativeEndian, usize>::with_metadata(0, 1usize << 32);
-//! let unsize = Ref::<str, NativeEndian, usize>::with_metadata(0, 1usize << 32);
+//! let reference = Ref::<Custom, Native, usize>::new(1usize << 32);
+//! let slice = Ref::<[Custom], Native, usize>::with_metadata(0, 1usize << 32);
+//! let unsize = Ref::<str, Native, usize>::with_metadata(0, 1usize << 32);
 //! ```
 //!
 //! To initialize an [`OwnedBuf`] with a custom [`Size`], you can use
@@ -475,18 +477,18 @@
 //! then carry into any pointers it return:
 //!
 //! ```
-//! use musli_zerocopy::{OwnedBuf, Ref, ZeroCopy, NativeEndian};
-//! use musli_zerocopy::buf::DefaultAlignment;
+//! use musli_zerocopy::{DefaultAlignment, OwnedBuf, Ref, ZeroCopy};
+//! use musli_zerocopy::endian::Native;
 //!
 //! #[derive(ZeroCopy)]
 //! #[repr(C)]
 //! struct Custom {
-//!     reference: Ref<u32, NativeEndian, usize>,
-//!     slice: Ref::<[u32], NativeEndian, usize>,
-//!     unsize: Ref::<str, NativeEndian, usize>,
+//!     reference: Ref<u32, Native, usize>,
+//!     slice: Ref::<[u32], Native, usize>,
+//!     unsize: Ref::<str, Native, usize>,
 //! }
 //!
-//! let mut buf = OwnedBuf::with_capacity_and_alignment::<DefaultAlignment>(0)
+//! let mut buf = OwnedBuf::with_capacity(0)
 //!     .with_size::<usize>();
 //!
 //! let reference = buf.store(&42u32);
@@ -559,11 +561,7 @@ pub use self::pointer::{DefaultSize, Ref, Size};
 pub mod pointer;
 
 #[doc(inline)]
-pub use self::order::Order;
-mod order;
-
-#[doc(inline)]
-pub use self::endian::{BigEndian, ByteOrder, LittleEndian, NativeEndian};
+pub use self::endian::{ByteOrder, Endian};
 pub mod endian;
 
 /// Derive macro to implement [`ZeroCopy`].

--- a/crates/musli-zerocopy/src/phf/map.rs
+++ b/crates/musli-zerocopy/src/phf/map.rs
@@ -16,12 +16,12 @@ use core::borrow::Borrow;
 use core::hash::Hash;
 
 use crate::buf::{Bindable, Buf, Visit};
-use crate::endian::{ByteOrder, NativeEndian};
+use crate::endian::{ByteOrder, Native};
 use crate::error::Error;
 use crate::phf::hashing::HashKey;
 use crate::phf::Entry;
 use crate::pointer::{DefaultSize, Ref, Size};
-use crate::{Order, ZeroCopy};
+use crate::{Endian, ZeroCopy};
 
 /// A map bound to a [`Buf`] through [`Buf::bind`] for convenience.
 ///
@@ -213,12 +213,12 @@ where
 #[derive(Debug, ZeroCopy)]
 #[repr(C)]
 #[zero_copy(crate)]
-pub struct MapRef<K, V, E: ByteOrder = NativeEndian, O: Size = DefaultSize>
+pub struct MapRef<K, V, E: ByteOrder = Native, O: Size = DefaultSize>
 where
     K: ZeroCopy,
     V: ZeroCopy,
 {
-    key: Order<HashKey, E>,
+    key: Endian<HashKey, E>,
     entries: Ref<[Entry<K, V>], E, O>,
     displacements: Ref<[Entry<u32, u32>], E, O>,
 }
@@ -235,7 +235,7 @@ where
         displacements: Ref<[Entry<u32, u32>], E, O>,
     ) -> Self {
         Self {
-            key: Order::new(key),
+            key: Endian::new(key),
             entries,
             displacements,
         }

--- a/crates/musli-zerocopy/src/phf/set.rs
+++ b/crates/musli-zerocopy/src/phf/set.rs
@@ -16,12 +16,12 @@ use core::borrow::Borrow;
 use core::hash::Hash;
 
 use crate::buf::{Bindable, Buf, Visit};
-use crate::endian::{ByteOrder, NativeEndian};
+use crate::endian::{ByteOrder, Native};
 use crate::error::Error;
 use crate::phf::hashing::HashKey;
 use crate::phf::Entry;
 use crate::pointer::{DefaultSize, Ref, Size};
-use crate::{Order, ZeroCopy};
+use crate::{Endian, ZeroCopy};
 
 /// A set bound to a [`Buf`] through [`Buf::bind`] for convenience.
 ///
@@ -141,11 +141,11 @@ where
 #[derive(Debug, ZeroCopy)]
 #[repr(C)]
 #[zero_copy(crate)]
-pub struct SetRef<T, E: ByteOrder = NativeEndian, O: Size = DefaultSize>
+pub struct SetRef<T, E: ByteOrder = Native, O: Size = DefaultSize>
 where
     T: ZeroCopy,
 {
-    key: Order<HashKey, E>,
+    key: Endian<HashKey, E>,
     entries: Ref<[T], E, O>,
     displacements: Ref<[Entry<u32, u32>], E, O>,
 }
@@ -162,7 +162,7 @@ where
         displacements: Ref<[Entry<u32, u32>], E, O>,
     ) -> Self {
         Self {
-            key: Order::new(key),
+            key: Endian::new(key),
             entries,
             displacements,
         }

--- a/crates/musli-zerocopy/src/pointer/size.rs
+++ b/crates/musli-zerocopy/src/pointer/size.rs
@@ -67,10 +67,10 @@ macro_rules! impl_size {
         /// # Examples
         ///
         /// ```
-        /// use musli_zerocopy::{BigEndian, LittleEndian, Size};
+        /// use musli_zerocopy::{endian, Size};
         ///
-        #[doc = concat!("let max = ", stringify!($ty), "::MAX.as_usize::<LittleEndian>();")]
-        #[doc = concat!("let min = ", stringify!($ty), "::MIN.as_usize::<LittleEndian>();")]
+        #[doc = concat!("let max = ", stringify!($ty), "::MAX.as_usize::<endian::Big>();")]
+        #[doc = concat!("let min = ", stringify!($ty), "::MIN.as_usize::<endian::Little>();")]
         /// ```
         impl Size for $ty {
             const ZERO: Self = 0;

--- a/crates/musli-zerocopy/src/swiss/map.rs
+++ b/crates/musli-zerocopy/src/swiss/map.rs
@@ -18,13 +18,13 @@ use core::hash::{Hash, Hasher};
 use core::mem::size_of;
 
 use crate::buf::{Bindable, Buf, Visit};
-use crate::endian::{ByteOrder, NativeEndian};
+use crate::endian::{ByteOrder, Native};
 use crate::error::{Error, ErrorKind};
 use crate::pointer::{DefaultSize, Ref, Size};
 use crate::sip::SipHasher13;
 use crate::swiss::raw::{h2, probe_seq, Group};
 use crate::swiss::Entry;
-use crate::{Order, ZeroCopy};
+use crate::{Endian, ZeroCopy};
 
 /// A map bound to a [`Buf`] through [`Buf::bind`] for convenience.
 ///
@@ -233,12 +233,12 @@ where
 #[derive(Debug, ZeroCopy)]
 #[repr(C)]
 #[zero_copy(crate)]
-pub struct MapRef<K, V, E: ByteOrder = NativeEndian, O: Size = DefaultSize>
+pub struct MapRef<K, V, E: ByteOrder = Native, O: Size = DefaultSize>
 where
     K: ZeroCopy,
     V: ZeroCopy,
 {
-    key: Order<u64, E>,
+    key: Endian<u64, E>,
     table: RawTableRef<Entry<K, V>, E, O>,
 }
 
@@ -250,7 +250,7 @@ where
     #[cfg(feature = "alloc")]
     pub(crate) fn new(key: u64, table: RawTableRef<Entry<K, V>, E, O>) -> Self {
         Self {
-            key: Order::new(key),
+            key: Endian::new(key),
             table,
         }
     }
@@ -460,14 +460,14 @@ impl<'a, T> RawTable<'a, T> {
 #[derive(Debug, ZeroCopy)]
 #[repr(C)]
 #[zero_copy(crate)]
-pub(crate) struct RawTableRef<T, E: ByteOrder = NativeEndian, O: Size = DefaultSize>
+pub(crate) struct RawTableRef<T, E: ByteOrder = Native, O: Size = DefaultSize>
 where
     T: ZeroCopy,
 {
     ctrl: Ref<[u8], E, O>,
     entries: Ref<[T], E, O>,
-    bucket_mask: Order<usize, E>,
-    len: Order<usize, E>,
+    bucket_mask: Endian<usize, E>,
+    len: Endian<usize, E>,
 }
 
 impl<T, E: ByteOrder, O: Size> RawTableRef<T, E, O>
@@ -485,8 +485,8 @@ where
         Self {
             ctrl,
             entries,
-            bucket_mask: Order::new(bucket_mask),
-            len: Order::new(len),
+            bucket_mask: Endian::new(bucket_mask),
+            len: Endian::new(len),
         }
     }
 

--- a/crates/musli-zerocopy/src/swiss/set.rs
+++ b/crates/musli-zerocopy/src/swiss/set.rs
@@ -16,7 +16,7 @@ use core::borrow::Borrow;
 use core::hash::{Hash, Hasher};
 
 use crate::buf::{Bindable, Buf, Visit};
-use crate::endian::{ByteOrder, NativeEndian};
+use crate::endian::{ByteOrder, Native};
 use crate::error::Error;
 use crate::pointer::{DefaultSize, Size};
 use crate::sip::SipHasher13;
@@ -141,7 +141,7 @@ where
 #[derive(Debug, ZeroCopy)]
 #[repr(C)]
 #[zero_copy(crate)]
-pub struct SetRef<T, E: ByteOrder = NativeEndian, O: Size = DefaultSize>
+pub struct SetRef<T, E: ByteOrder = Native, O: Size = DefaultSize>
 where
     T: ZeroCopy,
 {

--- a/crates/musli-zerocopy/src/traits.rs
+++ b/crates/musli-zerocopy/src/traits.rs
@@ -582,13 +582,13 @@ pub unsafe trait ZeroCopy: Sized {
     /// composite field that is apart of that type.
     ///
     /// ```
-    /// use musli_zerocopy::{BigEndian, LittleEndian, Ref, ZeroCopy};
+    /// use musli_zerocopy::{endian, Ref, ZeroCopy};
     ///
     /// #[derive(ZeroCopy)]
     /// #[repr(C)]
     /// struct Struct {
     ///     number: u32,
-    ///     reference: Ref<u32, LittleEndian, usize>,
+    ///     reference: Ref<u32, endian::Little, usize>,
     /// }
     ///
     /// let st = Struct {
@@ -599,7 +599,7 @@ pub unsafe trait ZeroCopy: Sized {
     /// assert_eq!(st.number, 0x10203040u32.to_le());
     /// assert_eq!(st.reference.offset(), 0x50607080usize);
     ///
-    /// let st2 = st.swap_bytes::<BigEndian>();
+    /// let st2 = st.swap_bytes::<endian::Big>();
     /// assert_eq!(st2.number, 0x10203040u32.to_be());
     /// assert_eq!(st2.reference.offset(), 0x50607080usize);
     /// ```
@@ -617,6 +617,12 @@ pub unsafe trait ZeroCopy: Sized {
     ///
     /// [`CAN_SWAP_BYTES`]: Self::CAN_SWAP_BYTES
     fn swap_bytes<E: ByteOrder>(self) -> Self;
+
+    /// Transpose a type from one byte order `F` to another `T`.
+    #[inline]
+    fn transpose_bytes<F: ByteOrder, T: ByteOrder>(self) -> Self {
+        self.swap_bytes::<F>().swap_bytes::<T>()
+    }
 }
 
 unsafe impl<P: ?Sized, O> UnsizedZeroCopy<P, O> for str


### PR DESCRIPTION
Rename endian-enforcing wrapper from `Order` to `Endian`.