### PR TITLE
zerocopy: Deprecate Ref::cast and introduce the safer Ref::coerce

### DIFF
--- a/crates/musli-zerocopy/src/pointer/coerce.rs
+++ b/crates/musli-zerocopy/src/pointer/coerce.rs
@@ -1,0 +1,319 @@
+use crate::pointer::{CoerceSlice, Packable, Pointee, Size};
+use crate::traits::ZeroCopy;
+
+/// A trait indicating that a coercion from `Self` to `U` is correct from a size
+/// perspective.
+pub trait Coerce<U: ?Sized + Pointee>: Pointee {
+    /// Coerce metadata from `Self` to `U`.
+    ///
+    /// Any overflow will wrap around.
+    fn coerce_metadata<O: Size>(
+        metadata: <Self::Metadata as Packable>::Packed<O>,
+    ) -> <U::Metadata as Packable>::Packed<O>;
+
+    /// Try to coerce metadata from `Self` to `U`.
+    ///
+    /// Any overflow will result in `None`.
+    fn try_coerce_metadata<O: Size>(
+        metadata: <Self::Metadata as Packable>::Packed<O>,
+    ) -> Option<<U::Metadata as Packable>::Packed<O>>;
+}
+
+/// Defines a coercion from a slice `[T]` to `[U]`.
+///
+/// Since slices have a length which depends on the exact sizing of `T` and `U`,
+/// this conversion is constrained by a special trait [`CoerceSlice<T>`].
+impl<T, U> Coerce<[U]> for [T]
+where
+    T: ZeroCopy,
+    U: ZeroCopy,
+    [T]: CoerceSlice<[U]>,
+{
+    #[inline]
+    fn coerce_metadata<O: Size>(metadata: O) -> O {
+        <[T]>::resize(metadata)
+    }
+
+    #[inline]
+    fn try_coerce_metadata<O: Size>(metadata: O) -> Option<O> {
+        <[T]>::try_resize(metadata)
+    }
+}
+
+/// Defines the coercion from `str` to `[T]`.
+///
+/// Broadly speaking, this inherits the coercions which are possible for `[u8]`,
+/// which basically limits it to `u8` and `i8` and other single byte types.
+///
+/// # Examples
+///
+/// ```
+/// use musli_zerocopy::Ref;
+///
+/// let reference: Ref<str> = Ref::with_metadata(0, 12);
+/// let reference2 = reference.coerce::<[u8]>();
+/// let reference3 = reference.coerce::<[i8]>();
+/// assert_eq!(reference2.len(), 12);
+/// assert_eq!(reference3.len(), 12);
+/// ```
+impl<T> Coerce<[T]> for str
+where
+    [u8]: CoerceSlice<[T]>,
+    T: ZeroCopy,
+{
+    #[inline]
+    fn coerce_metadata<O: Size>(metadata: O) -> O {
+        <[u8]>::resize(metadata)
+    }
+
+    #[inline]
+    fn try_coerce_metadata<O: Size>(metadata: O) -> Option<O> {
+        <[u8]>::try_resize(metadata)
+    }
+}
+
+/// Defines the coercion from `[T]` to `str`.
+///
+/// Broadly speaking, this inherits the coercions which are possible into `[u8]`,
+/// which means any type can be coerced into a `str`.
+///
+/// # Examples
+///
+/// ```
+/// use musli_zerocopy::Ref;
+///
+/// let reference: Ref<[u32]> = Ref::with_metadata(0, 12);
+/// let reference2 = reference.coerce::<str>();
+/// assert_eq!(reference2.len(), 12 * 4);
+/// ```
+impl<T> Coerce<str> for [T]
+where
+    [T]: CoerceSlice<[u8]>,
+    T: ZeroCopy,
+{
+    #[inline]
+    fn coerce_metadata<O: Size>(metadata: O) -> O {
+        <[T]>::resize(metadata)
+    }
+
+    #[inline]
+    fn try_coerce_metadata<O: Size>(metadata: O) -> Option<O> {
+        <[T]>::try_resize(metadata)
+    }
+}
+
+macro_rules! same_size_inner {
+    ($from:ty, {$($to:ty),*}) => {
+        $(
+            #[doc = concat!("Defines the coercion for `", stringify!($from) ,"` to `", stringify!($to), "`.")]
+            ///
+            /// # Examples
+            ///
+            /// ```
+            /// use musli_zerocopy::Ref;
+            ///
+            #[doc = concat!("let reference: Ref<", stringify!($from), "> = Ref::zero();")]
+            #[doc = concat!("let reference2 = reference.coerce::<", stringify!($to), ">();")]
+            /// assert_eq!(reference.offset(), reference2.offset());
+            /// ```
+            impl Coerce<$to> for $from {
+                #[inline(always)]
+                fn coerce_metadata<O: Size>(metadata: ()) -> () {
+                    metadata
+                }
+
+                #[inline(always)]
+                fn try_coerce_metadata<O: Size>(metadata: ()) -> Option<()> {
+                    Some(metadata)
+                }
+            }
+        )*
+    }
+}
+
+macro_rules! same_size {
+    ([$({$($from:ty),*}),*], [$($to:tt),*]) => {
+        $(
+            $(
+                same_size_inner!($from, $to);
+            )*
+        )*
+    };
+}
+
+same_size!([{u8, i8}], [{u8, i8}]);
+same_size!([{u16, i16}], [{u16, i16, [u8; 2], [i8; 2]}]);
+same_size!([{u32, i32}], [{u32, i32, [u16; 2], [i16; 2], [u8; 4], [i8; 4]}]);
+same_size!([{u64, i64}], [{u64, i64, [u32; 2], [i32; 2], [u16; 4], [i16; 4], [u8; 8], [i8; 8]}]);
+same_size!([{u128, i128}], [{u128, i128, [u64; 2], [i64; 2], [u32; 4], [i32; 4], [u16; 8], [i16; 8], [u8; 16], [i8; 16]}]);
+
+/// Defines the primitive coercion from `T` to `[U]`.
+///
+/// This coercion results in a single element slice of type `T`, and is largely
+/// defined through the help of [`CoerceSlice<T>`].
+///
+/// Note that coercing from a smaller to a larger type is not possible, since we
+/// don't know how many elements of the smaller type is in use:
+///
+/// ```compile_fail
+/// use musli_zerocopy::Ref;
+///
+/// let reference: Ref<u8> = Ref::zero();
+/// let reference2 = reference.coerce::<[u32]>();
+/// ```
+///
+/// # Examples
+///
+/// ```
+/// use musli_zerocopy::Ref;
+///
+/// let reference: Ref<u32> = Ref::zero();
+/// let reference2 = reference.coerce::<[u32]>();
+/// assert_eq!(reference2.len(), 1);
+///
+/// let reference: Ref<u64> = Ref::zero();
+/// let reference2 = reference.coerce::<[u32]>();
+/// assert_eq!(reference2.len(), 2);
+///
+/// let reference: Ref<u128> = Ref::zero();
+/// let reference2 = reference.coerce::<[u32]>();
+/// assert_eq!(reference2.len(), 4);
+/// ```
+impl<T, U> Coerce<[U]> for T
+where
+    T: ZeroCopy,
+    U: ZeroCopy,
+    [T]: CoerceSlice<[U]>,
+{
+    #[inline]
+    fn coerce_metadata<O: Size>((): ()) -> <<[T] as Pointee>::Metadata as Packable>::Packed<O> {
+        <[T]>::resize(O::ONE)
+    }
+
+    #[inline]
+    fn try_coerce_metadata<O: Size>(
+        (): (),
+    ) -> Option<<<[T] as Pointee>::Metadata as Packable>::Packed<O>> {
+        <[T]>::try_resize(O::ONE)
+    }
+}
+
+/// Defines the coercion from `[T; N]` to `[U]`.
+///
+/// This coercion results in a single element slice of type `T`, and is largely
+/// defined through the help of [`CoerceSlice<T>`].
+///
+/// # Examples
+///
+/// ```
+/// use musli_zerocopy::Ref;
+///
+/// let reference: Ref<[u32; 2]> = Ref::zero();
+/// let reference2 = reference.coerce::<[u32]>();
+/// assert_eq!(reference2.len(), 2);
+///
+/// let reference: Ref<[u128; 4]> = Ref::zero();
+/// let reference2 = reference.coerce::<[u64]>();
+/// assert_eq!(reference2.len(), 8);
+/// ```
+impl<T, const N: usize, U> Coerce<[U]> for [T; N]
+where
+    T: ZeroCopy,
+    U: ZeroCopy,
+    [T]: CoerceSlice<[U]>,
+{
+    #[inline]
+    fn coerce_metadata<O: Size>((): ()) -> <<[T] as Pointee>::Metadata as Packable>::Packed<O> {
+        let factor = O::try_from_usize(N).unwrap_or(O::MAX);
+        <[T]>::resize(factor)
+    }
+
+    #[inline]
+    fn try_coerce_metadata<O: Size>(
+        (): (),
+    ) -> Option<<<[T] as Pointee>::Metadata as Packable>::Packed<O>> {
+        let factor = O::try_from_usize(N)?;
+        <[T]>::try_resize(factor)
+    }
+}
+
+macro_rules! non_zero_inner {
+    ($from:ident, {$($to:ty),*}) => {
+        $(
+            #[doc = concat!("Defines the coercion for `", stringify!($from) ,"` to `", stringify!($to), "`.")]
+            ///
+            /// # Examples
+            ///
+            /// ```
+            #[doc = concat!("use std::num::", stringify!($from), ";")]
+            ///
+            /// use musli_zerocopy::Ref;
+            ///
+            #[doc = concat!("let reference: Ref<", stringify!($from), "> = Ref::zero();")]
+            #[doc = concat!("let reference2 = reference.coerce::<", stringify!($to), ">();")]
+            /// assert_eq!(reference.offset(), reference2.offset());
+            /// ```
+            impl Coerce<$to> for core::num::$from {
+                #[inline(always)]
+                fn coerce_metadata<O: Size>(metadata: ()) -> () {
+                    metadata
+                }
+
+                #[inline(always)]
+                fn try_coerce_metadata<O: Size>(metadata: ()) -> Option<()> {
+                    Some(metadata)
+                }
+            }
+        )*
+    }
+}
+
+macro_rules! non_zero {
+    ([$({$($from:ident),*}),*], [$($to:tt),*]) => {
+        $(
+            $(
+                non_zero_inner!($from, $to);
+            )*
+        )*
+    };
+}
+
+non_zero!([{NonZeroU8, NonZeroI8}], [{u8, i8}]);
+non_zero!([{NonZeroU16, NonZeroI16}], [{u16, i16}]);
+non_zero!([{NonZeroU32, NonZeroI32}], [{u32, i32}]);
+non_zero!([{NonZeroU64, NonZeroI64}], [{u64, i64}]);
+non_zero!([{NonZeroU128, NonZeroI128}], [{u128, i128}]);
+
+/// Defines the coercion for `core::num::Wrapping<T>` to `U`.
+///
+/// This is largely defined by the [`Coerce<T>`] of `T` to `U`.
+///
+/// # Examples
+///
+/// ```
+/// use std::num::Wrapping;
+///
+/// use musli_zerocopy::Ref;
+///
+/// let reference: Ref<Wrapping<i128>> = Ref::zero();
+/// let reference2 = reference.coerce::<u128>();
+/// let reference3 = reference.coerce::<[u32; 4]>();
+/// let reference4 = reference.coerce::<u128>().coerce::<[u32]>();
+/// assert_eq!(reference4.len(), 4);
+/// ```
+impl<T, U> Coerce<U> for core::num::Wrapping<T>
+where
+    T: Coerce<U>,
+    U: ZeroCopy,
+    T: ZeroCopy,
+{
+    #[inline(always)]
+    fn coerce_metadata<O: Size>(metadata: ()) {
+        metadata
+    }
+
+    #[inline(always)]
+    fn try_coerce_metadata<O: Size>(metadata: ()) -> Option<()> {
+        Some(metadata)
+    }
+}

