### PR TITLE
Conditional atomic_impl! for 64 bit atomics

### DIFF
--- a/crates/musli/src/impls.rs
+++ b/crates/musli/src/impls.rs
@@ -10,9 +10,11 @@ use core::num::{
     NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize, Wrapping,
 };
 use core::sync::atomic::{
-    AtomicBool, AtomicI16, AtomicI32, AtomicI64, AtomicI8, AtomicIsize, AtomicU16, AtomicU32,
-    AtomicU64, AtomicU8, AtomicUsize,
+    AtomicBool, AtomicI16, AtomicI32, AtomicI8, AtomicIsize, AtomicU16, AtomicU32, AtomicU8,
+    AtomicUsize,
 };
+#[cfg(target_has_atomic = "64")]
+use core::sync::atomic::{AtomicI64, AtomicU64};
 use core::{fmt, marker};
 
 use crate::de::{Decode, Decoder, ValueVisitor, VariantDecoder};
@@ -96,11 +98,13 @@ macro_rules! atomic_impl {
 atomic_impl!(AtomicBool);
 atomic_impl!(AtomicI16);
 atomic_impl!(AtomicI32);
+#[cfg(target_has_atomic = "64")]
 atomic_impl!(AtomicI64);
 atomic_impl!(AtomicI8);
 atomic_impl!(AtomicIsize);
 atomic_impl!(AtomicU16);
 atomic_impl!(AtomicU32);
+#[cfg(target_has_atomic = "64")]
 atomic_impl!(AtomicU64);
 atomic_impl!(AtomicU8);
 atomic_impl!(AtomicUsize);


### PR DESCRIPTION
Hi! Great looking set of crates you've got here!

I'm trying to use Musli in an embedded context on a ESP32C3, however that RISC-V architecture does not support 64 bit atomics.
This PR implements a check if the target supports 64 bit atomics.
cargo tests ran fine with the exception of a changed error message which looks unrelated.

Hope this helps!