### PR TITLE
Introduce packed slices and allow for configuring trie representation

### DIFF
--- a/crates/musli-zerocopy/src/pointer/ref.rs
+++ b/crates/musli-zerocopy/src/pointer/ref.rs
@@ -309,6 +309,41 @@ where
         Ref::new(offset)
     }
 
+    /// Split the slice reference at the given position `at`.
+    ///
+    /// # Panics
+    ///
+    /// This panics if the given range is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use musli_zerocopy::OwnedBuf;
+    ///
+    /// let mut buf = OwnedBuf::new();
+    /// let slice = buf.store_slice(&[1, 2, 3, 4]);
+    ///
+    /// buf.align_in_place();
+    ///
+    /// let (a, b) = slice.split_at(3);
+    /// let (c, d) = slice.split_at(4);
+    ///
+    /// assert_eq!(buf.load(a)?, &[1, 2, 3]);
+    /// assert_eq!(buf.load(b)?, &[4]);
+    /// assert_eq!(buf.load(c)?, &[1, 2, 3, 4]);
+    /// assert_eq!(buf.load(d)?, &[]);
+    /// # Ok::<_, musli_zerocopy::Error>(())
+    /// ```
+    #[inline]
+    pub fn split_at(&self, at: usize) -> (Self, Self) {
+        let offset = self.offset();
+        let len = self.len();
+        assert!(at <= len, "Split point {at} is out of bounds 0..={len}");
+        let a = Self::with_metadata(offset, at);
+        let b = Self::with_metadata(offset + at * size_of::<P>(), len - at);
+        (a, b)
+    }
+
     /// Perform an fetch like `get` which panics with diagnostics in case the
     /// index is out-of-bounds.
     #[inline]

--- a/crates/musli-zerocopy/src/pointer/ref.rs
+++ b/crates/musli-zerocopy/src/pointer/ref.rs
@@ -227,7 +227,7 @@ where
     /// assert_eq!(slice.len(), 2);
     /// ```
     #[inline]