--- a/crates/musli-zerocopy/src/pointer/coerce_slice.rs
+++ b/crates/musli-zerocopy/src/pointer/coerce_slice.rs
@@ -1,0 +1,180 @@
+use crate::pointer::Size;
+
+mod sealed {
+    pub trait Sealed<U: ?Sized> {}
+}
+
+/// Trait to coerce slice metadata, which defines its length.
+///
+/// Coercing from one kind of slice to another means that the length must be
+/// adjusted. We can only perform upwards adjustments such as `[u32]` to `[u16]`
+/// since independent of the length of the slice we know that it defines a
+/// region of memory which is appropriately sized.
+pub trait CoerceSlice<U: ?Sized>: self::sealed::Sealed<U> {
+    /// Resize with the given `factor`.
+    #[doc(hidden)]
+    fn resize<O: Size>(factor: O) -> O;
+
+    /// Try to resize with the given `factor`.
+    #[doc(hidden)]
+    fn try_resize<O: Size>(factor: O) -> Option<O>;
+}
+
+macro_rules! self_impl_inner {
+    ($from:ty, {$($to:ty),*}) => {
+        $(
+            impl self::sealed::Sealed<[$to]> for [$from] {}
+
+            #[doc = concat!("Defines the coercion from `[", stringify!($from) ,"]` to `[", stringify!($to), "]`.")]
+            ///
+            /// # Examples
+            ///
+            /// ```
+            /// use musli_zerocopy::Ref;
+            ///
+            #[doc = concat!("let reference: Ref<", stringify!($from), "> = Ref::zero();")]
+            #[doc = concat!("let reference2 = reference.coerce::<[", stringify!($from), "]>();")]
+            /// assert_eq!(reference2.len(), 1);
+            ///
+            #[doc = concat!("let reference3 = reference.coerce::<", stringify!($to), ">();")]
+            #[doc = concat!("let reference4 = reference2.coerce::<[", stringify!($to), "]>();")]
+            /// assert_eq!(reference4.len(), 1);
+            /// ```
+            impl CoerceSlice<[$to]> for [$from] {
+                #[inline]
+                fn resize<O: Size>(len: O) -> O {
+                    len
+                }
+
+                #[inline]
+                fn try_resize<O: Size>(len: O) -> Option<O> {
+                    Some(len)
+                }
+            }
+        )*
+    }
+}
+
+macro_rules! self_impl {
+    ([$({$($from:ty),*}),*], [$($to:tt),*]) => {
+        $(
+            $(
+                self_impl_inner!($from, $to);
+            )*
+        )*
+    };
+}
+
+macro_rules! coerce_slice_inner {
+    ($factor:ident, $value:literal, $from:ty, {$($to:ty),*}) => {
+        $(
+            impl self::sealed::Sealed<[$to]> for [$from] {}
+
+            #[doc = concat!("Defines the coercion from `[", stringify!($from) ,"]` to `[", stringify!($to), "]`.")]
+            ///
+            /// # Examples
+            ///
+            /// ```
+            /// use musli_zerocopy::Ref;
+            ///
+            #[doc = concat!("let reference: Ref<", stringify!($from), "> = Ref::zero();")]
+            #[doc = concat!("let reference2 = reference.coerce::<[", stringify!($to), "]>();")]
+            #[doc = concat!("assert_eq!(reference2.len(), ", stringify!($value), ");")]
+            ///
+            #[doc = concat!("let reference: Ref<[", stringify!($from), "]> = Ref::with_metadata(0, 5);")]
+            #[doc = concat!("let reference2 = reference.coerce::<[", stringify!($to), "]>();")]
+            #[doc = concat!("assert_eq!(reference2.len(), 5 * ", stringify!($value), ");")]
+            /// ```
+            impl CoerceSlice<[$to]> for [$from] {
+                #[inline]
+                fn resize<O: Size>(len: O) -> O {
+                    len.wrapping_mul(O::$factor)
+                }
+
+                #[inline]
+                fn try_resize<O: Size>(len: O) -> Option<O> {
+                    len.checked_mul(O::$factor)
+                }
+            }
+        )*
+    }
+}
+
+macro_rules! coerce_slice {
+    ($factor:ident, $value:literal, [$({$($from:ty),*}),*], [$($to:tt),*]) => {
+        $(
+            $(
+                coerce_slice_inner!($factor, $value, $from, $to);
+            )*
+        )*
+    }
+}
+
+self_impl! {
+    [
+        {u8, i8},
+        {u16, i16},
+        {u32, i32},
+        {u64, i64},
+        {u128, i128}
+    ],
+    [
+        {u8, i8},
+        {u16, i16, [u8; 2], [i8; 2]},
+        {u32, i32, [u16; 2], [i16; 2], [u8; 4], [i8; 4]},
+        {u64, i64, [u32; 2], [i32; 2], [u16; 4], [i16; 4], [u8; 8], [i8; 8]},
+        {u128, i128, [u64; 2], [i64; 2], [u32; 4], [i32; 4], [u16; 8], [i16; 8], [u8; 16], [i8; 16]}
+    ]
+}
+
+coerce_slice! {
+    N2, 2,
+    [
+        {u16, i16},
+        {u32, i32},
+        {u64, i64},
+        {u128, i128}
+    ],
+    [
+        {u8, i8},
+        {u16, i16, [u8; 2], [i8; 2]},
+        {u32, i32, [u16; 2], [i16; 2], [u8; 4], [i8; 4]},
+        {u64, i64, [u32; 2], [i32; 2], [u16; 4], [i16; 4], [u8; 8], [i8; 8]}
+    ]
+}
+
+coerce_slice! {
+    N4, 4,
+    [
+        {u32, i32},
+        {u64, i64},
+        {u128, i128}
+    ],
+    [
+        {u8, i8},
+        {u16, i16, [u8; 2], [i8; 2]},
+        {u32, i32, [u16; 2], [i16; 2], [u8; 4], [i8; 4]}
+    ]
+}
+
+coerce_slice! {
+    N8, 8,
+    [
+        {u64, i64},
+        {u128, i128}
+    ],
+    [
+        {u8, i8},
+        {u16, i16, [u8; 2], [i8; 2]}
+    ]
+}
+
+coerce_slice! {
+    N16, 16,
+    [
+        {u128, i128}
+    ],
+    [
+        {u8, i8}
+    ]
+}

