### PR TITLE
Decode: escape field name variables

### DIFF
--- a/crates/musli-macros/src/internals/build.rs
+++ b/crates/musli-macros/src/internals/build.rs
@@ -466,7 +466,7 @@ fn setup_field<'a>(
     };
 
     let var = match &member {
-        syn::Member::Named(ident) => ident.clone(),
+        syn::Member::Named(ident) => e.cx.escaped_ident(ident),
         syn::Member::Unnamed(index) => quote::format_ident!("_{}", index.index),
     };
 

--- a/crates/musli-macros/src/internals/ctxt.rs
+++ b/crates/musli-macros/src/internals/ctxt.rs
@@ -65,4 +65,10 @@ impl Ctxt {
         let name = format!("__{name}");
         syn::Ident::new(&name, Span::call_site())
     }
+
+    /// Escape an ident so it's harder to conflict with, preserving idents span
+    pub(crate) fn escaped_ident(&self, ident: &syn::Ident) -> syn::Ident {
+        let name = format!("__{ident}");
+        syn::Ident::new(&name, ident.span())
+    }
 }

--- a/crates/tests/tests/test_decode_field_named_tag.rs
+++ b/crates/tests/tests/test_decode_field_named_tag.rs
@@ -1,0 +1,14 @@
+use musli::{Decode, Encode};
+
+#[derive(Debug, PartialEq, Encode, Decode)]
+struct TestStruct {
+    tag: usize,
+}
+
+/// `tag` is used as a variable name to decode the field tag.
+/// It should not be confused with an actual field named `tag`.
+#[test]
+#[cfg(feature = "test")]
+fn test_struct_with_field_named_tag() {
+    tests::rt!(TestStruct { tag: 42 });
+}


### PR DESCRIPTION
Fixes #66.

I added a new `escaped_ident` function that preserves the original idents span. Not sure if that's the right thing to do or if I should just call `e.cx.ident(&ident.to_string())`

Added test which failed to compile until `build.rs` was patched.