-    pub fn len(&self) -> usize {
+    pub fn len(self) -> usize {
         self.metadata.as_usize::<E>()
     }
 
@@ -245,7 +245,7 @@ where
     /// assert!(!slice.is_empty());
     /// ```
     #[inline]
-    pub fn is_empty(&self) -> bool {
+    pub fn is_empty(self) -> bool {
         self.metadata.is_zero()
     }
 
@@ -269,7 +269,7 @@ where
     /// # Ok::<_, musli_zerocopy::Error>(())
     /// ```
     #[inline]
-    pub fn get(&self, index: usize) -> Option<Ref<P, E, O>> {
+    pub fn get(self, index: usize) -> Option<Ref<P, E, O>> {
         if index >= self.len() {
             return None;
         }
@@ -304,7 +304,7 @@ where
     /// assert!(buf.load(oob).is_err());
     /// # Ok::<_, musli_zerocopy::Error>(())
     /// ```
-    pub fn get_unchecked(&self, index: usize) -> Ref<P, E, O> {
+    pub fn get_unchecked(self, index: usize) -> Ref<P, E, O> {
         let offset = self.offset.as_usize::<E>() + size_of::<P>() * index;
         Ref::new(offset)
     }
@@ -335,7 +335,7 @@ where
     /// # Ok::<_, musli_zerocopy::Error>(())
     /// ```
     #[inline]
-    pub fn split_at(&self, at: usize) -> (Self, Self) {
+    pub fn split_at(self, at: usize) -> (Self, Self) {
         let offset = self.offset();
         let len = self.len();
         assert!(at <= len, "Split point {at} is out of bounds 0..={len}");
@@ -347,7 +347,7 @@ where
     /// Perform an fetch like `get` which panics with diagnostics in case the
     /// index is out-of-bounds.
     #[inline]
-    pub(crate) fn at(&self, index: usize) -> Ref<P, E, O> {
+    pub(crate) fn at(self, index: usize) -> Ref<P, E, O> {
         let Some(r) = self.get(index) else {
             panic!("Index {index} out of bounds 0-{}", self.len());
         };
@@ -383,7 +383,7 @@ where
     /// # Ok::<_, musli_zerocopy::Error>(())
     /// ```
     #[inline]
-    pub fn iter(&self) -> Iter<'_, P, E, O> {
+    pub fn iter(self) -> Iter<P, E, O> {
         let start = self.offset.as_usize::<E>();
         let end = start + self.metadata.as_usize::<E>() * size_of::<P>();
 
@@ -407,7 +407,7 @@ impl<O: Size, E: ByteOrder> Ref<str, E, O> {
     /// assert_eq!(slice.len(), 2);
     /// ```
     #[inline]
-    pub fn len(&self) -> usize {
+    pub fn len(self) -> usize {
         self.metadata.as_usize::<E>()
     }
 
@@ -425,7 +425,7 @@ impl<O: Size, E: ByteOrder> Ref<str, E, O> {
     /// assert!(!slice.is_empty());
     /// ```
     #[inline]
-    pub fn is_empty(&self) -> bool {
+    pub fn is_empty(self) -> bool {
         self.metadata.is_zero()
     }
 }
@@ -433,13 +433,13 @@ impl<O: Size, E: ByteOrder> Ref<str, E, O> {
 /// An iterator over a `Ref<[P]>` which produces `Ref<P>` values.
 ///
 /// See [Ref::<[P]>::iter].
-pub struct Iter<'a, P, E, O> {
+pub struct Iter<P, E, O> {
     start: usize,
     end: usize,
-    _marker: PhantomData<(&'a (), P, E, O)>,
+    _marker: PhantomData<(P, E, O)>,
 }
 
-impl<'a, P: ZeroCopy, E: ByteOrder, O: Size> Iterator for Iter<'a, P, E, O> {
+impl<'a, P: ZeroCopy, E: ByteOrder, O: Size> Iterator for Iter<P, E, O> {
     type Item = Ref<P, E, O>;
 
     #[inline]
@@ -454,7 +454,7 @@ impl<'a, P: ZeroCopy, E: ByteOrder, O: Size> Iterator for Iter<'a, P, E, O> {
     }
 }
 
-impl<'a, P: ZeroCopy, E: ByteOrder, O: Size> DoubleEndedIterator for Iter<'a, P, E, O> {
+impl<'a, P: ZeroCopy, E: ByteOrder, O: Size> DoubleEndedIterator for Iter<P, E, O> {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.start == self.end {
@@ -481,7 +481,7 @@ where
     /// assert_eq!(slice.metadata(), 10);
     /// ```
     #[inline]
-    pub fn metadata(&self) -> P::Packed {
+    pub fn metadata(self) -> P::Packed {
         self.metadata
     }
 }
@@ -567,7 +567,7 @@ where
     /// assert_eq!(reference.offset(), 42);
     /// ```
     #[inline]
-    pub fn offset(&self) -> usize {
+    pub fn offset(self) -> usize {
         self.offset.as_usize::<E>()
     }
 

--- a/crates/musli-zerocopy/src/pointer/ref.rs
+++ b/crates/musli-zerocopy/src/pointer/ref.rs
@@ -439,7 +439,7 @@ pub struct Iter<P, E, O> {
     _marker: PhantomData<(P, E, O)>,
 }
 
-impl<'a, P: ZeroCopy, E: ByteOrder, O: Size> Iterator for Iter<P, E, O> {
+impl<P: ZeroCopy, E: ByteOrder, O: Size> Iterator for Iter<P, E, O> {
     type Item = Ref<P, E, O>;
 
     #[inline]
@@ -454,7 +454,7 @@ impl<'a, P: ZeroCopy, E: ByteOrder, O: Size> Iterator for Iter<P, E, O> {
     }
 }
 
-impl<'a, P: ZeroCopy, E: ByteOrder, O: Size> DoubleEndedIterator for Iter<P, E, O> {
+impl<P: ZeroCopy, E: ByteOrder, O: Size> DoubleEndedIterator for Iter<P, E, O> {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.start == self.end {

--- a/crates/musli-zerocopy/src/slice/binary_search.rs
+++ b/crates/musli-zerocopy/src/slice/binary_search.rs
@@ -4,6 +4,7 @@ use crate::buf::{Buf, Visit};
 use crate::endian::ByteOrder;
 use crate::error::Error;
 use crate::pointer::{Ref, Size};
+use crate::slice::Slice;
 use crate::traits::ZeroCopy;
 
 /// The result of a [`binary_search()`].
@@ -100,13 +101,10 @@ where
 /// assert!(match r { BinarySearch::Found(1..=4) => true, _ => false, });
 /// # Ok::<_, musli_zerocopy::Error>(())
 /// ```
-pub fn binary_search_by<T, E: ByteOrder, O: Size, F>(
-    buf: &Buf,
-    slice: Ref<[T], E, O>,
-    mut f: F,
-) -> Result<BinarySearch, Error>
+pub fn binary_search_by<S, T, F>(buf: &Buf, slice: S, mut f: F) -> Result<BinarySearch, Error>
 where
     T: ZeroCopy,
+    S: Slice<T>,
     F: FnMut(&T) -> Result<Ordering, Error>,
 {
     // INVARIANTS:

--- a/crates/musli-zerocopy/src/slice/binary_search.rs
+++ b/crates/musli-zerocopy/src/slice/binary_search.rs
@@ -104,7 +104,7 @@ where
 pub fn binary_search_by<S, T, F>(buf: &Buf, slice: S, mut f: F) -> Result<BinarySearch, Error>
 where
     T: ZeroCopy,
-    S: Slice<T>,
+    S: Slice<[T]>,
     F: FnMut(&T) -> Result<Ordering, Error>,
 {
     // INVARIANTS:

--- a/crates/musli-zerocopy/src/slice/mod.rs
+++ b/crates/musli-zerocopy/src/slice/mod.rs
@@ -5,3 +5,6 @@ mod binary_search;
 
 pub use self::slice::Slice;
 mod slice;
+
+pub use self::packed::Packed;
+mod packed;

--- a/crates/musli-zerocopy/src/slice/mod.rs
+++ b/crates/musli-zerocopy/src/slice/mod.rs
@@ -2,3 +2,6 @@
 
 pub use self::binary_search::{binary_search, binary_search_by, BinarySearch};
 mod binary_search;
+
+pub use self::slice::Slice;
+mod slice;

--- a/crates/musli-zerocopy/src/slice/packed.rs
+++ b/crates/musli-zerocopy/src/slice/packed.rs
@@ -1,0 +1,294 @@
+use core::marker::PhantomData;
+use core::mem::size_of;
+
+use crate::buf::{Buf, Load};
+use crate::endian::{ByteOrder, Native};
+use crate::error::Error;
+use crate::pointer::{Pointee, Ref, Size};
+use crate::slice::Slice;
+use crate::{DefaultSize, ZeroCopy};
+
+/// A packed slice representation that uses exactly `O` and `L` for offset and
+/// length respectively.
+///
+/// This is functionally equivalent to a [`Ref<[T]>`], but pointer and metadata
+/// `L` does not have to be the same size and its representation is packed.
+///
+/// ```
+/// use core::mem::{size_of, align_of};
+///
+/// use musli_zerocopy::slice::Packed;
+/// use musli_zerocopy::{DefaultSize, Ref};
+///
+/// assert_eq!(size_of::<Packed<[u32], u32, u8>>(), 5);
+/// assert_eq!(align_of::<Packed<[u32], u32, u8>>(), 1);
+///
+/// assert_eq!(size_of::<Ref<[u32]>>(), size_of::<DefaultSize>() * 2);
+/// assert_eq!(align_of::<Ref<[u32]>>(), align_of::<DefaultSize>());
+/// ```
+///
+/// Since this implements [`Slice<T>`] it can be used to build collection
+/// flavors like [`trie::Flavor`].
+///
+/// [`trie::Flavor`]: crate::trie::Flavor
+#[derive(ZeroCopy)]
+#[zero_copy(crate, bounds = {O: ZeroCopy, L: ZeroCopy})]
+#[repr(C, packed)]
+pub struct Packed<T: ?Sized, O: Size = DefaultSize, L: Size = DefaultSize, E: ByteOrder = Native> {
+    offset: O,
+    len: L,
+    #[zero_copy(ignore)]
+    _marker: PhantomData<(E, T)>,
+}
+
+impl<T, O: Size, L: Size, E: ByteOrder> Slice<[T]> for Packed<[T], O, L, E>
+where
+    T: ZeroCopy,
+    O: TryFrom<usize>,
+    L: TryFrom<usize>,
+{
+    type Item = Ref<T, E, usize>;
+
+    #[inline]
+    fn from_ref<A: ByteOrder, B: Size>(slice: Ref<[T], A, B>) -> Self
+    where
+        T: ZeroCopy,
+    {
+        Self::with_metadata(slice.offset(), slice.len())
+    }
+
+    #[inline]
+    fn with_metadata(offset: usize, len: usize) -> Self {
+        Packed::from_raw_parts(offset, len)
+    }
+
+    #[inline]
+    fn get(self, index: usize) -> Option<Self::Item> {
+        Packed::get(self, index)
+    }
+
+    #[inline]
+    fn split_at(self, at: usize) -> (Self, Self) {
+        Packed::split_at(self, at)
+    }
+
+    #[inline]
+    fn get_unchecked(self, index: usize) -> Self::Item {
+        Packed::get_unchecked(self, index)
+    }
+
+    #[inline]
+    fn len(self) -> usize {
+        Packed::len(self)
+    }
+
+    #[inline]
+    fn is_empty(self) -> bool {
+        Packed::is_empty(self)
+    }
+}
+
+impl<T, O: Size, L: Size, E: ByteOrder> Packed<[T], O, L, E>
+where
+    T: ZeroCopy,
+{
+    /// Construct a packed slice from a reference.
+    #[inline]
+    pub fn from_ref<A: ByteOrder, B: Size>(slice: Ref<[T], A, B>) -> Self
+    where
+        T: Pointee<B>,
+    {
+        Self::from_raw_parts(slice.offset(), slice.len())
+    }
+
+    /// Construct a packed slice from its raw parts.
+    #[inline]
+    pub fn from_raw_parts(offset: usize, len: usize) -> Self
+    where
+        O: TryFrom<usize>,
+        L: TryFrom<usize>,
+    {
+        let Some(offset) = O::try_from(offset).ok() else {
+            panic!("Offset {offset:?} not in legal range 0-{}", O::MAX);
+        };
+
+        let Some(len) = L::try_from(len).ok() else {
+            panic!("Length {len:?} not in legal range 0-{}", L::MAX);
+        };
+
+        Self {
+            offset: O::swap_bytes::<E>(offset),
+            len: L::swap_bytes::<E>(len),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Try to get a reference directly out of the slice without validation.
+    ///
+    /// This avoids having to validate every element in a slice in order to
+    /// address them.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use musli_zerocopy::OwnedBuf;
+    /// use musli_zerocopy::slice::Packed;
+    ///
+    /// let mut buf = OwnedBuf::new();
+    ///
+    /// let slice: Packed<[i32]> = Packed::from_ref(buf.store_slice(&[1, 2, 3, 4]));
+    ///
+    /// let two = slice.get(2).expect("Missing element 2");
+    /// assert_eq!(buf.load(two)?, &3);
+    ///
+    /// assert!(slice.get(4).is_none());
+    /// # Ok::<_, musli_zerocopy::Error>(())
+    /// ```
+    #[inline]
+    pub fn get(self, index: usize) -> Option<Ref<T, E, usize>> {
+        if index >= self.len() {
+            return None;
+        }
+
+        Some(self.get_unchecked(index))
+    }
+
+    /// Split the slice reference at the given position `at`.
+    ///
+    /// # Panics
+    ///
+    /// This panics if the given range is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use musli_zerocopy::OwnedBuf;
+    /// use musli_zerocopy::slice::Packed;
+    ///
+    /// let mut buf = OwnedBuf::new();
+    ///
+    /// let slice: Packed<[i32]> = Packed::from_ref(buf.store_slice(&[1, 2, 3, 4]));
+    ///
+    /// buf.align_in_place();
+    ///
+    /// let (a, b) = slice.split_at(3);
+    /// let (c, d) = slice.split_at(4);
+    ///
+    /// assert_eq!(buf.load(a)?, &[1, 2, 3]);
+    /// assert_eq!(buf.load(b)?, &[4]);
+    /// assert_eq!(buf.load(c)?, &[1, 2, 3, 4]);
+    /// assert_eq!(buf.load(d)?, &[]);
+    /// # Ok::<_, musli_zerocopy::Error>(())
+    /// ```
+    #[inline]
+    pub fn split_at(self, at: usize) -> (Self, Self) {
+        let offset = self.offset.as_usize::<E>();
+        let len = self.len.as_usize::<E>();
+        assert!(at <= len, "Split point {at} is out of bounds 0..={len}");
+        let a = Self::from_raw_parts(offset, at);
+        let b = Self::from_raw_parts(offset + at * size_of::<T>(), len - at);
+        (a, b)
+    }
+
+    /// Get an unchecked reference directly out of the slice without validation.
+    ///
+    /// This avoids having to validate every element in a slice in order to
+    /// address them.
+    ///
+    /// In contrast to [`get()`], this does not check that the index is within
+    /// the bounds of the current slice, all though it's not unsafe since it
+    /// cannot lead to anything inherently unsafe. Only garbled data.
+    ///
+    /// [`get()`]: Ref::get
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use musli_zerocopy::OwnedBuf;
+    /// use musli_zerocopy::slice::Packed;
+    ///
+    /// let mut buf = OwnedBuf::new();
+    ///
+    /// let slice: Packed<[i32]> = Packed::from_ref(buf.store_slice(&[1, 2, 3, 4]));
+    ///
+    /// let two = slice.get_unchecked(2);
+    /// assert_eq!(buf.load(two)?, &3);
+    ///
+    /// let oob = slice.get_unchecked(4);
+    /// assert!(buf.load(oob).is_err());
+    /// # Ok::<_, musli_zerocopy::Error>(())
+    /// ```
+    #[inline]
+    pub fn get_unchecked(self, index: usize) -> Ref<T, E, usize> {
+        let offset = self.offset.as_usize::<E>() + size_of::<T>() * index;
+        Ref::new(offset)
+    }
+
+    /// Return the number of elements in the packed slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use musli_zerocopy::slice::Packed;
+    ///
+    /// let slice = Packed::<[u32], u32, u8>::from_raw_parts(0, 2);
+    /// assert_eq!(slice.len(), 2);
+    /// ```
+    #[inline]
+    pub fn len(self) -> usize {
+        self.len.as_usize::<E>()
+    }
+
+    /// Test if the packed slice is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use musli_zerocopy::slice::Packed;
+    ///
+    /// let slice = Packed::<[u32], u32, u8>::from_raw_parts(0, 0);
+    /// assert!(slice.is_empty());
+    ///
+    /// let slice = Packed::<[u32], u32, u8>::from_raw_parts(0, 2);
+    /// assert!(!slice.is_empty());
+    /// ```
+    #[inline]
+    pub fn is_empty(self) -> bool {
+        self.len.is_zero()
+    }
+}
+
+impl<T, O, L, E: ByteOrder> Load for Packed<[T], O, L, E>
+where
+    T: ZeroCopy,
+    O: Size,
+    L: Size,
+{
+    type Target = [T];
+
+    #[inline]
+    fn load<'buf>(&self, buf: &'buf Buf) -> Result<&'buf Self::Target, Error> {
+        buf.load(Ref::<[T], Native, usize>::with_metadata(
+            self.offset.as_usize::<E>(),
+            self.len.as_usize::<E>(),
+        ))
+    }
+}
+
+impl<T, O, L, E: ByteOrder> Clone for Packed<[T], O, L, E>
+where
+    O: Size,
+    L: Size,
+{
+    #[inline]
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T, O, L, E: ByteOrder> Copy for Packed<[T], O, L, E>
+where
+    O: Size,
+    L: Size,
+{
+}

--- a/crates/musli-zerocopy/src/slice/packed.rs
+++ b/crates/musli-zerocopy/src/slice/packed.rs
@@ -47,7 +47,7 @@ where
     O: TryFrom<usize>,
     L: TryFrom<usize>,
 {
-    type Item = Ref<T, E, usize>;
+    type ItemRef = Ref<T, E, usize>;
 
     #[inline]
     fn from_ref<A: ByteOrder, B: Size>(slice: Ref<[T], A, B>) -> Self
@@ -63,7 +63,7 @@ where
     }
 
     #[inline]
-    fn get(self, index: usize) -> Option<Self::Item> {
+    fn get(self, index: usize) -> Option<Self::ItemRef> {
         Packed::get(self, index)
     }
 
@@ -73,7 +73,7 @@ where
     }
 
     #[inline]
-    fn get_unchecked(self, index: usize) -> Self::Item {
+    fn get_unchecked(self, index: usize) -> Self::ItemRef {
         Packed::get_unchecked(self, index)
     }
 

--- a/crates/musli-zerocopy/src/slice/packed.rs
+++ b/crates/musli-zerocopy/src/slice/packed.rs
@@ -41,12 +41,13 @@ pub struct Packed<T: ?Sized, O: Size = DefaultSize, L: Size = DefaultSize, E: By
     _marker: PhantomData<(E, T)>,
 }
 
-impl<T, O: Size, L: Size, E: ByteOrder> Slice<[T]> for Packed<[T], O, L, E>
+impl<T, O: Size, L: Size, E: ByteOrder> Slice for Packed<[T], O, L, E>
 where
     T: ZeroCopy,
     O: TryFrom<usize>,
     L: TryFrom<usize>,
 {
+    type Item = T;
     type ItemRef = Ref<T, E, usize>;
 
     #[inline]
@@ -199,7 +200,7 @@ where
     /// the bounds of the current slice, all though it's not unsafe since it
     /// cannot lead to anything inherently unsafe. Only garbled data.
     ///
-    /// [`get()`]: Ref::get
+    /// [`get()`]: Packed::get
     ///
     /// # Examples
     ///

--- a/crates/musli-zerocopy/src/slice/slice.rs
+++ b/crates/musli-zerocopy/src/slice/slice.rs
@@ -1,0 +1,83 @@
+use crate::buf::Load;
+use crate::endian::ByteOrder;
+use crate::pointer::{Ref, Size};
+use crate::traits::ZeroCopy;
+
+/// A trait implemented by slice-like types.
+pub trait Slice<T>: ZeroCopy + Load<Target = [T]>
+where
+    T: ZeroCopy,
+{
+    /// An item inside of the slice.
+    type Item: Load<Target = T>;
+
+    /// Construct a slice from a [`Ref<[T]>`].
+    fn from_ref<E: ByteOrder, O: Size>(slice: Ref<[T], E, O>) -> Self;
+
+    /// Construct a slice from its metadata.
+    fn with_metadata(offset: usize, len: usize) -> Self;
+
+    /// Access an item in the slice.
+    fn get(&self, index: usize) -> Option<Self::Item>;
+
+    /// Split the slice at the given position.
+    ///
+    /// # Panics
+    ///
+    /// This panics if the given range is out of bounds.
+    fn split_at(&self, at: usize) -> (Self, Self);
+
+    /// Access an item in the slice in an unchecked manner.
+    fn get_unchecked(&self, index: usize) -> Self::Item;
+
+    /// The length of a slice.
+    fn len(&self) -> usize;
+
+    /// Test if the slice is empty.
+    fn is_empty(&self) -> bool;
+}
+
+impl<T, A: ByteOrder, B: Size> Slice<T> for Ref<[T], A, B>
+where
+    T: ZeroCopy,
+{
+    type Item = Ref<T, A, B>;
+
+    #[inline]
+    fn from_ref<E: ByteOrder, O: Size>(slice: Ref<[T], E, O>) -> Self {
+        Self::with_metadata(slice.offset(), slice.len())
+    }
+
+    #[inline]
+    fn with_metadata(offset: usize, len: usize) -> Self
+    where
+        T: ZeroCopy,
+    {
+        Self::with_metadata(offset, len)
+    }
+
+    #[inline]
+    fn get(&self, index: usize) -> Option<Self::Item> {
+        (*self).get(index)
+    }
+
+    #[inline]
+    fn split_at(&self, at: usize) -> (Self, Self) {
+        (*self).split_at(at)
+    }
+
+    #[inline]
+    fn get_unchecked(&self, index: usize) -> Self::Item {
+        (*self).get_unchecked(index)
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        (*self).len()
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        (*self).is_empty()
+    }
+}

--- a/crates/musli-zerocopy/src/slice/slice.rs
+++ b/crates/musli-zerocopy/src/slice/slice.rs
@@ -4,7 +4,7 @@ use crate::pointer::{Ref, Size};
 use crate::traits::ZeroCopy;
 
 /// A trait implemented by slice-like types.
-pub trait Slice<T>: ZeroCopy + Load<Target = [T]>
+pub trait Slice<T>: Copy + ZeroCopy + Load<Target = [T]>
 where
     T: ZeroCopy,
 {
@@ -18,23 +18,23 @@ where
     fn with_metadata(offset: usize, len: usize) -> Self;
 
     /// Access an item in the slice.
-    fn get(&self, index: usize) -> Option<Self::Item>;
+    fn get(self, index: usize) -> Option<Self::Item>;
 
     /// Split the slice at the given position.
     ///
     /// # Panics
     ///
     /// This panics if the given range is out of bounds.
-    fn split_at(&self, at: usize) -> (Self, Self);
+    fn split_at(self, at: usize) -> (Self, Self);
 
     /// Access an item in the slice in an unchecked manner.
-    fn get_unchecked(&self, index: usize) -> Self::Item;
+    fn get_unchecked(self, index: usize) -> Self::Item;
 
     /// The length of a slice.
-    fn len(&self) -> usize;
+    fn len(self) -> usize;
 
     /// Test if the slice is empty.
-    fn is_empty(&self) -> bool;
+    fn is_empty(self) -> bool;
 }
 
 impl<T, A: ByteOrder, B: Size> Slice<T> for Ref<[T], A, B>
@@ -57,27 +57,27 @@ where
     }
 
     #[inline]
-    fn get(&self, index: usize) -> Option<Self::Item> {
-        (*self).get(index)
+    fn get(self, index: usize) -> Option<Self::Item> {
+        Ref::get(self, index)
     }
 
     #[inline]
-    fn split_at(&self, at: usize) -> (Self, Self) {
-        (*self).split_at(at)
+    fn split_at(self, at: usize) -> (Self, Self) {
+        Ref::split_at(self, at)
     }
 
     #[inline]
-    fn get_unchecked(&self, index: usize) -> Self::Item {
-        (*self).get_unchecked(index)
+    fn get_unchecked(self, index: usize) -> Self::Item {
+        Ref::get_unchecked(self, index)
     }
 
     #[inline]
-    fn len(&self) -> usize {
-        (*self).len()
+    fn len(self) -> usize {
+        Ref::<[T], _, _>::len(self)
     }
 
     #[inline]
-    fn is_empty(&self) -> bool {
-        (*self).is_empty()
+    fn is_empty(self) -> bool {
+        Ref::<[T], _, _>::is_empty(self)
     }
 }

--- a/crates/musli-zerocopy/src/slice/slice.rs
+++ b/crates/musli-zerocopy/src/slice/slice.rs
@@ -4,60 +4,214 @@ use crate::pointer::{Ref, Size};
 use crate::traits::ZeroCopy;
 
 mod sealed {
+    use crate::endian::ByteOrder;
+    use crate::pointer::{Ref, Size};
+    use crate::slice::Packed;
+    use crate::traits::ZeroCopy;
+
     pub trait Sealed {}
-    impl<T> Sealed for [T] {}
 
-    /// Helper trait to differentiate between the unsized slice `[T]` type and the
-    /// item it contains.
-    pub trait UnsizedSlice: Sealed {
-        /// The item in an unsized slice, or the `T` in `[T]`.
-        type Item;
-    }
+    impl<T, E: ByteOrder, O: Size> Sealed for Ref<[T], E, O> where T: ZeroCopy {}
 
-    impl<T> UnsizedSlice for [T] {
-        type Item = T;
-    }
+    impl<T, O: Size, L: Size, E: ByteOrder> Sealed for Packed<[T], O, L, E> {}
 }
 
 /// A trait implemented by slice-like types.
-pub trait Slice<T: ?Sized + self::sealed::UnsizedSlice>:
-    Copy + ZeroCopy + Load<Target = T>
-{
-    /// An item inside of the slice.
-    type ItemRef: Load<Target = T::Item>;
+pub trait Slice: self::sealed::Sealed + Copy + ZeroCopy + Load<Target = [Self::Item]> {
+    /// The item in an unsized slice, or the `T` in `[T]`.
+    type Item;
 
-    /// Construct a slice from a [`Ref<[T]>`].
-    fn from_ref<E: ByteOrder, O: Size>(slice: Ref<[T::Item], E, O>) -> Self
+    /// A returned reference to an item in a slice.
+    type ItemRef: Load<Target = Self::Item>;
+
+    /// Construct a slice from a [`Ref<[Self::Item]>`].
+    ///
+    /// # Panics
+    ///
+    /// This method panics if construction of the slice would overflow any of
+    /// its parameters.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use musli_zerocopy::{Ref, ZeroCopy};
+    /// use musli_zerocopy::slice::Slice;
+    ///
+    /// fn generic<S>(r: Ref<[S::Item]>) -> S where S: Slice, S::Item: ZeroCopy {
+    ///     S::from_ref(r)
+    /// }
+    /// ```
+    fn from_ref<E: ByteOrder, O: Size>(slice: Ref<[Self::Item], E, O>) -> Self
     where
-        T::Item: ZeroCopy;
+        Self::Item: ZeroCopy;
 
-    /// Construct a slice from its metadata.
+    /// Construct a slice from its `offset` and `len`.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if construction of the slice would overflow any of
+    /// its parameters.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use musli_zerocopy::Ref;
+    /// use musli_zerocopy::slice::Slice;
+    ///
+    /// fn generic<S>() -> S where S: Slice {
+    ///     S::with_metadata(0, 10)
+    /// }
+    /// ```
     fn with_metadata(offset: usize, len: usize) -> Self;
 
-    /// Access an item in the slice.
+    /// Try to get a reference directly out of the slice without validation.
+    ///
+    /// This avoids having to validate every element in a slice in order to
+    /// address them.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use musli_zerocopy::{Buf, Error, OwnedBuf};
+    /// use musli_zerocopy::slice::Slice;
+    ///
+    /// fn generic<S>(buf: &Buf, slice: S) -> Result<(), Error>
+    /// where
+    ///     S: Slice<Item = i32>
+    /// {
+    ///     let two = slice.get(2).expect("Missing element 2");
+    ///     assert_eq!(buf.load(two)?, &3);
+    ///
+    ///     assert!(slice.get(4).is_none());
+    ///     Ok(())
+    /// }
+    ///
+    /// let mut buf = OwnedBuf::new();
+    /// let slice = buf.store_slice(&[1, 2, 3, 4]);
+    ///
+    /// generic(&buf, slice)?;
+    /// # Ok::<_, musli_zerocopy::Error>(())
+    /// ```
     fn get(self, index: usize) -> Option<Self::ItemRef>;
 
-    /// Split the slice at the given position.
+    /// Split the slice at the given position `at`.
     ///
     /// # Panics
     ///
     /// This panics if the given range is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use musli_zerocopy::{Buf, Error, OwnedBuf};
+    /// use musli_zerocopy::slice::Slice;
+    ///
+    /// fn generic<S>(buf: &Buf, slice: S) -> Result<(), Error>
+    /// where
+    ///     S: Slice<Item = i32>
+    /// {
+    ///     let (a, b) = slice.split_at(3);
+    ///     let (c, d) = slice.split_at(4);
+    ///
+    ///     assert_eq!(buf.load(a)?, &[1, 2, 3]);
+    ///     assert_eq!(buf.load(b)?, &[4]);
+    ///     assert_eq!(buf.load(c)?, &[1, 2, 3, 4]);
+    ///     assert_eq!(buf.load(d)?, &[]);
+    ///     Ok(())
+    /// }
+    ///
+    /// let mut buf = OwnedBuf::new();
+    /// let slice = buf.store_slice(&[1, 2, 3, 4]);
+    ///
+    /// buf.align_in_place();
+    ///
+    /// generic(&buf, slice)?;
+    /// # Ok::<_, musli_zerocopy::Error>(())
+    /// ```
     fn split_at(self, at: usize) -> (Self, Self);
 
-    /// Access an item in the slice in an unchecked manner.
+    /// Get an unchecked reference directly out of the slice without validation.
+    ///
+    /// This avoids having to validate every element in a slice in order to
+    /// address them.
+    ///
+    /// In contrast to [`get()`], this does not check that the index is within
+    /// the bounds of the current slice, all though it's not unsafe since it
+    /// cannot lead to anything inherently unsafe. Only garbled data.
+    ///
+    /// [`get()`]: Slice::get
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use musli_zerocopy::{Buf, Error, Ref, OwnedBuf};
+    /// use musli_zerocopy::slice::Slice;
+    ///
+    /// // A method generic over a specific slice implementation.
+    /// fn generic<S>(buf: &Buf, slice: S) -> Result<(), Error>
+    /// where
+    ///     S: Slice<Item = i32>
+    /// {
+    ///     let two = slice.get_unchecked(2);
+    ///     assert_eq!(buf.load(two)?, &3);
+    ///
+    ///     let oob = slice.get_unchecked(4);
+    ///     assert!(buf.load(oob).is_err());
+    ///     Ok(())
+    /// }
+    ///
+    /// let mut buf = OwnedBuf::new();
+    ///
+    /// let slice = buf.store_slice(&[1, 2, 3, 4]);
+    /// generic(&buf, slice)?;
+    /// # Ok::<_, musli_zerocopy::Error>(())
+    /// ```
     fn get_unchecked(self, index: usize) -> Self::ItemRef;
 
-    /// The length of a slice.
+    /// Return the number of elements in the slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use musli_zerocopy::Ref;
+    /// use musli_zerocopy::slice::Slice;
+    ///
+    /// // A method generic over a specific slice implementation.
+    /// fn generic<S>(slice: S) where S: Slice {
+    ///     assert_eq!(slice.len(), 2);
+    /// }
+    ///
+    /// let slice = Ref::<[i32]>::with_metadata(0, 2);
+    /// generic(slice);
+    /// ```
     fn len(self) -> usize;
 
     /// Test if the slice is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use musli_zerocopy::Ref;
+    /// use musli_zerocopy::slice::Slice;
+    ///
+    /// // A method generic over a specific slice implementation.
+    /// fn generic<S>(a: S, b: S) where S: Slice {
+    ///     assert!(a.is_empty());
+    ///     assert!(!b.is_empty());
+    /// }
+    ///
+    /// let a = Ref::<[u32]>::with_metadata(0, 0);
+    /// let b = Ref::<[u32]>::with_metadata(0, 2);
+    /// generic(a, b);
+    /// ```
     fn is_empty(self) -> bool;
 }
 
-impl<T, A: ByteOrder, B: Size> Slice<[T]> for Ref<[T], A, B>
+impl<T, A: ByteOrder, B: Size> Slice for Ref<[T], A, B>
 where
     T: ZeroCopy,
 {
+    type Item = T;
     type ItemRef = Ref<T, A, B>;
 
     #[inline]

--- a/crates/musli-zerocopy/src/slice/slice.rs
+++ b/crates/musli-zerocopy/src/slice/slice.rs
@@ -24,7 +24,7 @@ pub trait Slice<T: ?Sized + self::sealed::UnsizedSlice>:
     Copy + ZeroCopy + Load<Target = T>
 {
     /// An item inside of the slice.
-    type Item: Load<Target = T::Item>;
+    type ItemRef: Load<Target = T::Item>;
 
     /// Construct a slice from a [`Ref<[T]>`].
     fn from_ref<E: ByteOrder, O: Size>(slice: Ref<[T::Item], E, O>) -> Self
@@ -35,7 +35,7 @@ pub trait Slice<T: ?Sized + self::sealed::UnsizedSlice>:
     fn with_metadata(offset: usize, len: usize) -> Self;
 
     /// Access an item in the slice.
-    fn get(self, index: usize) -> Option<Self::Item>;
+    fn get(self, index: usize) -> Option<Self::ItemRef>;
 
     /// Split the slice at the given position.
     ///
@@ -45,7 +45,7 @@ pub trait Slice<T: ?Sized + self::sealed::UnsizedSlice>:
     fn split_at(self, at: usize) -> (Self, Self);
 
     /// Access an item in the slice in an unchecked manner.
-    fn get_unchecked(self, index: usize) -> Self::Item;
+    fn get_unchecked(self, index: usize) -> Self::ItemRef;
 
     /// The length of a slice.
     fn len(self) -> usize;
@@ -58,7 +58,7 @@ impl<T, A: ByteOrder, B: Size> Slice<[T]> for Ref<[T], A, B>
 where
     T: ZeroCopy,
 {
-    type Item = Ref<T, A, B>;
+    type ItemRef = Ref<T, A, B>;
 
     #[inline]
     fn from_ref<E: ByteOrder, O: Size>(slice: Ref<[T], E, O>) -> Self
@@ -77,7 +77,7 @@ where
     }
 
     #[inline]
-    fn get(self, index: usize) -> Option<Self::Item> {
+    fn get(self, index: usize) -> Option<Self::ItemRef> {
         Ref::get(self, index)
     }
 
@@ -87,7 +87,7 @@ where
     }
 
     #[inline]
-    fn get_unchecked(self, index: usize) -> Self::Item {
+    fn get_unchecked(self, index: usize) -> Self::ItemRef {
         Ref::get_unchecked(self, index)
     }
 

--- a/crates/musli-zerocopy/src/trie/mod.rs
+++ b/crates/musli-zerocopy/src/trie/mod.rs
@@ -70,15 +70,15 @@ use crate::{Buf, ByteOrder, DefaultSize, Error, OwnedBuf, Ref, Size, ZeroCopy};
 /// ```
 pub trait Flavor {
     /// The type representing a string in the trie.
-    type String: Copy + Slice<[u8]>;
+    type String: Slice<[u8]>;
 
     /// The type representing a collection of values in the trie.
-    type Values<T>: Copy + Slice<[T]>
+    type Values<T>: Slice<[T]>
     where
         T: ZeroCopy;
 
     /// The type representing a collection of children in the trie.
-    type Children<T>: Copy + Slice<[T]>
+    type Children<T>: Slice<[T]>
     where
         T: ZeroCopy;
 }

--- a/crates/musli-zerocopy/src/trie/mod.rs
+++ b/crates/musli-zerocopy/src/trie/mod.rs
@@ -70,15 +70,15 @@ use crate::{Buf, ByteOrder, DefaultSize, Error, OwnedBuf, Ref, Size, ZeroCopy};
 /// ```
 pub trait Flavor {
     /// The type representing a string in the trie.
-    type String: Slice<[u8]>;
+    type String: Slice<Item = u8>;
 
     /// The type representing a collection of values in the trie.
-    type Values<T>: Slice<[T]>
+    type Values<T>: Slice<Item = T>
     where
         T: ZeroCopy;
 
     /// The type representing a collection of children in the trie.
-    type Children<T>: Slice<[T]>
+    type Children<T>: Slice<Item = T>
     where
         T: ZeroCopy;
 }

--- a/crates/musli-zerocopy/src/trie/mod.rs
+++ b/crates/musli-zerocopy/src/trie/mod.rs
@@ -553,7 +553,7 @@ where
 {
     buf: &'buf Buf,
     state: PrefixState<'a, 'buf, T, F>,
-    stack: Vec<(LinksRef<T, F>, usize)>,
+    stack: Vec<(&'buf LinksRef<T, F>, usize)>,
 }
 
 impl<'a, 'buf, T, F: Flavor> Prefix<'a, 'buf, T, F>
@@ -571,7 +571,7 @@ where
 
                         match search {
                             BinarySearch::Found(n) => {
-                                break self.buf.load(this.children.get_unchecked(n))?.links;
+                                break &self.buf.load(this.children.get_unchecked(n))?.links;
                             }
                             BinarySearch::Missing(n) => {
                                 // For missing nodes, we need to find any
@@ -594,7 +594,7 @@ where
                                     }
 
                                     if prefix == string.len() {
-                                        break 'links child.links;
+                                        break 'links &child.links;
                                     }
 
                                     string = &string[prefix..];
@@ -635,7 +635,7 @@ where
                     let node = self.buf.load(node)?;
                     self.state = PrefixState::Iter(self.buf.load(node.links.values)?.iter());
                     self.stack.push((links, index + 1));
-                    self.stack.push((node.links, 0));
+                    self.stack.push((&node.links, 0));
                     continue 'outer;
                 },
             }
@@ -773,7 +773,7 @@ where
 
 #[derive(ZeroCopy)]
 #[zero_copy(crate)]
-#[repr(C, packed)]
+#[repr(C)]
 struct LinksRef<T, F: Flavor>
 where
     T: ZeroCopy,
@@ -804,7 +804,7 @@ where
 
 #[derive(ZeroCopy)]
 #[zero_copy(crate)]
-#[repr(C, packed)]
+#[repr(C)]
 struct NodeRef<T, F: Flavor>
 where
     T: ZeroCopy,


### PR DESCRIPTION
In particular, this allows a trie to be stored more compactly by defining a `Flavor`:

```rust
use musli_zerocopy::trie;
use musli_zerocopy::slice;
use musli_zerocopy::ZeroCopy;

impl trie::Flavor for TrieFlavor {
    type String = slice::Packed<[u8], u32, u8>;
    type Values<T> = slice::Packed<[T], u32, u16> where T: ZeroCopy;
    type Children<T> = slice::Packed<[T], u32, u16> where T: ZeroCopy;
}
```

See the documentation for `trie::Flavor` for more information.