### PR TITLE
Unsized zerocopy cleanup

### DIFF
--- a/crates/musli-zerocopy/src/buf/buf.rs
+++ b/crates/musli-zerocopy/src/buf/buf.rs
@@ -826,13 +826,13 @@ impl Buf {
     /// # Ok::<_, musli_zerocopy::Error>(())
     /// ```
     #[inline]
-    pub fn swap<P, E: ByteOrder, O: Size>(
+    pub fn swap<T, E: ByteOrder, O: Size>(
         &mut self,
-        a: Ref<P, E, O>,
-        b: Ref<P, E, O>,
+        a: Ref<T, E, O>,
+        b: Ref<T, E, O>,
     ) -> Result<(), Error>
     where
-        P: ZeroCopy,
+        T: ZeroCopy,
     {
         let a = a.offset();
         let b = b.offset();
@@ -842,7 +842,7 @@ impl Buf {
         }
 
         let start = a.max(b);
-        let end = start + size_of::<P>();
+        let end = start + size_of::<T>();
 
         if end > self.data.len() {
             return Err(Error::new(ErrorKind::OutOfRangeBounds {
@@ -855,16 +855,16 @@ impl Buf {
         // ensuring to utilize the appropriate copy primitive depending on
         // whether two values may or may not overlap.
         unsafe {
-            let mut tmp = MaybeUninit::<P>::uninit();
+            let mut tmp = MaybeUninit::<T>::uninit();
             let base = self.data.as_mut_ptr();
 
             let tmp = tmp.as_mut_ptr().cast::<u8>();
             let a = base.add(a);
             let b = base.add(b);
 
-            tmp.copy_from_nonoverlapping(a, size_of::<P>());
-            a.copy_from(b, size_of::<P>());
-            b.copy_from_nonoverlapping(tmp, size_of::<P>());
+            tmp.copy_from_nonoverlapping(a, size_of::<T>());
+            a.copy_from(b, size_of::<T>());
+            b.copy_from_nonoverlapping(tmp, size_of::<T>());
         }
 
         Ok(())

--- a/crates/musli-zerocopy/src/buf/buf.rs
+++ b/crates/musli-zerocopy/src/buf/buf.rs
@@ -708,7 +708,7 @@ impl Buf {
         unsize: Ref<P, E, O>,
     ) -> Result<&P, Error>
     where
-        P: Pointee<O, Packed = O> + UnsizedZeroCopy<P, O>,
+        P: Pointee + UnsizedZeroCopy<P, O>,
     {
         let start = unsize.offset();
         let metadata = unsize.metadata();
@@ -729,7 +729,7 @@ impl Buf {
         unsize: Ref<P, E, O>,
     ) -> Result<&mut P, Error>
     where
-        P: Pointee<O, Packed = O> + UnsizedZeroCopy<P, O>,
+        P: Pointee + UnsizedZeroCopy<P, O>,
     {
         let start = unsize.offset();
         let metadata = unsize.metadata();

--- a/crates/musli-zerocopy/src/buf/load.rs
+++ b/crates/musli-zerocopy/src/buf/load.rs
@@ -33,15 +33,15 @@ pub trait LoadMut: Load {
     fn load_mut<'buf>(&self, buf: &'buf mut Buf) -> Result<&'buf mut Self::Target, Error>;
 }
 
-impl<P, E: ByteOrder, O: Size> Load for Ref<P, E, O>
+impl<T, E: ByteOrder, O: Size> Load for Ref<T, E, O>
 where
-    P: ZeroCopy,
+    T: ZeroCopy,
 {
-    type Target = P;
+    type Target = T;
 
     #[inline]
     fn load<'buf>(&self, buf: &'buf Buf) -> Result<&'buf Self::Target, Error> {
-        buf.load_sized::<P>(self.offset())
+        buf.load_sized::<T>(self.offset())
     }
 }
 
@@ -66,13 +66,13 @@ impl<E: ByteOrder, O: Size> Load for Ref<str, E, O> {
     }
 }
 
-impl<P, E: ByteOrder, O: Size> LoadMut for Ref<P, E, O>
+impl<T, E: ByteOrder, O: Size> LoadMut for Ref<T, E, O>
 where
-    P: ZeroCopy,
+    T: ZeroCopy,
 {
     #[inline]
     fn load_mut<'buf>(&self, buf: &'buf mut Buf) -> Result<&'buf mut Self::Target, Error> {
-        buf.load_sized_mut::<P>(self.offset())
+        buf.load_sized_mut::<T>(self.offset())
     }
 }
 

--- a/crates/musli-zerocopy/src/buf/load.rs
+++ b/crates/musli-zerocopy/src/buf/load.rs
@@ -1,7 +1,7 @@
 use crate::buf::Buf;
 use crate::endian::ByteOrder;
 use crate::error::Error;
-use crate::pointer::{Pointee, Ref, Size};
+use crate::pointer::{Ref, Size};
 use crate::traits::ZeroCopy;
 
 /// Trait used for loading any kind of reference through [`Buf::load`].
@@ -47,7 +47,6 @@ where
 
 impl<T, E: ByteOrder, O: Size> Load for Ref<[T], E, O>
 where
-    [T]: Pointee<O, Packed = O, Metadata = usize>,
     T: ZeroCopy,
 {
     type Target = [T];
@@ -79,7 +78,6 @@ where
 
 impl<T, E: ByteOrder, O: Size> LoadMut for Ref<[T], E, O>
 where
-    [T]: Pointee<O, Packed = O, Metadata = usize>,
     T: ZeroCopy,
 {
     #[inline]

--- a/crates/musli-zerocopy/src/buf/owned_buf.rs
+++ b/crates/musli-zerocopy/src/buf/owned_buf.rs
@@ -612,11 +612,11 @@ impl<E: ByteOrder, O: Size> OwnedBuf<E, O> {
     /// # Ok::<_, musli_zerocopy::Error>(())
     /// ```
     #[inline]
-    pub fn store<P>(&mut self, value: &P) -> Ref<P, E, O>
+    pub fn store<T>(&mut self, value: &T) -> Ref<T, E, O>
     where
-        P: ZeroCopy,
+        T: ZeroCopy,
     {
-        self.next_offset_with_and_reserve(align_of::<P>(), size_of::<P>());
+        self.next_offset_with_and_reserve(align_of::<T>(), size_of::<T>());
 
         // SAFETY: We're ensuring to both align the internal buffer and store
         // the value.
@@ -675,14 +675,14 @@ impl<E: ByteOrder, O: Size> OwnedBuf<E, O> {
     /// # Ok::<_, musli_zerocopy::Error>(())
     /// ```
     #[inline]
-    pub unsafe fn store_unchecked<P>(&mut self, value: &P) -> Ref<P, E, O>
+    pub unsafe fn store_unchecked<T>(&mut self, value: &T) -> Ref<T, E, O>
     where
-        P: ZeroCopy,
+        T: ZeroCopy,
     {
         let offset = self.len;
         let ptr = NonNull::new_unchecked(self.data.as_ptr().add(offset));
         buf::store_unaligned(ptr, value);
-        self.len += size_of::<P>();
+        self.len += size_of::<T>();
         Ref::new(offset)
     }
 
@@ -1281,21 +1281,21 @@ impl<E: ByteOrder, O: Size> StoreBuf for OwnedBuf<E, O> {
     }
 
     #[inline]
-    fn store<P>(&mut self, value: &P) -> Ref<P, Self::ByteOrder, Self::Size>
+    fn store<T>(&mut self, value: &T) -> Ref<T, Self::ByteOrder, Self::Size>
     where
-        P: ZeroCopy,
+        T: ZeroCopy,
     {
         OwnedBuf::store(self, value)
     }
 
     #[inline]
-    fn swap<P>(
+    fn swap<T>(
         &mut self,
-        a: Ref<P, Self::ByteOrder, Self::Size>,
-        b: Ref<P, Self::ByteOrder, Self::Size>,
+        a: Ref<T, Self::ByteOrder, Self::Size>,
+        b: Ref<T, Self::ByteOrder, Self::Size>,
     ) -> Result<(), Error>
     where
-        P: ZeroCopy,
+        T: ZeroCopy,
     {
         Buf::swap(self, a, b)
     }

--- a/crates/musli-zerocopy/src/buf/owned_buf.rs
+++ b/crates/musli-zerocopy/src/buf/owned_buf.rs
@@ -705,7 +705,7 @@ impl<E: ByteOrder, O: Size> OwnedBuf<E, O> {
     #[inline]
     pub fn store_unsized<P: ?Sized>(&mut self, value: &P) -> Ref<P, E, O>
     where
-        P: Pointee<O, Packed = O, Metadata = usize>,
+        P: Pointee<Metadata = usize>,
         P: UnsizedZeroCopy<P, O>,
     {
         unsafe {
@@ -756,7 +756,6 @@ impl<E: ByteOrder, O: Size> OwnedBuf<E, O> {
     #[inline(always)]
     pub fn store_slice<T>(&mut self, values: &[T]) -> Ref<[T], E, O>
     where
-        [T]: Pointee<O, Packed = O, Metadata = usize>,
         T: ZeroCopy,
     {
         self.store_unsized(values)
@@ -1277,7 +1276,7 @@ impl<E: ByteOrder, O: Size> StoreBuf for OwnedBuf<E, O> {
     #[inline]
     fn store_unsized<P: ?Sized>(&mut self, value: &P) -> Ref<P, Self::ByteOrder, Self::Size>
     where
-        P: Pointee<Self::Size, Packed = Self::Size, Metadata = usize>,
+        P: Pointee<Metadata = usize>,
         P: UnsizedZeroCopy<P, Self::Size>,
     {
         OwnedBuf::store_unsized(self, value)

--- a/crates/musli-zerocopy/src/buf/slice_mut.rs
+++ b/crates/musli-zerocopy/src/buf/slice_mut.rs
@@ -515,11 +515,11 @@ impl<'a, E: ByteOrder, O: Size> SliceMut<'a, E, O> {
     /// # Ok::<_, musli_zerocopy::Error>(())
     /// ```
     #[inline]
-    pub fn store<P>(&mut self, value: &P) -> Ref<P, E, O>
+    pub fn store<T>(&mut self, value: &T) -> Ref<T, E, O>
     where
-        P: ZeroCopy,
+        T: ZeroCopy,
     {
-        self.next_offset_with_and_reserve(align_of::<P>(), size_of::<P>());
+        self.next_offset_with_and_reserve(align_of::<T>(), size_of::<T>());
 
         // SAFETY: We're ensuring to both align the internal buffer and store
         // the value.
@@ -580,15 +580,15 @@ impl<'a, E: ByteOrder, O: Size> SliceMut<'a, E, O> {
     /// # Ok::<_, musli_zerocopy::Error>(())
     /// ```
     #[inline]
-    pub unsafe fn store_unchecked<P>(&mut self, value: &P) -> Ref<P, E, O>
+    pub unsafe fn store_unchecked<T>(&mut self, value: &T) -> Ref<T, E, O>
     where
-        P: ZeroCopy,
+        T: ZeroCopy,
     {
         let offset = self.len;
 
         let ptr = NonNull::new_unchecked(self.data.as_ptr().add(offset));
         buf::store_unaligned(ptr, value);
-        self.len += size_of::<P>();
+        self.len += size_of::<T>();
         Ref::new(offset)
     }
 
@@ -986,21 +986,21 @@ impl<'a, E: ByteOrder, O: Size> StoreBuf for SliceMut<'a, E, O> {
     }
 
     #[inline]
-    fn store<P>(&mut self, value: &P) -> Ref<P, Self::ByteOrder, Self::Size>
+    fn store<T>(&mut self, value: &T) -> Ref<T, Self::ByteOrder, Self::Size>
     where
-        P: ZeroCopy,
+        T: ZeroCopy,
     {
         SliceMut::store(self, value)
     }
 
     #[inline]
-    fn swap<P>(
+    fn swap<T>(
         &mut self,
-        a: Ref<P, Self::ByteOrder, Self::Size>,
-        b: Ref<P, Self::ByteOrder, Self::Size>,
+        a: Ref<T, Self::ByteOrder, Self::Size>,
+        b: Ref<T, Self::ByteOrder, Self::Size>,
     ) -> Result<(), Error>
     where
-        P: ZeroCopy,
+        T: ZeroCopy,
     {
         Buf::swap(self, a, b)
     }

--- a/crates/musli-zerocopy/src/buf/slice_mut.rs
+++ b/crates/musli-zerocopy/src/buf/slice_mut.rs
@@ -12,7 +12,7 @@ use crate::buf::{self, Buf, DefaultAlignment, Padder, StoreBuf};
 use crate::endian::{ByteOrder, Native};
 use crate::error::Error;
 use crate::mem::MaybeUninit;
-use crate::pointer::{DefaultSize, Pointee, Ref, Size};
+use crate::pointer::{DefaultSize, Ref, Size};
 use crate::traits::{UnsizedZeroCopy, ZeroCopy};
 
 /// A fixed buffer wrapping a `&mut [u8]` with a dynamic alignment.
@@ -639,19 +639,18 @@ impl<'a, E: ByteOrder, O: Size> SliceMut<'a, E, O> {
     /// # Ok::<_, musli_zerocopy::Error>(())
     /// ```
     #[inline]
-    pub fn store_unsized<P: ?Sized>(&mut self, value: &P) -> Ref<P, E, O>
+    pub fn store_unsized<T: ?Sized>(&mut self, value: &T) -> Ref<T, E, O>
     where
-        P: Pointee<Metadata = usize>,
-        P: UnsizedZeroCopy<P, O>,
+        T: UnsizedZeroCopy<Metadata = usize>,
     {
         unsafe {
             let size = size_of_val(value);
-            self.next_offset_with_and_reserve(P::ALIGN, size);
+            self.next_offset_with_and_reserve(T::ALIGN, size);
             let offset = self.len;
             let ptr = NonNull::new_unchecked(self.data.as_ptr().add(offset));
             ptr.as_ptr().copy_from_nonoverlapping(value.as_ptr(), size);
 
-            if P::PADDED {
+            if T::PADDED {
                 let mut padder = Padder::new(ptr);
                 value.pad(&mut padder);
                 padder.remaining_unsized(value);
@@ -979,10 +978,9 @@ impl<'a, E: ByteOrder, O: Size> StoreBuf for SliceMut<'a, E, O> {
     }
 
     #[inline]
-    fn store_unsized<P: ?Sized>(&mut self, value: &P) -> Ref<P, Self::ByteOrder, Self::Size>
+    fn store_unsized<T: ?Sized>(&mut self, value: &T) -> Ref<T, Self::ByteOrder, Self::Size>
     where
-        P: Pointee<Metadata = usize>,
-        P: UnsizedZeroCopy<P, Self::Size>,
+        T: UnsizedZeroCopy<Metadata = usize>,
     {
         SliceMut::store_unsized(self, value)
     }

--- a/crates/musli-zerocopy/src/buf/slice_mut.rs
+++ b/crates/musli-zerocopy/src/buf/slice_mut.rs
@@ -641,7 +641,7 @@ impl<'a, E: ByteOrder, O: Size> SliceMut<'a, E, O> {
     #[inline]
     pub fn store_unsized<P: ?Sized>(&mut self, value: &P) -> Ref<P, E, O>
     where
-        P: Pointee<O, Packed = O, Metadata = usize>,
+        P: Pointee<Metadata = usize>,
         P: UnsizedZeroCopy<P, O>,
     {
         unsafe {
@@ -695,7 +695,6 @@ impl<'a, E: ByteOrder, O: Size> SliceMut<'a, E, O> {
     #[inline(always)]
     pub fn store_slice<T>(&mut self, values: &[T]) -> Ref<[T], E, O>
     where
-        [T]: Pointee<O, Packed = O, Metadata = usize>,
         T: ZeroCopy,
     {
         self.store_unsized(values)
@@ -982,7 +981,7 @@ impl<'a, E: ByteOrder, O: Size> StoreBuf for SliceMut<'a, E, O> {
     #[inline]
     fn store_unsized<P: ?Sized>(&mut self, value: &P) -> Ref<P, Self::ByteOrder, Self::Size>
     where
-        P: Pointee<Self::Size, Packed = Self::Size, Metadata = usize>,
+        P: Pointee<Metadata = usize>,
         P: UnsizedZeroCopy<P, Self::Size>,
     {
         SliceMut::store_unsized(self, value)

--- a/crates/musli-zerocopy/src/buf/store_buf.rs
+++ b/crates/musli-zerocopy/src/buf/store_buf.rs
@@ -42,19 +42,19 @@ pub trait StoreBuf: self::sealed::Sealed {
 
     /// Store a [`ZeroCopy`] value.
     #[doc(hidden)]
-    fn store<P>(&mut self, value: &P) -> Ref<P, Self::ByteOrder, Self::Size>
+    fn store<T>(&mut self, value: &T) -> Ref<T, Self::ByteOrder, Self::Size>
     where
-        P: ZeroCopy;
+        T: ZeroCopy;
 
     /// Swap the location of two references.
     #[doc(hidden)]
-    fn swap<P>(
+    fn swap<T>(
         &mut self,
-        a: Ref<P, Self::ByteOrder, Self::Size>,
-        b: Ref<P, Self::ByteOrder, Self::Size>,
+        a: Ref<T, Self::ByteOrder, Self::Size>,
+        b: Ref<T, Self::ByteOrder, Self::Size>,
     ) -> Result<(), Error>
     where
-        P: ZeroCopy;
+        T: ZeroCopy;
 
     /// Ensure that the store buffer is aligned.
     ///

--- a/crates/musli-zerocopy/src/buf/store_buf.rs
+++ b/crates/musli-zerocopy/src/buf/store_buf.rs
@@ -39,7 +39,7 @@ pub trait StoreBuf: self::sealed::Sealed {
     #[doc(hidden)]
     fn store_unsized<P: ?Sized>(&mut self, value: &P) -> Ref<P, Self::ByteOrder, Self::Size>
     where
-        P: Pointee<Self::Size, Packed = Self::Size, Metadata = usize>,
+        P: Pointee<Metadata = usize>,
         P: UnsizedZeroCopy<P, Self::Size>;
 
     /// Store a [`ZeroCopy`] value.

--- a/crates/musli-zerocopy/src/buf/store_buf.rs
+++ b/crates/musli-zerocopy/src/buf/store_buf.rs
@@ -1,6 +1,5 @@
 use core::slice::SliceIndex;
 
-use crate::pointer::Pointee;
 use crate::traits::{UnsizedZeroCopy, ZeroCopy};
 use crate::{Buf, ByteOrder, Error, Ref, Size};
 
@@ -37,10 +36,9 @@ pub trait StoreBuf: self::sealed::Sealed {
 
     /// Store an unsigned value.
     #[doc(hidden)]
-    fn store_unsized<P: ?Sized>(&mut self, value: &P) -> Ref<P, Self::ByteOrder, Self::Size>
+    fn store_unsized<T: ?Sized>(&mut self, value: &T) -> Ref<T, Self::ByteOrder, Self::Size>
     where
-        P: Pointee<Metadata = usize>,
-        P: UnsizedZeroCopy<P, Self::Size>;
+        T: UnsizedZeroCopy<Metadata = usize>;
 
     /// Store a [`ZeroCopy`] value.
     #[doc(hidden)]

--- a/crates/musli-zerocopy/src/buf/visit.rs
+++ b/crates/musli-zerocopy/src/buf/visit.rs
@@ -36,12 +36,12 @@ impl<T: ?Sized> Visit for &T {
     }
 }
 
-impl<P: ?Sized, E: ByteOrder, O: Size> Visit for Ref<P, E, O>
+impl<T: ?Sized, E: ByteOrder, O: Size> Visit for Ref<T, E, O>
 where
-    P: Pointee<O>,
+    T: Pointee,
     Self: Load,
 {
-    type Target = <Ref<P, E, O> as Load>::Target;
+    type Target = <Ref<T, E, O> as Load>::Target;
 
     #[inline]
     fn visit<V, U>(&self, buf: &Buf, visitor: V) -> Result<U, Error>

--- a/crates/musli-zerocopy/src/mem/maybe_uninit.rs
+++ b/crates/musli-zerocopy/src/mem/maybe_uninit.rs
@@ -109,10 +109,9 @@ impl<T> fmt::Debug for MaybeUninit<T> {
     }
 }
 
-impl<T, O> Pointee<O> for MaybeUninit<T>
+impl<T> Pointee for MaybeUninit<T>
 where
-    T: Pointee<O>,
+    T: Pointee,
 {
     type Metadata = T::Metadata;
-    type Packed = T::Packed;
 }

--- a/crates/musli-zerocopy/src/pointer/mod.rs
+++ b/crates/musli-zerocopy/src/pointer/mod.rs
@@ -4,11 +4,11 @@
 //! in combination with methods such as [`Buf::load`] to load the pointer into a
 //! reference.
 //!
-//! * [`Ref<P>`] is a simple pointer to a typed reference, where `T` implements
+//! * [`Ref<T>`] is a simple pointer to a typed reference, where `T` implements
 //!   [`ZeroCopy`]. It loads into `&T`.
 //! * [`Ref<[T]>`] is a wide pointer encoding both a plain pointer and a length
 //!   where `T` implements [`ZeroCopy`]. It loads into `&[T]`.
-//! * [`Ref<P>`] where `T: ?Sized` is a wide pointer encoding both a plain
+//! * [`Ref<T>`] where `T: ?Sized` is a wide pointer encoding both a plain
 //!   pointer and a size to a typed reference where `T` implements
 //!   [`UnsizedZeroCopy`]. It loads into `&T` and is implemented by types such
 //!   as `str` and `[u8]`.`
@@ -24,5 +24,8 @@ mod size;
 pub use self::r#ref::Ref;
 mod r#ref;
 
-pub use self::pointee::{Packable, Pointee};
+pub use self::pointee::Pointee;
 mod pointee;
+
+pub use self::packable::Packable;
+mod packable;

--- a/crates/musli-zerocopy/src/pointer/mod.rs
+++ b/crates/musli-zerocopy/src/pointer/mod.rs
@@ -24,5 +24,5 @@ mod size;
 pub use self::r#ref::Ref;
 mod r#ref;
 
-pub use self::pointee::Pointee;
+pub use self::pointee::{Packable, Pointee};
 mod pointee;

--- a/crates/musli-zerocopy/src/pointer/packable.rs
+++ b/crates/musli-zerocopy/src/pointer/packable.rs
@@ -1,0 +1,25 @@
+use crate::pointer::Size;
+use crate::traits::ZeroCopy;
+
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for () {}
+    impl Sealed for usize {}
+}
+
+/// A type that can inhabit a packed representation.
+pub trait Packable: self::sealed::Sealed {
+    /// The packed representation of the item.
+    #[doc(hidden)]
+    type Packed<O>: Copy + ZeroCopy
+    where
+        O: Size;
+}
+
+impl Packable for () {
+    type Packed<O> = () where O: Size;
+}
+
+impl Packable for usize {
+    type Packed<O> = O where O: Size;
+}

--- a/crates/musli-zerocopy/src/pointer/pointee.rs
+++ b/crates/musli-zerocopy/src/pointer/pointee.rs
@@ -1,19 +1,13 @@
-use crate::ZeroCopy;
+use crate::traits::ZeroCopy;
 
-/// A type that can inhabit a packed representation.
-pub trait Packable: Sized {
-    /// The packed representation of the item.
-    type Packed<O>: Copy + ZeroCopy
-    where
-        O: Copy + ZeroCopy;
-}
+mod sealed {
+    use crate::traits::ZeroCopy;
 
-impl Packable for () {
-    type Packed<O> = () where O: Copy + ZeroCopy;
-}
+    pub trait Sealed {}
 
-impl Packable for usize {
-    type Packed<O> = O where O: Copy + ZeroCopy;
+    impl<T> Sealed for T where T: ZeroCopy {}
+    impl<T> Sealed for [T] where T: ZeroCopy {}
+    impl Sealed for str {}
 }
 
 /// The trait for a value that can be pointed to by a [`Ref<P>`].
@@ -31,7 +25,7 @@ impl Packable for usize {
 /// ```
 ///
 /// [`Ref<P>`]: crate::Ref
-pub trait Pointee {
+pub trait Pointee: self::sealed::Sealed {
     /// Metadata associated with the pointee.
     type Metadata: Packable;
 }
@@ -52,4 +46,20 @@ where
 
 impl Pointee for str {
     type Metadata = usize;
+}
+
+/// A type that can inhabit a packed representation.
+pub trait Packable: Sized {
+    /// The packed representation of the item.
+    type Packed<O>: Copy + ZeroCopy
+    where
+        O: Copy + ZeroCopy;
+}
+
+impl Packable for () {
+    type Packed<O> = () where O: Copy + ZeroCopy;
+}
+
+impl Packable for usize {
+    type Packed<O> = O where O: Copy + ZeroCopy;
 }

--- a/crates/musli-zerocopy/src/pointer/pointee.rs
+++ b/crates/musli-zerocopy/src/pointer/pointee.rs
@@ -1,18 +1,22 @@
+use crate::pointer::Packable;
 use crate::traits::ZeroCopy;
 
 mod sealed {
+    use crate::mem::MaybeUninit;
+    use crate::pointer::Pointee;
     use crate::traits::ZeroCopy;
 
     pub trait Sealed {}
 
+    impl<T> Sealed for MaybeUninit<T> where T: Pointee {}
     impl<T> Sealed for T where T: ZeroCopy {}
     impl<T> Sealed for [T] where T: ZeroCopy {}
     impl Sealed for str {}
 }
 
-/// The trait for a value that can be pointed to by a [`Ref<P>`].
+/// The trait for a value that can be pointed to by a [`Ref<T>`].
 ///
-/// This ultimately determines the layout of [`Ref<P>`] as for unsized types it
+/// This ultimately determines the layout of [`Ref<T>`] as for unsized types it
 /// needs to accommodate the size of the pointed-to type as well.
 ///
 /// ```
@@ -24,9 +28,9 @@ mod sealed {
 /// assert_eq!(size_of::<Ref::<[u32]>>(), 8);
 /// ```
 ///
-/// [`Ref<P>`]: crate::Ref
+/// [`Ref<T>`]: crate::Ref
 pub trait Pointee: self::sealed::Sealed {
-    /// Metadata associated with the pointee.
+    /// Metadata associated with a pointee.
     type Metadata: Packable;
 }
 
@@ -46,20 +50,4 @@ where
 
 impl Pointee for str {
     type Metadata = usize;
-}
-
-/// A type that can inhabit a packed representation.
-pub trait Packable: Sized {
-    /// The packed representation of the item.
-    type Packed<O>: Copy + ZeroCopy
-    where
-        O: Copy + ZeroCopy;
-}
-
-impl Packable for () {
-    type Packed<O> = () where O: Copy + ZeroCopy;
-}
-
-impl Packable for usize {
-    type Packed<O> = O where O: Copy + ZeroCopy;
 }

--- a/crates/musli-zerocopy/src/pointer/pointee.rs
+++ b/crates/musli-zerocopy/src/pointer/pointee.rs
@@ -1,5 +1,21 @@
 use crate::ZeroCopy;
 
+/// A type that can inhabit a packed representation.
+pub trait Packable: Sized {
+    /// The packed representation of the item.
+    type Packed<O>: Copy + ZeroCopy
+    where
+        O: Copy + ZeroCopy;
+}
+
+impl Packable for () {
+    type Packed<O> = () where O: Copy + ZeroCopy;
+}
+
+impl Packable for usize {
+    type Packed<O> = O where O: Copy + ZeroCopy;
+}
+
 /// The trait for a value that can be pointed to by a [`Ref<P>`].
 ///
 /// This ultimately determines the layout of [`Ref<P>`] as for unsized types it
@@ -15,35 +31,25 @@ use crate::ZeroCopy;
 /// ```
 ///
 /// [`Ref<P>`]: crate::Ref
-pub trait Pointee<O: ?Sized> {
+pub trait Pointee {
     /// Metadata associated with the pointee.
-    type Metadata: Copy;
-
-    /// The packed representation of the pointer metadata.
-    type Packed: Copy;
+    type Metadata: Packable;
 }
 
-impl<T, O> Pointee<O> for T
+impl<T> Pointee for T
 where
     T: ZeroCopy,
 {
     type Metadata = ();
-    type Packed = ();
 }
 
-impl<T, O> Pointee<O> for [T]
+impl<T> Pointee for [T]
 where
     T: ZeroCopy,
-    O: Copy,
 {
     type Metadata = usize;
-    type Packed = O;
 }
 
-impl<O> Pointee<O> for str
-where
-    O: Copy,
-{
+impl Pointee for str {
     type Metadata = usize;
-    type Packed = O;
 }

--- a/crates/musli-zerocopy/src/slice/packed.rs
+++ b/crates/musli-zerocopy/src/slice/packed.rs
@@ -4,7 +4,7 @@ use core::mem::size_of;
 use crate::buf::{Buf, Load};
 use crate::endian::{ByteOrder, Native};
 use crate::error::{Error, ErrorKind, IntoRepr};
-use crate::pointer::{Pointee, Ref, Size};
+use crate::pointer::{Ref, Size};
 use crate::slice::Slice;
 use crate::{DefaultSize, ZeroCopy};
 
@@ -115,7 +115,7 @@ where
     #[inline]
     pub fn from_ref<A: ByteOrder, B: Size>(slice: Ref<[T], A, B>) -> Self
     where
-        T: Pointee<B>,
+        T: ZeroCopy,
     {
         Self::from_raw_parts(slice.offset(), slice.len())
     }

--- a/crates/musli-zerocopy/src/tests.rs
+++ b/crates/musli-zerocopy/src/tests.rs
@@ -509,12 +509,6 @@ fn validate_packed() -> Result<()> {
 
 #[cfg(test)]
 mod primitive_slices {
-    /// Macro to implement `UnsizedZeroCopy`.
-    ///
-    /// Its requirements are the following:
-    /// * Can only be implemented for types which can inhabit any bit-pattern.
-    /// * Must only be implemented for types which are not padded (as per
-    ///   [`ZeroCopy::PADDED`]).
     macro_rules! test_case {
         ({$($param:ident)?}, $ty:ident, $example:expr) => {
             #[test]

--- a/crates/musli-zerocopy/src/traits.rs
+++ b/crates/musli-zerocopy/src/traits.rs
@@ -5,14 +5,14 @@
 //! Please see their corresponding safety documentation or use the
 //! [`ZeroCopy`][derive@crate::ZeroCopy] derive.
 //!
-//! * [`ZeroCopy`] for types which can safely be coerced from a [`Ref<P>`] to
+//! * [`ZeroCopy`] for types which can safely be coerced from a [`Ref<T>`] to
 //!   `&T` or `&mut T`.
 //! * [`UnsizedZeroCopy`] for types which can safely be coerced from an
-//!   [`Ref<P>`] where `T: ?Sized` to `&T` or `&mut T`.
+//!   [`Ref<T>`] where `T: ?Sized` to `&T` or `&mut T`.
 //! * [`ZeroSized`] for types which can be ignored when deriving
 //!   [`ZeroCopy`][derive@crate::ZeroCopy] using `#[zero_copy(ignore)]`.
 //!
-//! [`Ref<P>`]: crate::pointer::Ref
+//! [`Ref<T>`]: crate::pointer::Ref
 
 #![allow(clippy::missing_safety_doc)]
 
@@ -37,14 +37,14 @@ mod sealed {
     impl<T> Sealed for [T] where T: ZeroCopy {}
 }
 
-/// Trait governing which `P` in [`Ref<P>`] where `P: ?Sized` the wrapper can
+/// Trait governing which `P` in [`Ref<T>`] where `P: ?Sized` the wrapper can
 /// handle.
 ///
 /// We only support slice-like, unaligned unsized types, such as `str` and
 /// `[u8]`. We can't support types such as `dyn Debug` because metadata is a
 /// vtable which can't be serialized.
 ///
-/// [`Ref<P>`]: crate::pointer::Ref
+/// [`Ref<T>`]: crate::pointer::Ref
 ///
 /// # Safety
 ///

--- a/crates/musli-zerocopy/src/trie/factory.rs
+++ b/crates/musli-zerocopy/src/trie/factory.rs
@@ -54,7 +54,7 @@ pub fn store<S, E: ByteOrder, O: Size, I, T>(
 where
     I: IntoIterator<Item = (Ref<S, E, O>, T)>,
     T: ZeroCopy,
-    S: ?Sized + Pointee<O, Packed = <[u8] as Pointee<O>>::Packed>,
+    S: ?Sized + Pointee<Metadata = <[u8] as Pointee>::Metadata>,
 {
     // First step is to construct the trie in-memory.
     let mut trie = Builder::with_flavor();
@@ -132,7 +132,7 @@ impl<T, F: Flavor> Builder<T, F> {
         value: T,
     ) -> Result<(), Error>
     where
-        S: ?Sized + Pointee<O, Packed = <[u8] as Pointee<O>>::Packed>,
+        S: ?Sized + Pointee<Metadata = <[u8] as Pointee>::Metadata>,
     {
         let mut string = string.cast::<[u8]>();
         let mut current = buf.load(string)?;


### PR DESCRIPTION
Various trait-related cleanups. Removal of parameters and have UnsizedZeroCopy extend Pointee rather than receive it unecessarily.