--- a/crates/musli-zerocopy/src/pointer/mod.rs
+++ b/crates/musli-zerocopy/src/pointer/mod.rs
@@ -33,3 +33,9 @@ mod pointee;
 #[doc(inline)]
 pub use self::packable::Packable;
 mod packable;
+
+pub use self::coerce::Coerce;
+mod coerce;
+
+pub use self::coerce_slice::CoerceSlice;
+mod coerce_slice;

--- a/crates/musli-zerocopy/src/pointer/size.rs
+++ b/crates/musli-zerocopy/src/pointer/size.rs
@@ -54,6 +54,29 @@ pub trait Size:
     #[doc(hidden)]
     const MAX: Self;
 
+    #[doc(hidden)]
+    const ONE: Self;
+
+    #[doc(hidden)]
+    const N2: Self;
+
+    #[doc(hidden)]
+    const N4: Self;
+
+    #[doc(hidden)]
+    const N8: Self;
+
+    #[doc(hidden)]
+    const N16: Self;
+
+    #[doc(hidden)]
+    /// Perform wrapping multiplication over the type.
+    fn wrapping_mul(self, other: Self) -> Self;
+
+    #[doc(hidden)]
+    /// Perform checked multiplication over the type.
+    fn checked_mul(self, other: Self) -> Option<Self>;
+
     /// Try to construct this value from usize.
     fn try_from_usize(value: usize) -> Option<Self>;
 
@@ -81,6 +104,21 @@ macro_rules! impl_size {
         impl Size for $ty {
             const ZERO: Self = 0;
             const MAX: Self = <$ty>::MAX;
+            const ONE: Self = 1;
+            const N2: Self = 2;
+            const N4: Self = 4;
+            const N8: Self = 8;
+            const N16: Self = 16;
+
+            #[inline(always)]
+            fn wrapping_mul(self, other: Self) -> Self {
+                self.wrapping_mul(other)
+            }
+
+            #[inline(always)]
+            fn checked_mul(self, other: Self) -> Option<Self> {
+                self.checked_mul(other)
+            }
 
             #[inline]
             fn try_from_usize(value: usize) -> Option<Self> {

--- a/crates/musli-zerocopy/src/traits.rs
+++ b/crates/musli-zerocopy/src/traits.rs
@@ -209,7 +209,7 @@ unsafe impl<T> ZeroSized for Wrapping<T> where T: ZeroSized {}
 
 unsafe impl<T> ZeroCopy for Wrapping<T>
 where
-    T: Copy + ZeroCopy,
+    T: ZeroCopy,
 {
     const ANY_BITS: bool = T::ANY_BITS;
     const PADDED: bool = T::PADDED;

--- a/crates/musli-zerocopy/src/trie/factory.rs
+++ b/crates/musli-zerocopy/src/trie/factory.rs
@@ -6,7 +6,7 @@ use core::mem::replace;
 use alloc::vec::Vec;
 
 use crate::endian::Native;
-use crate::pointer::Pointee;
+use crate::pointer::{Coerce, Pointee};
 use crate::slice::{BinarySearch, Slice};
 use crate::{Buf, ByteOrder, Error, OwnedBuf, Ref, Size, ZeroCopy};
 
@@ -54,7 +54,7 @@ pub fn store<S, E: ByteOrder, O: Size, I, T>(
 where
     I: IntoIterator<Item = (Ref<S, E, O>, T)>,
     T: ZeroCopy,
-    S: ?Sized + Pointee<Metadata = <[u8] as Pointee>::Metadata>,
+    S: ?Sized + Pointee + Coerce<[u8]>,
 {
     // First step is to construct the trie in-memory.
     let mut trie = Builder::with_flavor();
@@ -132,9 +132,9 @@ impl<T, F: Flavor> Builder<T, F> {
         value: T,
     ) -> Result<(), Error>
     where
-        S: ?Sized + Pointee<Metadata = <[u8] as Pointee>::Metadata>,
+        S: ?Sized + Pointee + Coerce<[u8]>,
     {
-        let mut string = string.cast::<[u8]>();
+        let mut string = string.coerce::<[u8]>();
         let mut current = buf.load(string)?;
         let mut this = &mut self.links;
 


### PR DESCRIPTION
This pull request adds `Ref::coerce` and `Ref::try_coerce` which are a series of valid conversion.

These methods accomplishes a few things:
* It ensures that common types which have the same size can be coerced to and from each other.
* It defines slice coercions which adjust the size of slices, for example when `[T]` to `[U]` conversions are performed. The important aspect here is the pointed-to data.
* Defines a single generic API for performing "valid conversion" for APIs which are interested in that, such as the newly introduced `trie` which only cares about the byte representation of its strings.

Since coercions *might* overflow, `Ref::try_coerce` is available which returns `None` if metadata coercion overflows.