### PR TITLE
Add more implementations and implement proper allocators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: ['1.67', stable]
+        rust: ['1.73', stable]
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: ["1.67", stable]
+        rust: ["1.73", stable]
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ struct MyType {
 }
 
 impl<'de, M> Decode<'de, M> for MyType where M: Mode {
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,

--- a/crates/musli-common/Cargo.toml
+++ b/crates/musli-common/Cargo.toml
@@ -3,7 +3,7 @@ name = "musli-common"
 version = "0.0.96"
 authors = ["John-John Tedro <udoprog@tedro.se>"]
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.73"
 description = """
 Common utilities shared among Müsli encodings.
 """

--- a/crates/musli-common/src/allocator.rs
+++ b/crates/musli-common/src/allocator.rs
@@ -7,7 +7,7 @@ mod tests;
 #[cfg(feature = "alloc")]
 mod alloc;
 #[cfg(feature = "alloc")]
-pub use self::alloc::Alloc;
+pub use self::alloc::{Alloc, HeapBuffer};
 
 mod disabled;
 pub use self::disabled::Disabled;
@@ -15,13 +15,82 @@ pub use self::disabled::Disabled;
 mod no_std;
 pub use self::no_std::{NoStd, StackBuffer};
 
+#[cfg(feature = "alloc")]
 mod default_alloc {
     #![allow(missing_docs)]
 
-    #[cfg(feature = "alloc")]
-    pub type Default = super::Alloc;
-    #[cfg(not(feature = "alloc"))]
-    pub type Default = super::NoStd<1024>;
+    use super::Allocator;
+
+    pub struct DefaultBuffer(super::HeapBuffer);
+    pub struct DefaultAllocator<'a>(super::Alloc<'a>);
+
+    pub(super) fn buffer() -> DefaultBuffer {
+        DefaultBuffer(super::HeapBuffer::new())
+    }
+
+    pub(super) fn alloc(DefaultBuffer(buf): &mut DefaultBuffer) -> DefaultAllocator<'_> {
+        DefaultAllocator(super::Alloc::new(buf))
+    }
+
+    impl<'a> Allocator for DefaultAllocator<'a> {
+        type Buf<'this> = <super::Alloc<'a> as super::Allocator>::Buf<'this>
+        where
+            Self: 'this;
+
+        #[inline(always)]
+        fn alloc(&self) -> Option<Self::Buf<'_>> {
+            self.0.alloc()
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+mod default_alloc {
+    #![allow(missing_docs)]
+
+    use super::Allocator;
+
+    type InnerAllocator<'a> = super::NoStd<'a>;
+
+    pub struct DefaultBuffer(super::StackBuffer<4096>);
+    pub struct DefaultAllocator<'a>(InnerAllocator<'a>);
+
+    pub(super) fn buffer() -> DefaultBuffer {
+        DefaultBuffer(super::StackBuffer::new())
+    }
+
+    pub(super) fn alloc(DefaultBuffer(buf): &mut DefaultBuffer) -> DefaultAllocator<'_> {
+        DefaultAllocator(super::NoStd::new(buf))
+    }
+
+    impl<'a> Allocator for DefaultAllocator<'a> {
+        type Buf<'this> = <super::NoStd<'a> as super::Allocator>::Buf<'this>
+        where
+            Self: 'this;
+
+        #[inline(always)]
+        fn alloc(&self) -> Option<Self::Buf<'_>> {
+            self.0.alloc()
+        }
+    }
+}
+
+/// Construct a new default buffer.
+///
+/// Uses [`HeapBuffer`] if the `alloc` feature is enabled, otherwise
+/// `StackBuffer` is used with a default size of `4096`.
+pub fn buffer() -> DefaultBuffer {
+    self::default_alloc::buffer()
+}
+
+/// Construct a new default allocator.
+///
+/// Uses the [`Alloc`] allocator if the `alloc` feature is enabled, otherwise
+/// [`NoStd`].
+///
+/// Requires that [`buffer()`] is used to construct the provided buffer.
+pub fn new(buf: &mut DefaultBuffer) -> DefaultAllocator<'_> {
+    self::default_alloc::alloc(buf)
 }
 
 /// The default allocator.
@@ -31,7 +100,7 @@ mod default_alloc {
 /// * If `alloc` is enabled, this is the [`Alloc`] allocator.
 /// * Otherwise this is the [`NoStd`] allocator.
 #[doc(inline)]
-pub use self::default_alloc::Default;
+pub use self::default_alloc::{DefaultAllocator, DefaultBuffer};
 
 use musli::context::Buffer;
 
@@ -43,8 +112,8 @@ use musli::context::Buffer;
 /// use musli_common::allocator::{self, Allocator};
 /// use musli::context::Buffer;
 ///
-/// let alloc = allocator::Default::default();
-/// let alloc = &alloc;
+/// let mut buf = allocator::buffer();
+/// let alloc = allocator::new(&mut buf);
 ///
 /// let mut a = alloc.alloc();
 /// let mut b = alloc.alloc();

--- a/crates/musli-common/src/allocator.rs
+++ b/crates/musli-common/src/allocator.rs
@@ -13,7 +13,7 @@ mod disabled;
 pub use self::disabled::Disabled;
 
 mod no_std;
-pub use self::no_std::NoStd;
+pub use self::no_std::{NoStd, StackBuffer};
 
 mod default_alloc {
     #![allow(missing_docs)]

--- a/crates/musli-common/src/allocator.rs
+++ b/crates/musli-common/src/allocator.rs
@@ -83,7 +83,7 @@ pub trait Allocator {
     /// Allocate an empty, uninitialized buffer. Just calling this function
     /// doesn't cause any allocations to occur, for that to happen the returned
     /// allocation has to be written to.
-    fn alloc(&self) -> Self::Buf<'_>;
+    fn alloc(&self) -> Option<Self::Buf<'_>>;
 }
 
 impl<A> Allocator for &A
@@ -93,7 +93,7 @@ where
     type Buf<'this> = A::Buf<'this> where Self: 'this;
 
     #[inline(always)]
-    fn alloc(&self) -> Self::Buf<'_> {
+    fn alloc(&self) -> Option<Self::Buf<'_>> {
         (*self).alloc()
     }
 }

--- a/crates/musli-common/src/allocator.rs
+++ b/crates/musli-common/src/allocator.rs
@@ -115,11 +115,11 @@ use musli::context::Buffer;
 /// let mut buf = allocator::buffer();
 /// let alloc = allocator::new(&mut buf);
 ///
-/// let mut a = alloc.alloc();
-/// let mut b = alloc.alloc();
+/// let mut a = alloc.alloc().expect("allocation a failed");
+/// let mut b = alloc.alloc().expect("allocation b failed");
 ///
 /// b.write(b"He11o");
-/// a.copy_back(b);
+/// a.write(b.as_slice());
 ///
 /// assert_eq!(a.as_slice(), b"He11o");
 /// assert_eq!(a.len(), 5);
@@ -129,18 +129,11 @@ use musli::context::Buffer;
 /// assert_eq!(a.as_slice(), b"He11o W0rld");
 /// assert_eq!(a.len(), 11);
 ///
-/// let mut c = alloc.alloc();
+/// let mut c = alloc.alloc().expect("allocation c failed");
 /// c.write(b"!");
-/// assert!(a.write_at(7, b"o"));
-/// assert!(!a.write_at(11, b"!"));
-/// a.copy_back(c);
+/// a.write(c.as_slice());
 ///
-/// assert_eq!(a.as_slice(), b"He11o World!");
-/// assert_eq!(a.len(), 12);
-///
-/// assert!(a.write_at(2, b"ll"));
-///
-/// assert_eq!(a.as_slice(), b"Hello World!");
+/// assert_eq!(a.as_slice(), b"He11o W0rld!");
 /// assert_eq!(a.len(), 12);
 /// ```
 pub trait Allocator {

--- a/crates/musli-common/src/allocator/alloc.rs
+++ b/crates/musli-common/src/allocator/alloc.rs
@@ -35,11 +35,11 @@ impl Allocator for Alloc {
     type Buf<'this> = Buf<'this>;
 
     #[inline(always)]
-    fn alloc(&self) -> Self::Buf<'_> {
-        Buf {
+    fn alloc(&self) -> Option<Self::Buf<'_>> {
+        Some(Buf {
             region: Internal::alloc(&self.internal),
             internal: &self.internal,
-        }
+        })
     }
 }
 

--- a/crates/musli-common/src/allocator/disabled.rs
+++ b/crates/musli-common/src/allocator/disabled.rs
@@ -12,19 +12,6 @@ impl Buffer for EmptyBuf {
     }
 
     #[inline(always)]
-    fn write_at(&mut self, _: usize, _: &[u8]) -> bool {
-        false
-    }
-
-    #[inline(always)]
-    fn copy_back<B>(&mut self, _: B) -> bool
-    where
-        B: Buffer,
-    {
-        false
-    }
-
-    #[inline(always)]
     fn len(&self) -> usize {
         0
     }

--- a/crates/musli-common/src/allocator/disabled.rs
+++ b/crates/musli-common/src/allocator/disabled.rs
@@ -1,5 +1,3 @@
-use core::ptr::NonNull;
-
 use musli::context::Buffer;
 
 use crate::allocator::Allocator;
@@ -32,12 +30,7 @@ impl Buffer for EmptyBuf {
     }
 
     #[inline(always)]
-    fn raw_parts(&self) -> (NonNull<u8>, usize, usize) {
-        (NonNull::dangling(), 0, 0)
-    }
-
-    #[inline(always)]
-    unsafe fn as_slice(&self) -> &[u8] {
+    fn as_slice(&self) -> &[u8] {
         &[]
     }
 }
@@ -64,10 +57,10 @@ impl Default for Disabled {
 }
 
 impl Allocator for Disabled {
-    type Buf = EmptyBuf;
+    type Buf<'this> = EmptyBuf;
 
     #[inline(always)]
-    fn alloc(&self) -> Self::Buf {
+    fn alloc(&self) -> Self::Buf<'_> {
         EmptyBuf
     }
 }

--- a/crates/musli-common/src/allocator/disabled.rs
+++ b/crates/musli-common/src/allocator/disabled.rs
@@ -47,7 +47,7 @@ impl Allocator for Disabled {
     type Buf<'this> = EmptyBuf;
 
     #[inline(always)]
-    fn alloc(&self) -> Self::Buf<'_> {
-        EmptyBuf
+    fn alloc(&self) -> Option<Self::Buf<'_>> {
+        Some(EmptyBuf)
     }
 }

--- a/crates/musli-common/src/allocator/no_std.rs
+++ b/crates/musli-common/src/allocator/no_std.rs
@@ -1,4 +1,9 @@
-use core::cell::UnsafeCell;
+use core::cell::{Cell, UnsafeCell};
+use core::marker::PhantomData;
+use core::mem::{size_of, MaybeUninit};
+use core::num::NonZeroU8;
+use core::ops::{Deref, DerefMut};
+use core::ptr;
 use core::slice;
 
 use musli::context::Buffer;
@@ -6,125 +11,633 @@ use musli::context::Buffer;
 use crate::allocator::Allocator;
 use crate::fixed::FixedVec;
 
-// TODO: rewrite into a proper allocator.
-
-/// Buffer used in combination with a `Context`.
-///
-/// This type of allocator has a fixed capacity specified by `C` and can be
-/// constructed statically.
-pub struct NoStd<const C: usize> {
-    // This must be an unsafe cell, since it's mutably accessed through an
-    // immutable pointers. We simply make sure that those accesses do not
-    // clobber each other, which we can do since the API is restricted through
-    // the `Buffer` trait.
-    scratch: UnsafeCell<FixedVec<u8, C>>,
+/// A buffer that can be used to store data on the stack.
+pub struct StackBuffer<const C: usize> {
+    data: FixedVec<u8, C>,
 }
 
-impl<const C: usize> NoStd<C> {
-    /// Build a new no-std allocator.
+impl<const C: usize> StackBuffer<C> {
+    /// Construct a new buffer.
     pub const fn new() -> Self {
         Self {
-            scratch: UnsafeCell::new(FixedVec::new()),
+            data: FixedVec::new(),
         }
     }
 }
 
-impl<const C: usize> Default for NoStd<C> {
+impl<const C: usize> Default for StackBuffer<C> {
     #[inline]
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<const C: usize> Allocator for NoStd<C> {
-    type Buf<'this> = Buf<'this, C>;
+impl<const C: usize> Deref for StackBuffer<C> {
+    type Target = [MaybeUninit<u8>];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.data.as_uninit_slice()
+    }
+}
+
+impl<const C: usize> DerefMut for StackBuffer<C> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.data.as_mut_uninit_slice()
+    }
+}
+
+/// Minimum length of a region as its being written to.
+const MIN_LEN: usize = 8;
+
+/// TODO: Make sure allocator passes miri.
+///
+/// It currently cannot, since projecting from a pointer through a reference
+/// inherits its provinance, which means that each reference holds onto the
+/// entirety of the slice.
+
+/// Buffer used in combination with a `Context`.
+///
+/// This type of allocator has a fixed capacity specified by `C` and can be
+/// constructed statically.
+pub struct NoStd<'a> {
+    // This must be an unsafe cell, since it's mutably accessed through an
+    // immutable pointers. We simply make sure that those accesses do not
+    // clobber each other, which we can do since the API is restricted through
+    // the `Buffer` trait.
+    internal: UnsafeCell<Internal>,
+    // The underlying vector being borrowed.
+    _marker: PhantomData<&'a mut [MaybeUninit<u8>]>,
+}
+
+impl<'a> NoStd<'a> {
+    /// Build a new no-std allocator.
+    pub fn new(buffer: &'a mut [MaybeUninit<u8>]) -> Self {
+        Self {
+            internal: UnsafeCell::new(Internal {
+                free: None,
+                head: None,
+                tail: None,
+                bytes: 0,
+                regions: 0,
+                size: buffer.len(),
+                data: buffer.as_mut_ptr(),
+            }),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl Allocator for NoStd<'_> {
+    type Buf<'this> = Buf<'this> where Self: 'this;
 
     #[inline(always)]
     fn alloc(&self) -> Self::Buf<'_> {
-        unsafe {
-            let n = (*self.scratch.get()).len();
+        // SAFETY: We have exclusive access to the internal state, and it's only
+        // held for the duration of this call.
+        let alloc = unsafe { (*self.internal.get()).alloc(MIN_LEN) };
 
-            Buf {
-                base: n,
-                len: 0,
-                data: &self.scratch,
-            }
+        let Some((region, _)) = alloc else {
+            panic!("Out of memory");
+        };
+
+        Buf {
+            region: Cell::new(region),
+            len: Cell::new(0),
+            internal: &self.internal,
         }
     }
 }
 
 /// A no-std allocated buffer.
-pub struct Buf<'a, const C: usize> {
-    base: usize,
-    len: usize,
-    data: &'a UnsafeCell<FixedVec<u8, C>>,
+pub struct Buf<'a> {
+    region: Cell<Region>,
+    len: Cell<usize>,
+    internal: &'a UnsafeCell<Internal>,
 }
 
-impl<'a, const C: usize> Buffer for Buf<'a, C> {
+impl<'a> Buffer for Buf<'a> {
     #[inline]
     fn write(&mut self, bytes: &[u8]) -> bool {
         unsafe {
-            let data = &mut *self.data.get();
-            assert_eq!(data.len(), self.len.wrapping_add(self.base));
+            let len = self.len.get();
 
-            if data.try_extend_from_slice(bytes).is_err() {
-                return false;
-            }
+            let i = &mut *self.internal.get();
 
-            self.len = self.len.wrapping_add(bytes.len());
-        }
+            let header_ptr = i.header_mut(self.region.get());
 
-        true
-    }
+            // Region can fit the bytes available.
+            let header_ptr = if (*header_ptr).size() - len < bytes.len() {
+                let to_len = (len + bytes.len()).next_power_of_two().max(MIN_LEN);
 
-    #[inline]
-    fn write_at(&mut self, at: usize, bytes: &[u8]) -> bool {
-        unsafe {
-            if at.wrapping_add(bytes.len()) > self.len {
-                return false;
-            }
+                let Some(region) = i.realloc(self.region.get(), len, to_len) else {
+                    return false;
+                };
 
-            let data = &mut *self.data.get();
-
-            let Some(data) = data.get_mut(at..at.wrapping_add(bytes.len())) else {
-                return false;
+                self.region.set(region);
+                i.header_mut(region)
+            } else {
+                header_ptr
             };
 
-            data.copy_from_slice(bytes);
+            let dst = i.data.wrapping_add((*header_ptr).start() + len).cast();
+
+            ptr::copy_nonoverlapping(bytes.as_ptr(), dst, bytes.len());
+            self.len.set(len + bytes.len());
             true
         }
     }
 
     #[inline(always)]
     fn len(&self) -> usize {
-        self.len
-    }
-
-    #[inline]
-    fn copy_back<B>(&mut self, other: B) -> bool
-    where
-        B: Buffer,
-    {
-        self.write(other.as_slice())
+        self.len.get()
     }
 
     #[inline(always)]
     fn as_slice(&self) -> &[u8] {
         unsafe {
-            let data = &*self.data.get();
-            slice::from_raw_parts(data.as_ptr().wrapping_add(self.base), self.len)
+            let i = &*self.internal.get();
+            let start = i.header(self.region.get()).start();
+            let data = i.data.wrapping_add(start).cast();
+            slice::from_raw_parts(data, self.len.get())
         }
     }
 }
 
-impl<'a, const C: usize> Drop for Buf<'a, C> {
+impl Drop for Buf<'_> {
     fn drop(&mut self) {
-        // SAFETY: During construction of the buffer, we fetch the length of the
-        // vector which is known to be initialized. Since the only way the
-        // vector can be extended is through `Buffer::write`.
+        // SAFETY: We have exclusive access to the internal state.
         unsafe {
-            let data = &mut *self.data.get();
-            data.set_len(self.base);
+            (*self.internal.get()).free(self.region.get());
         }
+    }
+}
+
+/// The identifier of a region.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(transparent)]
+struct Region(NonZeroU8);
+
+impl Region {
+    /// Create a new region identifier.
+    ///
+    /// # Safety
+    ///
+    /// The given value must be non-zero.
+    #[inline]
+    const unsafe fn new_unchecked(value: u8) -> Self {
+        Self(NonZeroU8::new_unchecked(value))
+    }
+
+    /// Get the value of the region identifier.
+    #[inline]
+    fn get(self) -> u8 {
+        self.0.get()
+    }
+}
+
+struct Internal {
+    // The first region to allocate if it's been freed.
+    free: Option<Region>,
+    // Pointer to the head region.
+    head: Option<Region>,
+    // Pointer to the tail region.
+    tail: Option<Region>,
+    // Bytes used by regions.
+    regions: usize,
+    // Bytes allocated.
+    bytes: usize,
+    /// The size of the buffer being wrapped.
+    size: usize,
+    // The slab of regions and allocations.
+    //
+    // Allocated memory grows from the bottom upwards, because this allows
+    // copying writes to be optimized.
+    //
+    // Region metadata is written to the end growing downwards.
+    data: *mut MaybeUninit<u8>,
+}
+
+impl Internal {
+    /// Get the header pointer corresponding to the given index.
+    #[inline]
+    fn header(&self, at: Region) -> &Header {
+        // SAFETY: Once we've coerced to `&self`, then we guarantee that we can
+        // get a header immutably.
+        unsafe {
+            &*self
+                .data
+                .wrapping_add(self.region_to_addr(at))
+                .cast::<Header>()
+        }
+    }
+
+    /// Get the mutable header pointer corresponding to the given index.
+    #[inline]
+    fn header_mut(&mut self, at: Region) -> *mut Header {
+        self.data
+            .wrapping_add(self.region_to_addr(at))
+            .cast::<Header>()
+    }
+
+    /// Allocate a region.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `this` is exclusively available.
+    unsafe fn alloc(&mut self, requested: usize) -> Option<(Region, *mut Header)> {
+        debug_assert!(requested.is_power_of_two());
+
+        if let Some((region, header_ptr, prev)) = self.find_free(|h| h.size() >= requested) {
+            let free = (*header_ptr).free.take();
+
+            if let Some(prev) = prev {
+                (*self.header_mut(prev)).free = free;
+            } else {
+                self.free = free;
+            }
+
+            (*header_ptr).state = State::Used;
+
+            // TODO: Should we split the allocated region?
+            return Some((region, header_ptr));
+        }
+
+        let start = u32::try_from(self.bytes).ok()?;
+        let size = u32::try_from(requested).ok()?;
+
+        let bytes = self.bytes.checked_add(requested)?;
+        let regions = self.regions.checked_add(size_of::<Header>())?;
+        let total = bytes.checked_add(regions)?;
+
+        if total > self.size {
+            return None;
+        }
+
+        let addr = self.size - regions;
+        let region = self.addr_to_region(addr);
+        let header_ptr = self.data.wrapping_add(addr).cast::<Header>();
+        self.regions = regions;
+        self.bytes = bytes;
+
+        header_ptr.write(Header {
+            start,
+            size,
+            state: State::Used,
+            free: None,
+            prev: None,
+            next: None,
+        });
+
+        if self.head.is_none() {
+            self.head = Some(region);
+        }
+
+        if let Some(tail) = self.tail.replace(region) {
+            (*header_ptr).prev = Some(tail);
+            let tail_ptr = self.header_mut(tail);
+            (*tail_ptr).next = Some(region);
+        }
+
+        Some((region, header_ptr))
+    }
+
+    unsafe fn free(&mut self, at: Region) {
+        let header_ptr = self.header_mut(at);
+
+        (*header_ptr).state = State::Free;
+        (*header_ptr).free = self.free.replace(at);
+
+        if (*header_ptr).next.is_none() {
+            self.bytes += (*header_ptr).size();
+            self.tail = (*header_ptr).prev.take();
+            (*header_ptr).start = 0;
+            (*header_ptr).size = 0;
+            (*header_ptr).next = None;
+            return;
+        }
+
+        let Some(prev) = (*header_ptr).prev else {
+            return;
+        };
+
+        let prev_ptr = &mut *self.header_mut(prev);
+
+        if prev_ptr.state != State::Free {
+            return;
+        }
+
+        // Move allocation to the previous region.
+        let Header {
+            size, next, prev, ..
+        } = header_ptr.replace(Header {
+            start: 0,
+            size: 0,
+            state: State::Free,
+            free: (*header_ptr).free,
+            prev: None,
+            next: None,
+        });
+
+        prev_ptr.size += size;
+        prev_ptr.next = next;
+
+        if let Some(next) = next {
+            (*self.header_mut(next)).prev = prev;
+        } else {
+            // The current header being freed is the last in the list.
+            self.bytes = (*header_ptr).start();
+            self.tail = prev;
+        }
+    }
+
+    unsafe fn realloc(&mut self, from: Region, len: usize, to_len: usize) -> Option<Region> {
+        debug_assert!(to_len.is_power_of_two());
+
+        let from_header = self.header_mut(from);
+
+        let (to, to_header) = self.alloc(to_len)?;
+
+        let from_data = self
+            .data
+            .wrapping_add((*from_header).start())
+            .cast::<u8>()
+            .cast_const();
+
+        let to_data = self.data.wrapping_add((*to_header).start()).cast::<u8>();
+
+        ptr::copy_nonoverlapping(from_data, to_data, len);
+        self.free(from);
+        Some(to)
+    }
+
+    unsafe fn find_free<T>(
+        &mut self,
+        mut condition: T,
+    ) -> Option<(Region, *mut Header, Option<Region>)>
+    where
+        T: FnMut(&Header) -> bool,
+    {
+        // First iterate over existing regions to try and find a different one
+        // which is suitable.
+        let mut current = self.free;
+        let mut prev = None;
+
+        while let Some(to) = current {
+            let header_ptr = self.header_mut(to);
+
+            if condition(&*header_ptr) {
+                return Some((to, header_ptr, prev));
+            }
+
+            prev = Some(to);
+            current = (*header_ptr).free;
+        }
+
+        None
+    }
+
+    #[inline]
+    fn region_to_addr(&self, at: Region) -> usize {
+        self.size - (at.get() as usize) * size_of::<Header>()
+    }
+
+    #[inline]
+    unsafe fn addr_to_region(&self, addr: usize) -> Region {
+        debug_assert!(addr < self.size);
+        Region::new_unchecked(((self.size - addr) / size_of::<Header>()) as u8)
+    }
+}
+
+/// The state of an allocated region.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+enum State {
+    Free = 0,
+    Used,
+}
+
+/// The header of a region.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(C, packed)]
+struct Header {
+    // Start of the allocated region as a multiple of 8.
+    start: u32,
+    // Size of the region.
+    size: u32,
+    // The state of the region.
+    state: State,
+    // The next freed region to be allocated.
+    free: Option<Region>,
+    // The previous neighbouring region.
+    prev: Option<Region>,
+    // The next neighbouring region.
+    next: Option<Region>,
+}
+
+impl Header {
+    /// Get the start address.
+    #[inline]
+    fn start(&self) -> usize {
+        self.start as usize
+    }
+
+    /// Get the size.
+    #[inline]
+    fn size(&self) -> usize {
+        self.size as usize
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::allocator::{Allocator, Buffer};
+
+    use super::{Header, NoStd, Region, State};
+
+    macro_rules! assert_header {
+        (
+            $header:expr,
+            {
+                $start:expr,
+                $size:expr,
+                $state:expr,
+                free: $free:expr,
+                prev: $prev:expr,
+                next: $next:expr $(,)?
+            } $(,)?
+        ) => {
+            assert_eq! {
+                $header,
+                Header {
+                    start: $start,
+                    size: $size,
+                    state: $state,
+                    free: $free,
+                    prev: $prev,
+                    next: $next,
+                }
+            };
+        };
+    }
+
+    fn realloc(alloc: &NoStd<'_>) {
+        const A: Region = unsafe { Region::new_unchecked(1) };
+        const B: Region = unsafe { Region::new_unchecked(2) };
+        const C: Region = unsafe { Region::new_unchecked(3) };
+        const D: Region = unsafe { Region::new_unchecked(4) };
+
+        let mut a = alloc.alloc();
+        a.write(&[1, 2, 3, 4]);
+        assert_eq!(a.region.get(), A);
+
+        let mut b = alloc.alloc();
+        b.write(&[1, 2, 3, 4]);
+        assert_eq!(b.region.get(), B);
+
+        let mut c = alloc.alloc();
+        c.write(&[1, 2, 3, 4]);
+        assert_eq!(c.region.get(), C);
+
+        assert_eq!(a.region.get(), A);
+        assert_eq!(b.region.get(), B);
+        assert_eq!(c.region.get(), C);
+
+        {
+            let i = unsafe { &*alloc.internal.get() };
+
+            assert_eq!(i.free, None);
+            assert_eq!(i.head, Some(A));
+            assert_eq!(i.tail, Some(C));
+
+            assert_header! {
+                *i.header(A),
+                { 0, 8, State::Used, free: None, prev: None, next: Some(B) },
+            };
+
+            assert_header! {
+                *i.header(B),
+                { 8, 8, State::Used, free: None, prev: Some(A), next: Some(C) }
+            };
+
+            assert_header! {
+                *i.header(C),
+                { 16, 8, State::Used, free: None, prev: Some(B), next: None }
+            };
+        }
+
+        drop(a);
+
+        {
+            let i = unsafe { &*alloc.internal.get() };
+            assert_eq!(i.free, Some(A));
+            assert_eq!(i.head, Some(A));
+            assert_eq!(i.tail, Some(C));
+
+            assert_header! {
+                *i.header(A),
+                { 0, 8, State::Free, free: None, prev: None, next: Some(B) }
+            };
+
+            assert_header! {
+                *i.header(B),
+                { 8, 8, State::Used, free: None, prev: Some(A), next: Some(C) }
+            };
+
+            assert_header! {
+                *i.header(C),
+                { 16, 8, State::Used, free: None, prev: Some(B), next: None }
+            };
+        }
+
+        drop(b);
+
+        {
+            let i = unsafe { &*alloc.internal.get() };
+            assert_eq!(i.free, Some(B));
+            assert_eq!(i.head, Some(A));
+            assert_eq!(i.tail, Some(C));
+
+            assert_header! {
+                *i.header(A),
+                { 0, 16, State::Free, free: None, prev: None, next: Some(C) }
+            };
+
+            assert_header! {
+                *i.header(B),
+                { 0, 0, State::Free, free: Some(A), prev: None, next: None }
+            };
+
+            assert_header! {
+                *i.header(C),
+                { 16, 8, State::Used, free: None, prev: Some(A), next: None }
+            };
+        }
+
+        let mut d = alloc.alloc();
+        d.write(&[1, 2]);
+
+        assert_eq!(d.region.get(), A);
+
+        {
+            let i = unsafe { &*alloc.internal.get() };
+            assert_eq!(i.free, Some(B));
+            assert_eq!(i.head, Some(A));
+            assert_eq!(i.tail, Some(C));
+
+            assert_header! {
+                *i.header(A),
+                { 0, 16, State::Used, free: None, prev: None, next: Some(C) }
+            };
+
+            assert_header! {
+                *i.header(B),
+                { 0, 0, State::Free, free: None, prev: None, next: None }
+            };
+
+            assert_header! {
+                *i.header(C),
+                { 16, 8, State::Used, free: None, prev: Some(A), next: None }
+            };
+        }
+
+        d.write(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+
+        assert_eq!(d.region.get(), D);
+
+        {
+            let i = unsafe { &*alloc.internal.get() };
+            assert_eq!(i.free, Some(A));
+            assert_eq!(i.head, Some(A));
+            assert_eq!(i.tail, Some(D));
+
+            assert_header! {
+                *i.header(A),
+                { 0, 16, State::Free, free: Some(B), prev: None, next: Some(C) }
+            };
+
+            assert_header! {
+                *i.header(B),
+                { 0, 0, State::Free, free: None, prev: None, next: None }
+            };
+
+            assert_header! {
+                *i.header(C),
+                { 16, 8, State::Used, free: None, prev: Some(A), next: Some(D) }
+            };
+
+            assert_header! {
+                *i.header(D),
+                { 24, 32, State::Used, free: None, prev: Some(C), next: None }
+            };
+        }
+    }
+
+    #[test]
+    fn nostd_realloc() {
+        let mut buf = crate::allocator::StackBuffer::<4096>::new();
+        let alloc = crate::allocator::NoStd::new(&mut buf);
+        realloc(&alloc);
     }
 }

--- a/crates/musli-common/src/allocator/tests.rs
+++ b/crates/musli-common/src/allocator/tests.rs
@@ -1,0 +1,36 @@
+use crate::allocator::Allocator;
+use musli::context::Buffer;
+
+#[test]
+fn test_allocator() {
+    let alloc = crate::allocator::Default::default();
+    let alloc = &alloc;
+
+    let mut a = alloc.alloc();
+    let mut b = alloc.alloc();
+
+    b.write(b"He11o");
+    a.copy_back(b);
+
+    assert_eq!(a.as_slice(), b"He11o");
+    assert_eq!(a.len(), 5);
+
+    a.write(b" W0rld");
+
+    assert_eq!(a.as_slice(), b"He11o W0rld");
+    assert_eq!(a.len(), 11);
+
+    let mut c = alloc.alloc();
+    c.write(b"!");
+    assert!(a.write_at(7, b"o"));
+    assert!(!a.write_at(11, b"!"));
+    a.copy_back(c);
+
+    assert_eq!(a.as_slice(), b"He11o World!");
+    assert_eq!(a.len(), 12);
+
+    assert!(a.write_at(2, b"ll"));
+
+    assert_eq!(a.as_slice(), b"Hello World!");
+    assert_eq!(a.len(), 12);
+}

--- a/crates/musli-common/src/allocator/tests.rs
+++ b/crates/musli-common/src/allocator/tests.rs
@@ -1,16 +1,16 @@
 use crate::allocator::Allocator;
 use musli::context::Buffer;
 
-#[test]
-fn test_allocator() {
-    let alloc = crate::allocator::Default::default();
-    let alloc = &alloc;
-
+fn basic_allocations<A: Allocator>(alloc: &A) {
     let mut a = alloc.alloc();
     let mut b = alloc.alloc();
 
     b.write(b"He11o");
-    a.copy_back(b);
+
+    assert_eq!(b.as_slice(), b"He11o");
+    assert_eq!(b.len(), 5);
+
+    a.write(b.as_slice());
 
     assert_eq!(a.as_slice(), b"He11o");
     assert_eq!(a.len(), 5);
@@ -22,15 +22,22 @@ fn test_allocator() {
 
     let mut c = alloc.alloc();
     c.write(b"!");
-    assert!(a.write_at(7, b"o"));
-    assert!(!a.write_at(11, b"!"));
-    a.copy_back(c);
+    assert_eq!(c.len(), 1);
 
-    assert_eq!(a.as_slice(), b"He11o World!");
+    a.write(c.as_slice());
+    assert_eq!(a.as_slice(), b"He11o W0rld!");
     assert_eq!(a.len(), 12);
+}
 
-    assert!(a.write_at(2, b"ll"));
+#[test]
+fn alloc_basic() {
+    let alloc = crate::allocator::Default::default();
+    basic_allocations(&alloc);
+}
 
-    assert_eq!(a.as_slice(), b"Hello World!");
-    assert_eq!(a.len(), 12);
+#[test]
+fn nostd_basic() {
+    let mut buf = crate::allocator::StackBuffer::<4096>::new();
+    let alloc = crate::allocator::NoStd::new(&mut buf);
+    basic_allocations(&alloc);
 }

--- a/crates/musli-common/src/allocator/tests.rs
+++ b/crates/musli-common/src/allocator/tests.rs
@@ -2,8 +2,8 @@ use crate::allocator::Allocator;
 use musli::context::Buffer;
 
 fn basic_allocations<A: Allocator>(alloc: &A) {
-    let mut a = alloc.alloc();
-    let mut b = alloc.alloc();
+    let mut a = alloc.alloc().unwrap();
+    let mut b = alloc.alloc().unwrap();
 
     b.write(b"He11o");
 
@@ -20,7 +20,7 @@ fn basic_allocations<A: Allocator>(alloc: &A) {
     assert_eq!(a.as_slice(), b"He11o W0rld");
     assert_eq!(a.len(), 11);
 
-    let mut c = alloc.alloc();
+    let mut c = alloc.alloc().unwrap();
     c.write(b"!");
     assert_eq!(c.len(), 1);
 

--- a/crates/musli-common/src/allocator/tests.rs
+++ b/crates/musli-common/src/allocator/tests.rs
@@ -31,7 +31,8 @@ fn basic_allocations<A: Allocator>(alloc: &A) {
 
 #[test]
 fn alloc_basic() {
-    let alloc = crate::allocator::Default::default();
+    let mut buf = crate::allocator::HeapBuffer::new();
+    let alloc = crate::allocator::Alloc::new(&mut buf);
     basic_allocations(&alloc);
 }
 

--- a/crates/musli-common/src/buffered_writer.rs
+++ b/crates/musli-common/src/buffered_writer.rs
@@ -61,7 +61,7 @@ where
         B: Buffer,
     {
         // SAFETY: the buffer never outlives this function call.
-        self.write_bytes(cx, unsafe { buffer.as_slice() })
+        self.write_bytes(cx, buffer.as_slice())
     }
 
     #[inline]

--- a/crates/musli-common/src/buffered_writer.rs
+++ b/crates/musli-common/src/buffered_writer.rs
@@ -29,7 +29,7 @@ where
     }
 
     /// Finish writing.
-    pub fn finish<C>(mut self, cx: &mut C) -> Result<(), C::Error>
+    pub fn finish<C>(mut self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = W::Error>,
     {
@@ -55,7 +55,7 @@ where
     }
 
     #[inline]
-    fn write_buffer<C, B>(&mut self, cx: &mut C, buffer: B) -> Result<(), C::Error>
+    fn write_buffer<C, B>(&mut self, cx: &C, buffer: B) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
         B: Buffer,
@@ -65,7 +65,7 @@ where
     }
 
     #[inline]
-    fn write_bytes<C>(&mut self, cx: &mut C, bytes: &[u8]) -> Result<(), C::Error>
+    fn write_bytes<C>(&mut self, cx: &C, bytes: &[u8]) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {

--- a/crates/musli-common/src/context.rs
+++ b/crates/musli-common/src/context.rs
@@ -66,7 +66,7 @@ where
     type Buf<'this> = A::Buf<'this> where Self: 'this;
 
     #[inline(always)]
-    fn alloc(&self) -> Self::Buf<'_> {
+    fn alloc(&self) -> Option<Self::Buf<'_>> {
         self.alloc.alloc()
     }
 
@@ -156,7 +156,7 @@ where
     type Buf<'this> = A::Buf<'this> where Self: 'this;
 
     #[inline(always)]
-    fn alloc(&self) -> Self::Buf<'_> {
+    fn alloc(&self) -> Option<Self::Buf<'_>> {
         self.alloc.alloc()
     }
 
@@ -227,7 +227,7 @@ where
     type Buf<'this> = A::Buf<'this> where Self: 'this;
 
     #[inline(always)]
-    fn alloc(&self) -> Self::Buf<'_> {
+    fn alloc(&self) -> Option<Self::Buf<'_>> {
         self.alloc.alloc()
     }
 

--- a/crates/musli-common/src/context.rs
+++ b/crates/musli-common/src/context.rs
@@ -63,10 +63,10 @@ where
     type Input = E;
     type Error = E;
     type Mark = ();
-    type Buf = A::Buf;
+    type Buf<'this> = A::Buf<'this> where Self: 'this;
 
     #[inline(always)]
-    fn alloc(&self) -> Self::Buf {
+    fn alloc(&self) -> Self::Buf<'_> {
         self.alloc.alloc()
     }
 
@@ -153,10 +153,10 @@ where
     type Input = E;
     type Error = Error;
     type Mark = ();
-    type Buf = A::Buf;
+    type Buf<'this> = A::Buf<'this> where Self: 'this;
 
     #[inline(always)]
-    fn alloc(&self) -> Self::Buf {
+    fn alloc(&self) -> Self::Buf<'_> {
         self.alloc.alloc()
     }
 
@@ -224,10 +224,10 @@ where
     type Input = E;
     type Error = Error;
     type Mark = ();
-    type Buf = A::Buf;
+    type Buf<'this> = A::Buf<'this> where Self: 'this;
 
     #[inline(always)]
-    fn alloc(&self) -> Self::Buf {
+    fn alloc(&self) -> Self::Buf<'_> {
         self.alloc.alloc()
     }
 

--- a/crates/musli-common/src/context/access.rs
+++ b/crates/musli-common/src/context/access.rs
@@ -1,0 +1,69 @@
+use core::cell::Cell;
+
+/// Guarded access to some underlying state.
+pub(crate) struct Access {
+    state: Cell<isize>,
+}
+
+impl Access {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: Cell::new(0),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn shared(&self) -> Shared<'_> {
+        let state = self.state.get();
+
+        if state > 0 {
+            panic!("Context is exclusively held")
+        }
+
+        if state == isize::MIN {
+            crate::system::abort();
+        }
+
+        self.state.set(state - 1);
+
+        Shared { access: self }
+    }
+
+    #[inline]
+    pub(crate) fn exclusive(&self) -> Exlusive<'_> {
+        let state = self.state.get();
+
+        if state != 0 {
+            panic!("Context is already in shared use")
+        }
+
+        if state == isize::MIN {
+            crate::system::abort();
+        }
+
+        self.state.set(1);
+        Exlusive { access: self }
+    }
+}
+
+/// A shared access to some underlying state.
+pub(crate) struct Shared<'a> {
+    access: &'a Access,
+}
+
+impl Drop for Shared<'_> {
+    fn drop(&mut self) {
+        self.access.state.set(self.access.state.get() + 1);
+    }
+}
+
+/// An exclusive access to some underlying state.
+pub(crate) struct Exlusive<'a> {
+    access: &'a Access,
+}
+
+impl Drop for Exlusive<'_> {
+    fn drop(&mut self) {
+        self.access.state.set(0);
+    }
+}

--- a/crates/musli-common/src/context/alloc_context.rs
+++ b/crates/musli-common/src/context/alloc_context.rs
@@ -106,7 +106,7 @@ where
     type Buf<'this> = A::Buf<'this> where Self: 'this;
 
     #[inline(always)]
-    fn alloc(&self) -> Self::Buf<'_> {
+    fn alloc(&self) -> Option<Self::Buf<'_>> {
         self.alloc.alloc()
     }
 

--- a/crates/musli-common/src/context/alloc_context.rs
+++ b/crates/musli-common/src/context/alloc_context.rs
@@ -103,10 +103,10 @@ where
     type Input = E;
     type Error = Error;
     type Mark = usize;
-    type Buf = A::Buf;
+    type Buf<'this> = A::Buf<'this> where Self: 'this;
 
     #[inline(always)]
-    fn alloc(&self) -> Self::Buf {
+    fn alloc(&self) -> Self::Buf<'_> {
         self.alloc.alloc()
     }
 

--- a/crates/musli-common/src/context/no_std_context.rs
+++ b/crates/musli-common/src/context/no_std_context.rs
@@ -286,7 +286,7 @@ impl<'a, const S: usize, E: 'a> Iterator for Errors<'a, S, E> {
         let (range, error) = self.error.take()?;
 
         Some(RichError::new(
-            &self.path,
+            self.path,
             self.path_cap,
             range.clone(),
             error,

--- a/crates/musli-common/src/context/no_std_context.rs
+++ b/crates/musli-common/src/context/no_std_context.rs
@@ -125,7 +125,7 @@ where
     type Buf<'this> = A::Buf<'this> where Self: 'this;
 
     #[inline(always)]
-    fn alloc(&self) -> Self::Buf<'_> {
+    fn alloc(&self) -> Option<Self::Buf<'_>> {
         self.alloc.alloc()
     }
 

--- a/crates/musli-common/src/context/no_std_context.rs
+++ b/crates/musli-common/src/context/no_std_context.rs
@@ -122,10 +122,10 @@ where
     type Input = E;
     type Error = Error;
     type Mark = usize;
-    type Buf = A::Buf;
+    type Buf<'this> = A::Buf<'this> where Self: 'this;
 
     #[inline(always)]
-    fn alloc(&self) -> Self::Buf {
+    fn alloc(&self) -> Self::Buf<'_> {
         self.alloc.alloc()
     }
 

--- a/crates/musli-common/src/fixed.rs
+++ b/crates/musli-common/src/fixed.rs
@@ -34,11 +34,6 @@ impl<T, const N: usize> FixedVec<T, N> {
     }
 
     #[inline]
-    pub(crate) fn capacity(&self) -> usize {
-        N
-    }
-
-    #[inline]
     pub(crate) unsafe fn set_len(&mut self, len: usize) {
         self.len = len;
     }

--- a/crates/musli-common/src/fixed.rs
+++ b/crates/musli-common/src/fixed.rs
@@ -13,7 +13,7 @@ use core::str;
 #[non_exhaustive]
 pub(crate) struct CapacityError;
 
-pub(crate) struct FixedVec<T, const N: usize> {
+pub struct FixedVec<T, const N: usize> {
     data: [MaybeUninit<T>; N],
     len: usize,
 }
@@ -26,16 +26,6 @@ impl<T, const N: usize> FixedVec<T, N> {
                 len: 0,
             }
         }
-    }
-
-    #[inline]
-    pub(crate) fn len(&self) -> usize {
-        self.len
-    }
-
-    #[inline]
-    pub(crate) unsafe fn set_len(&mut self, len: usize) {
-        self.len = len;
     }
 
     #[inline]
@@ -54,8 +44,18 @@ impl<T, const N: usize> FixedVec<T, N> {
     }
 
     #[inline]
+    pub(crate) fn as_uninit_slice(&self) -> &[MaybeUninit<T>] {
+        unsafe { slice::from_raw_parts(self.data.as_ptr(), N) }
+    }
+
+    #[inline]
     pub(crate) fn as_mut_slice(&mut self) -> &mut [T] {
         unsafe { slice::from_raw_parts_mut(self.as_mut_ptr(), self.len) }
+    }
+
+    #[inline]
+    pub(crate) fn as_mut_uninit_slice(&mut self) -> &mut [MaybeUninit<T>] {
+        unsafe { slice::from_raw_parts_mut(self.data.as_mut_ptr(), N) }
     }
 
     pub(crate) fn try_extend_from_slice(&mut self, other: &[T]) -> Result<(), CapacityError>

--- a/crates/musli-common/src/fixed.rs
+++ b/crates/musli-common/src/fixed.rs
@@ -148,7 +148,7 @@ impl<T, const N: usize> Drop for FixedVec<T, N> {
 }
 
 /// A fixed capacity string.
-pub(crate) struct FixedString<const N: usize> {
+pub struct FixedString<const N: usize> {
     data: FixedVec<u8, N>,
 }
 

--- a/crates/musli-common/src/fixed_bytes.rs
+++ b/crates/musli-common/src/fixed_bytes.rs
@@ -156,7 +156,7 @@ impl<const N: usize> FixedBytes<N> {
 
     /// Try and extend from the given slice.
     #[inline]
-    pub fn write_bytes<C>(&mut self, cx: &mut C, source: &[u8]) -> Result<(), C::Error>
+    pub fn write_bytes<C>(&mut self, cx: &C, source: &[u8]) -> Result<(), C::Error>
     where
         C: Context<Input = FixedBytesOverflow>,
     {
@@ -189,7 +189,7 @@ impl<const N: usize> Writer for FixedBytes<N> {
     }
 
     #[inline]
-    fn write_buffer<C, B>(&mut self, cx: &mut C, buffer: B) -> Result<(), C::Error>
+    fn write_buffer<C, B>(&mut self, cx: &C, buffer: B) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
         B: Buffer,
@@ -199,7 +199,7 @@ impl<const N: usize> Writer for FixedBytes<N> {
     }
 
     #[inline]
-    fn write_bytes<C>(&mut self, cx: &mut C, bytes: &[u8]) -> Result<(), C::Error>
+    fn write_bytes<C>(&mut self, cx: &C, bytes: &[u8]) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {

--- a/crates/musli-common/src/fixed_bytes.rs
+++ b/crates/musli-common/src/fixed_bytes.rs
@@ -195,7 +195,7 @@ impl<const N: usize> Writer for FixedBytes<N> {
         B: Buffer,
     {
         // SAFETY: the buffer never outlives this function call.
-        self.write_bytes(cx, unsafe { buffer.as_slice() })
+        self.write_bytes(cx, buffer.as_slice())
     }
 
     #[inline]

--- a/crates/musli-common/src/int/continuation.rs
+++ b/crates/musli-common/src/int/continuation.rs
@@ -9,13 +9,13 @@
 //!
 //! let alloc = musli_common::allocator::Default::default();
 //!
-//! let mut cx: Ignore<_, FixedBytesOverflow> = Ignore::new(&alloc);
+//! let cx: Ignore<_, FixedBytesOverflow> = Ignore::new(&alloc);
 //! let mut bytes = FixedBytes::<8>::new();
-//! c::encode(&mut cx, &mut bytes, 5000u32).unwrap();
+//! c::encode(&cx, &mut bytes, 5000u32).unwrap();
 //! assert_eq!(bytes.as_slice(), &[0b1000_1000, 0b0010_0111]);
 //!
-//! let mut cx: Ignore<_, SliceUnderflow> = Ignore::new(&alloc);
-//! let number: u32 = c::decode(&mut cx, bytes.as_slice()).unwrap();
+//! let cx: Ignore<_, SliceUnderflow> = Ignore::new(&alloc);
+//! let number: u32 = c::decode(&cx, bytes.as_slice()).unwrap();
 //! assert_eq!(number, 5000u32);
 //! ```
 

--- a/crates/musli-common/src/int/continuation.rs
+++ b/crates/musli-common/src/int/continuation.rs
@@ -7,7 +7,8 @@
 //! use musli_common::int::continuation as c;
 //! use musli_common::reader::SliceUnderflow;
 //!
-//! let alloc = musli_common::allocator::Default::default();
+//! let mut buf = musli_common::allocator::buffer();
+//! let alloc = musli_common::allocator::new(&mut buf);
 //!
 //! let cx: Ignore<_, FixedBytesOverflow> = Ignore::new(&alloc);
 //! let mut bytes = FixedBytes::<8>::new();

--- a/crates/musli-common/src/int/continuation.rs
+++ b/crates/musli-common/src/int/continuation.rs
@@ -36,7 +36,7 @@ const CONT_BYTE: u8 = 0b1000_0000;
 
 /// Decode the given length using variable int encoding.
 #[inline(never)]
-pub fn decode<'de, C, R, T>(cx: &mut C, mut r: R) -> Result<T, C::Error>
+pub fn decode<'de, C, R, T>(cx: &C, mut r: R) -> Result<T, C::Error>
 where
     C: Context<Input = R::Error>,
     R: Reader<'de>,
@@ -67,7 +67,7 @@ where
 
 /// Encode the given length using variable length encoding.
 #[inline(never)]
-pub fn encode<C, W, T>(cx: &mut C, mut w: W, mut value: T) -> Result<(), C::Error>
+pub fn encode<C, W, T>(cx: &C, mut w: W, mut value: T) -> Result<(), C::Error>
 where
     C: Context<Input = W::Error>,
     W: Writer,

--- a/crates/musli-common/src/int/encoding.rs
+++ b/crates/musli-common/src/int/encoding.rs
@@ -10,7 +10,7 @@ use crate::writer::Writer;
 /// Governs how unsigned integers are encoded into a [Writer].
 #[inline]
 pub fn encode_unsigned<C, W, T, const F: Options>(
-    cx: &mut C,
+    cx: &C,
     writer: W,
     value: T,
 ) -> Result<(), C::Error>
@@ -32,7 +32,7 @@ where
 /// passed in through `F`.
 #[inline]
 pub fn decode_unsigned<'de, C, R, T: UnsignedOps, const F: Options>(
-    cx: &mut C,
+    cx: &C,
     reader: R,
 ) -> Result<T, C::Error>
 where
@@ -51,11 +51,7 @@ where
 
 /// Governs how signed integers are encoded into a [Writer].
 #[inline]
-pub fn encode_signed<C, W, T, const F: Options>(
-    cx: &mut C,
-    writer: W,
-    value: T,
-) -> Result<(), C::Error>
+pub fn encode_signed<C, W, T, const F: Options>(cx: &C, writer: W, value: T) -> Result<(), C::Error>
 where
     C: Context<Input = W::Error>,
     W: Writer,
@@ -73,7 +69,7 @@ where
 
 /// Governs how signed integers are decoded from a [Reader].
 #[inline]
-pub fn decode_signed<'de, C, R, T, const F: Options>(cx: &mut C, reader: R) -> Result<T, C::Error>
+pub fn decode_signed<'de, C, R, T, const F: Options>(cx: &C, reader: R) -> Result<T, C::Error>
 where
     C: Context<Input = R::Error>,
     R: Reader<'de>,
@@ -94,11 +90,7 @@ where
 
 /// Governs how usize lengths are encoded into a [Writer].
 #[inline]
-pub fn encode_usize<C, W, const F: Options>(
-    cx: &mut C,
-    writer: W,
-    value: usize,
-) -> Result<(), C::Error>
+pub fn encode_usize<C, W, const F: Options>(cx: &C, writer: W, value: usize) -> Result<(), C::Error>
 where
     C: Context<Input = W::Error>,
     W: Writer,
@@ -124,7 +116,7 @@ where
 
 /// Governs how usize lengths are decoded from a [Reader].
 #[inline]
-pub fn decode_usize<'de, C, R, const F: Options>(cx: &mut C, reader: R) -> Result<usize, C::Error>
+pub fn decode_usize<'de, C, R, const F: Options>(cx: &C, reader: R) -> Result<usize, C::Error>
 where
     C: Context<Input = R::Error>,
     R: Reader<'de>,

--- a/crates/musli-common/src/int/tests.rs
+++ b/crates/musli-common/src/int/tests.rs
@@ -22,13 +22,13 @@ fn test_continuation_encoding() {
     {
         let mut out = Vec::new();
         let alloc = Alloc::default();
-        let mut cx = crate::context::Ignore::new(&alloc);
-        c::encode(&mut cx, &mut out, expected).unwrap();
-        c::encode(&mut cx, &mut out, expected).unwrap();
+        let cx = crate::context::Ignore::new(&alloc);
+        c::encode(&cx, &mut out, expected).unwrap();
+        c::encode(&cx, &mut out, expected).unwrap();
         let mut data = out.as_slice();
-        let mut cx = context::Ignore::new(&alloc);
-        let a: T = c::decode(&mut cx, &mut data).unwrap();
-        let b: T = c::decode(&mut cx, &mut data).unwrap();
+        let cx = context::Ignore::new(&alloc);
+        let a: T = c::decode(&cx, &mut data).unwrap();
+        let b: T = c::decode(&cx, &mut data).unwrap();
         assert!(data.is_empty());
         assert_eq!(a, expected);
         assert_eq!(b, expected);
@@ -40,8 +40,8 @@ fn test_continuation_encoding() {
     {
         let mut out = Vec::new();
         let alloc = Alloc::default();
-        let mut cx = crate::context::Same::new(&alloc);
-        c::encode(&mut cx, crate::wrap::wrap(&mut out), value).unwrap();
+        let cx = crate::context::Same::new(&alloc);
+        c::encode(&cx, crate::wrap::wrap(&mut out), value).unwrap();
         out
     }
 

--- a/crates/musli-common/src/int/tests.rs
+++ b/crates/musli-common/src/int/tests.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::vec::Vec;
 
-use crate::allocator::Alloc;
+use crate::allocator;
 use crate::context;
 use crate::int::continuation as c;
 use crate::int::zigzag as zig;
@@ -21,7 +21,8 @@ fn test_continuation_encoding() {
         T: PartialEq<T> + fmt::Debug + Unsigned,
     {
         let mut out = Vec::new();
-        let alloc = Alloc::default();
+        let mut buf = allocator::buffer();
+        let alloc = allocator::new(&mut buf);
         let cx = crate::context::Ignore::new(&alloc);
         c::encode(&cx, &mut out, expected).unwrap();
         c::encode(&cx, &mut out, expected).unwrap();
@@ -39,7 +40,8 @@ fn test_continuation_encoding() {
         T: Unsigned,
     {
         let mut out = Vec::new();
-        let alloc = Alloc::default();
+        let mut buf = allocator::buffer();
+        let alloc = allocator::new(&mut buf);
         let cx = crate::context::Same::new(&alloc);
         c::encode(&cx, crate::wrap::wrap(&mut out), value).unwrap();
         out

--- a/crates/musli-common/src/int/traits.rs
+++ b/crates/musli-common/src/int/traits.rs
@@ -62,22 +62,13 @@ pub trait Unsigned:
 pub trait UnsignedOps: Unsigned {
     /// Write the current byte array to the given writer in little-endian
     /// encoding.
-    fn write_bytes<C, W>(
-        self,
-        cx: &mut C,
-        writer: W,
-        byte_order: ByteOrder,
-    ) -> Result<(), C::Error>
+    fn write_bytes<C, W>(self, cx: &C, writer: W, byte_order: ByteOrder) -> Result<(), C::Error>
     where
         C: Context<Input = W::Error>,
         W: Writer;
 
     /// Read the current value from the reader in little-endian encoding.
-    fn read_bytes<'de, C, R>(
-        cx: &mut C,
-        reader: R,
-        byte_order: ByteOrder,
-    ) -> Result<Self, C::Error>
+    fn read_bytes<'de, C, R>(cx: &C, reader: R, byte_order: ByteOrder) -> Result<Self, C::Error>
     where
         C: Context<Input = R::Error>,
         R: Reader<'de>;
@@ -181,7 +172,7 @@ macro_rules! implement_ops {
             #[inline(always)]
             fn write_bytes<C, W>(
                 self,
-                cx: &mut C,
+                cx: &C,
                 mut writer: W,
                 byte_order: ByteOrder,
             ) -> Result<(), C::Error>
@@ -200,7 +191,7 @@ macro_rules! implement_ops {
 
             #[inline(always)]
             fn read_bytes<'de, C, R>(
-                cx: &mut C,
+                cx: &C,
                 mut reader: R,
                 byte_order: ByteOrder,
             ) -> Result<Self, C::Error>

--- a/crates/musli-common/src/lib.rs
+++ b/crates/musli-common/src/lib.rs
@@ -38,3 +38,7 @@ pub mod writer;
 
 #[macro_use]
 mod macros;
+
+#[cfg_attr(feature = "std", path = "system/std.rs")]
+#[cfg_attr(not(feature = "std"), path = "system/nostd.rs")]
+mod system;

--- a/crates/musli-common/src/lib.rs
+++ b/crates/musli-common/src/lib.rs
@@ -13,6 +13,7 @@
 //! [Reader]: https://docs.rs/musli-common/latest/musli-common/reader/trait.Reader.html
 //! [Writer]: https://docs.rs/musli-common/latest/musli-common/writer/trait.Writer.html
 
+#![allow(clippy::type_complexity)]
 #![deny(missing_docs)]
 #![no_std]
 

--- a/crates/musli-common/src/macros.rs
+++ b/crates/musli-common/src/macros.rs
@@ -49,7 +49,7 @@ macro_rules! encode_with_extensions {
         /// configurable [`Context`].
         #[cfg(feature = "alloc")]
         #[inline]
-        pub fn to_vec_with<C, T>(self, cx: &mut C, value: &T) -> Result<Vec<u8>, C::Error>
+        pub fn to_vec_with<C, T>(self, cx: &C, value: &T) -> Result<Vec<u8>, C::Error>
         where
             C: Context<Input = Error>,
             T: ?Sized + Encode<M>,
@@ -76,7 +76,7 @@ macro_rules! encode_with_extensions {
         #[inline]
         pub fn to_fixed_bytes_with<C, const N: usize, T>(
             self,
-            cx: &mut C,
+            cx: &C,
             value: &T,
         ) -> Result<FixedBytes<N>, C::Error>
         where
@@ -114,7 +114,7 @@ macro_rules! encoding_from_slice_impls {
         /// This is the same as [`Encoding::from_slice`], but allows for using a
         /// configurable [`Context`].
         #[inline]
-        pub fn from_slice_with<'de, C, T>(self, cx: &mut C, bytes: &'de [u8]) -> Result<T, C::Error>
+        pub fn from_slice_with<'de, C, T>(self, cx: &C, bytes: &'de [u8]) -> Result<T, C::Error>
         where
             C: Context<Input = Error>,
             T: Decode<'de, M>,
@@ -136,7 +136,7 @@ macro_rules! encoding_impls {
         /// This is the same as [`Encoding::encode`] but allows for using a
         /// configurable [`Context`].
         #[inline]
-        pub fn encode_with<C, W, T>(self, cx: &mut C, writer: W, value: &T) -> Result<(), C::Error>
+        pub fn encode_with<C, W, T>(self, cx: &C, writer: W, value: &T) -> Result<(), C::Error>
         where
             C: Context<Input = Error>,
             W: Writer,
@@ -152,7 +152,7 @@ macro_rules! encoding_impls {
         /// This is the same as [`Encoding::decode`] but allows for using a
         /// configurable [`Context`].
         #[inline]
-        pub fn decode_with<'de, C, R, T>(self, cx: &mut C, reader: R) -> Result<T, C::Error>
+        pub fn decode_with<'de, C, R, T>(self, cx: &C, reader: R) -> Result<T, C::Error>
         where
             C: Context<Input = Error>,
             R: Reader<'de>,

--- a/crates/musli-common/src/macros.rs
+++ b/crates/musli-common/src/macros.rs
@@ -12,7 +12,8 @@ macro_rules! encode_with_extensions {
             Error: From<W::Error>,
             T: ?Sized + Encode<M>,
         {
-            let alloc = musli_common::allocator::Default::default();
+            let mut buf = musli_common::allocator::buffer();
+            let alloc = musli_common::allocator::new(&mut buf);
             let cx = musli_common::context::Same::new(&alloc);
             self.encode_with(&cx, writer, value)
         }
@@ -66,7 +67,8 @@ macro_rules! encode_with_extensions {
         where
             T: ?Sized + Encode<M>,
         {
-            let alloc = musli_common::allocator::Default::default();
+            let mut buf = musli_common::allocator::buffer();
+            let alloc = musli_common::allocator::new(&mut buf);
             let cx = musli_common::context::Same::new(&alloc);
             self.to_fixed_bytes_with(&cx, value)
         }
@@ -102,7 +104,8 @@ macro_rules! encoding_from_slice_impls {
         where
             T: Decode<'de, M>,
         {
-            let alloc = musli_common::allocator::Default::default();
+            let mut buf = musli_common::allocator::buffer();
+            let alloc = musli_common::allocator::new(&mut buf);
             let cx = musli_common::context::Same::new(&alloc);
             let reader = SliceReader::new(bytes);
             T::decode(&cx, $decoder_new(reader))
@@ -171,7 +174,8 @@ macro_rules! encoding_impls {
             Error: From<R::Error>,
             T: Decode<'de, M>,
         {
-            let alloc = musli_common::allocator::Default::default();
+            let mut buf = musli_common::allocator::buffer();
+            let alloc = musli_common::allocator::new(&mut buf);
             let cx = musli_common::context::Same::new(&alloc);
             self.decode_with(&cx, reader)
         }

--- a/crates/musli-common/src/macros.rs
+++ b/crates/musli-common/src/macros.rs
@@ -13,8 +13,8 @@ macro_rules! encode_with_extensions {
             T: ?Sized + Encode<M>,
         {
             let alloc = musli_common::allocator::Default::default();
-            let mut cx = musli_common::context::Same::new(&alloc);
-            self.encode_with(&mut cx, writer, value)
+            let cx = musli_common::context::Same::new(&alloc);
+            self.encode_with(&cx, writer, value)
         }
 
         /// Encode the given value to the given [Write][io::Write] using the current
@@ -67,8 +67,8 @@ macro_rules! encode_with_extensions {
             T: ?Sized + Encode<M>,
         {
             let alloc = musli_common::allocator::Default::default();
-            let mut cx = musli_common::context::Same::new(&alloc);
-            self.to_fixed_bytes_with(&mut cx, value)
+            let cx = musli_common::context::Same::new(&alloc);
+            self.to_fixed_bytes_with(&cx, value)
         }
 
         /// Encode the given value to a fixed-size bytes using the current
@@ -103,9 +103,9 @@ macro_rules! encoding_from_slice_impls {
             T: Decode<'de, M>,
         {
             let alloc = musli_common::allocator::Default::default();
-            let mut cx = musli_common::context::Same::new(&alloc);
+            let cx = musli_common::context::Same::new(&alloc);
             let reader = SliceReader::new(bytes);
-            T::decode(&mut cx, $decoder_new(reader))
+            T::decode(&cx, $decoder_new(reader))
         }
 
         /// Decode the given type `T` from the given slice using the current
@@ -172,8 +172,8 @@ macro_rules! encoding_impls {
             T: Decode<'de, M>,
         {
             let alloc = musli_common::allocator::Default::default();
-            let mut cx = musli_common::context::Same::new(&alloc);
-            self.decode_with(&mut cx, reader)
+            let cx = musli_common::context::Same::new(&alloc);
+            self.decode_with(&cx, reader)
         }
 
         $crate::encode_with_extensions!();

--- a/crates/musli-common/src/reader.rs
+++ b/crates/musli-common/src/reader.rs
@@ -57,18 +57,18 @@ pub trait Reader<'de> {
     fn borrow_mut(&mut self) -> Self::Mut<'_>;
 
     /// Skip over the given number of bytes.
-    fn skip<C>(&mut self, cx: &mut C, n: usize) -> Result<(), C::Error>
+    fn skip<C>(&mut self, cx: &C, n: usize) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>;
 
     /// Peek the next value.
-    fn peek<C>(&mut self, cx: &mut C) -> Result<Option<u8>, C::Error>
+    fn peek<C>(&mut self, cx: &C) -> Result<Option<u8>, C::Error>
     where
         C: Context<Input = Self::Error>;
 
     /// Read a slice into the given buffer.
     #[inline]
-    fn read<C>(&mut self, cx: &mut C, buf: &mut [u8]) -> Result<(), C::Error>
+    fn read<C>(&mut self, cx: &C, buf: &mut [u8]) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -86,12 +86,12 @@ pub trait Reader<'de> {
             }
 
             #[inline]
-            fn visit_borrowed(self, cx: &mut C, bytes: &'de [u8]) -> Result<Self::Ok, C::Error> {
+            fn visit_borrowed(self, cx: &C, bytes: &'de [u8]) -> Result<Self::Ok, C::Error> {
                 self.visit_ref(cx, bytes)
             }
 
             #[inline]
-            fn visit_ref(self, _: &mut C, bytes: &[u8]) -> Result<Self::Ok, C::Error> {
+            fn visit_ref(self, _: &C, bytes: &[u8]) -> Result<Self::Ok, C::Error> {
                 self.0.copy_from_slice(bytes);
                 Ok(())
             }
@@ -101,7 +101,7 @@ pub trait Reader<'de> {
     }
 
     /// Read a slice out of the current reader.
-    fn read_bytes<C, V>(&mut self, cx: &mut C, n: usize, visitor: V) -> Result<V::Ok, C::Error>
+    fn read_bytes<C, V>(&mut self, cx: &C, n: usize, visitor: V) -> Result<V::Ok, C::Error>
     where
         C: Context,
         C::Input: From<Self::Error>,
@@ -109,7 +109,7 @@ pub trait Reader<'de> {
 
     /// Read a single byte.
     #[inline]
-    fn read_byte<C>(&mut self, cx: &mut C) -> Result<u8, C::Error>
+    fn read_byte<C>(&mut self, cx: &C) -> Result<u8, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -119,7 +119,7 @@ pub trait Reader<'de> {
 
     /// Read an array out of the current reader.
     #[inline]
-    fn read_array<C, const N: usize>(&mut self, cx: &mut C) -> Result<[u8; N], C::Error>
+    fn read_array<C, const N: usize>(&mut self, cx: &C) -> Result<[u8; N], C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -137,12 +137,12 @@ pub trait Reader<'de> {
             }
 
             #[inline]
-            fn visit_borrowed(self, cx: &mut C, bytes: &'de [u8]) -> Result<Self::Ok, C::Error> {
+            fn visit_borrowed(self, cx: &C, bytes: &'de [u8]) -> Result<Self::Ok, C::Error> {
                 self.visit_ref(cx, bytes)
             }
 
             #[inline]
-            fn visit_ref(mut self, cx: &mut C, bytes: &[u8]) -> Result<Self::Ok, C::Error> {
+            fn visit_ref(mut self, cx: &C, bytes: &[u8]) -> Result<Self::Ok, C::Error> {
                 self.0.copy_from_slice(bytes);
                 cx.advance(bytes.len());
                 Ok(self.0)
@@ -174,7 +174,7 @@ impl<'de> Reader<'de> for &'de [u8] {
     }
 
     #[inline]
-    fn skip<C>(&mut self, cx: &mut C, n: usize) -> Result<(), C::Error>
+    fn skip<C>(&mut self, cx: &C, n: usize) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -192,7 +192,7 @@ impl<'de> Reader<'de> for &'de [u8] {
     }
 
     #[inline]
-    fn read<C>(&mut self, cx: &mut C, buf: &mut [u8]) -> Result<(), C::Error>
+    fn read<C>(&mut self, cx: &C, buf: &mut [u8]) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -208,7 +208,7 @@ impl<'de> Reader<'de> for &'de [u8] {
     }
 
     #[inline]
-    fn read_bytes<C, V>(&mut self, cx: &mut C, n: usize, visitor: V) -> Result<V::Ok, C::Error>
+    fn read_bytes<C, V>(&mut self, cx: &C, n: usize, visitor: V) -> Result<V::Ok, C::Error>
     where
         C: Context,
         C::Input: From<Self::Error>,
@@ -226,7 +226,7 @@ impl<'de> Reader<'de> for &'de [u8] {
     }
 
     #[inline]
-    fn read_byte<C>(&mut self, cx: &mut C) -> Result<u8, C::Error>
+    fn read_byte<C>(&mut self, cx: &C) -> Result<u8, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -240,7 +240,7 @@ impl<'de> Reader<'de> for &'de [u8] {
     }
 
     #[inline]
-    fn read_array<C, const N: usize>(&mut self, cx: &mut C) -> Result<[u8; N], C::Error>
+    fn read_array<C, const N: usize>(&mut self, cx: &C) -> Result<[u8; N], C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -255,7 +255,7 @@ impl<'de> Reader<'de> for &'de [u8] {
     }
 
     #[inline]
-    fn peek<C>(&mut self, _: &mut C) -> Result<Option<u8>, C::Error>
+    fn peek<C>(&mut self, _: &C) -> Result<Option<u8>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -290,7 +290,7 @@ impl<'de> Reader<'de> for SliceReader<'de> {
     }
 
     #[inline]
-    fn skip<C>(&mut self, cx: &mut C, n: usize) -> Result<(), C::Error>
+    fn skip<C>(&mut self, cx: &C, n: usize) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -300,7 +300,7 @@ impl<'de> Reader<'de> for SliceReader<'de> {
     }
 
     #[inline]
-    fn read_bytes<C, V>(&mut self, cx: &mut C, n: usize, visitor: V) -> Result<V::Ok, C::Error>
+    fn read_bytes<C, V>(&mut self, cx: &C, n: usize, visitor: V) -> Result<V::Ok, C::Error>
     where
         C: Context,
         C::Input: From<Self::Error>,
@@ -319,7 +319,7 @@ impl<'de> Reader<'de> for SliceReader<'de> {
     }
 
     #[inline]
-    fn peek<C>(&mut self, _: &mut C) -> Result<Option<u8>, C::Error>
+    fn peek<C>(&mut self, _: &C) -> Result<Option<u8>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -332,7 +332,7 @@ impl<'de> Reader<'de> for SliceReader<'de> {
     }
 
     #[inline]
-    fn read<C>(&mut self, cx: &mut C, buf: &mut [u8]) -> Result<(), C::Error>
+    fn read<C>(&mut self, cx: &C, buf: &mut [u8]) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -349,11 +349,7 @@ impl<'de> Reader<'de> for SliceReader<'de> {
 }
 
 #[inline]
-fn bounds_check_add<C>(
-    cx: &mut C,
-    range: &Range<*const u8>,
-    len: usize,
-) -> Result<*const u8, C::Error>
+fn bounds_check_add<C>(cx: &C, range: &Range<*const u8>, len: usize) -> Result<*const u8, C::Error>
 where
     C: Context,
     C::Input: From<SliceUnderflow>,
@@ -389,7 +385,7 @@ impl<'de, R> Limit<R>
 where
     R: Reader<'de>,
 {
-    fn bounds_check<C>(&mut self, cx: &mut C, n: usize) -> Result<(), C::Error>
+    fn bounds_check<C>(&mut self, cx: &C, n: usize) -> Result<(), C::Error>
     where
         C: Context,
         C::Input: From<R::Error>,
@@ -418,7 +414,7 @@ where
     }
 
     #[inline]
-    fn skip<C>(&mut self, cx: &mut C, n: usize) -> Result<(), C::Error>
+    fn skip<C>(&mut self, cx: &C, n: usize) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -427,7 +423,7 @@ where
     }
 
     #[inline]
-    fn read_bytes<C, V>(&mut self, cx: &mut C, n: usize, visitor: V) -> Result<V::Ok, C::Error>
+    fn read_bytes<C, V>(&mut self, cx: &C, n: usize, visitor: V) -> Result<V::Ok, C::Error>
     where
         C: Context,
         C::Input: From<Self::Error>,
@@ -438,7 +434,7 @@ where
     }
 
     #[inline]
-    fn peek<C>(&mut self, cx: &mut C) -> Result<Option<u8>, C::Error>
+    fn peek<C>(&mut self, cx: &C) -> Result<Option<u8>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -446,7 +442,7 @@ where
     }
 
     #[inline]
-    fn read<C>(&mut self, cx: &mut C, buf: &mut [u8]) -> Result<(), C::Error>
+    fn read<C>(&mut self, cx: &C, buf: &mut [u8]) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -455,7 +451,7 @@ where
     }
 
     #[inline]
-    fn read_byte<C>(&mut self, cx: &mut C) -> Result<u8, C::Error>
+    fn read_byte<C>(&mut self, cx: &C) -> Result<u8, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -464,7 +460,7 @@ where
     }
 
     #[inline]
-    fn read_array<C, const N: usize>(&mut self, cx: &mut C) -> Result<[u8; N], C::Error>
+    fn read_array<C, const N: usize>(&mut self, cx: &C) -> Result<[u8; N], C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -489,7 +485,7 @@ where
     }
 
     #[inline]
-    fn skip<C>(&mut self, cx: &mut C, n: usize) -> Result<(), C::Error>
+    fn skip<C>(&mut self, cx: &C, n: usize) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -497,7 +493,7 @@ where
     }
 
     #[inline]
-    fn read_bytes<C, V>(&mut self, cx: &mut C, n: usize, visitor: V) -> Result<V::Ok, C::Error>
+    fn read_bytes<C, V>(&mut self, cx: &C, n: usize, visitor: V) -> Result<V::Ok, C::Error>
     where
         C: Context,
         C::Input: From<Self::Error>,
@@ -507,7 +503,7 @@ where
     }
 
     #[inline]
-    fn peek<C>(&mut self, cx: &mut C) -> Result<Option<u8>, C::Error>
+    fn peek<C>(&mut self, cx: &C) -> Result<Option<u8>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -515,7 +511,7 @@ where
     }
 
     #[inline]
-    fn read<C>(&mut self, cx: &mut C, buf: &mut [u8]) -> Result<(), C::Error>
+    fn read<C>(&mut self, cx: &C, buf: &mut [u8]) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -523,7 +519,7 @@ where
     }
 
     #[inline]
-    fn read_byte<C>(&mut self, cx: &mut C) -> Result<u8, C::Error>
+    fn read_byte<C>(&mut self, cx: &C) -> Result<u8, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -531,7 +527,7 @@ where
     }
 
     #[inline]
-    fn read_array<C, const N: usize>(&mut self, cx: &mut C) -> Result<[u8; N], C::Error>
+    fn read_array<C, const N: usize>(&mut self, cx: &C) -> Result<[u8; N], C::Error>
     where
         C: Context<Input = Self::Error>,
     {

--- a/crates/musli-common/src/reader.rs
+++ b/crates/musli-common/src/reader.rs
@@ -38,7 +38,7 @@ impl fmt::Display for SliceUnderflow {
 /// byte source through [Reader::read_bytes].
 pub trait Reader<'de> {
     /// Error type raised by the current reader.
-    type Error;
+    type Error: 'static;
 
     /// Type borrowed from self.
     ///

--- a/crates/musli-common/src/system/nostd.rs
+++ b/crates/musli-common/src/system/nostd.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::empty_loop)]
 pub(crate) fn abort() -> ! {
     loop {}
 }

--- a/crates/musli-common/src/system/nostd.rs
+++ b/crates/musli-common/src/system/nostd.rs
@@ -1,3 +1,4 @@
+// TODO: Make use of core::abort intrinsics when they are available.
 #[allow(clippy::empty_loop)]
 pub(crate) fn abort() -> ! {
     loop {}

--- a/crates/musli-common/src/system/nostd.rs
+++ b/crates/musli-common/src/system/nostd.rs
@@ -1,0 +1,3 @@
+pub(crate) fn abort() -> ! {
+    loop {}
+}

--- a/crates/musli-common/src/system/std.rs
+++ b/crates/musli-common/src/system/std.rs
@@ -1,0 +1,1 @@
+pub(crate) use ::std::process::abort;

--- a/crates/musli-common/src/wrap.rs
+++ b/crates/musli-common/src/wrap.rs
@@ -43,7 +43,7 @@ where
         B: Buffer,
     {
         // SAFETY: the buffer never outlives this function call.
-        self.write_bytes(cx, unsafe { buffer.as_slice() })
+        self.write_bytes(cx, buffer.as_slice())
     }
 
     #[inline]

--- a/crates/musli-common/src/wrap.rs
+++ b/crates/musli-common/src/wrap.rs
@@ -37,7 +37,7 @@ where
     }
 
     #[inline]
-    fn write_buffer<C, B>(&mut self, cx: &mut C, buffer: B) -> Result<(), C::Error>
+    fn write_buffer<C, B>(&mut self, cx: &C, buffer: B) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
         B: Buffer,
@@ -47,7 +47,7 @@ where
     }
 
     #[inline]
-    fn write_bytes<C>(&mut self, cx: &mut C, bytes: &[u8]) -> Result<(), C::Error>
+    fn write_bytes<C>(&mut self, cx: &C, bytes: &[u8]) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {

--- a/crates/musli-common/src/writer.rs
+++ b/crates/musli-common/src/writer.rs
@@ -58,19 +58,19 @@ pub trait Writer {
     fn borrow_mut(&mut self) -> Self::Mut<'_>;
 
     /// Write a buffer to the current writer.
-    fn write_buffer<C, B>(&mut self, cx: &mut C, buffer: B) -> Result<(), C::Error>
+    fn write_buffer<C, B>(&mut self, cx: &C, buffer: B) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
         B: Buffer;
 
     /// Write bytes to the current writer.
-    fn write_bytes<C>(&mut self, cx: &mut C, bytes: &[u8]) -> Result<(), C::Error>
+    fn write_bytes<C>(&mut self, cx: &C, bytes: &[u8]) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>;
 
     /// Write a single byte.
     #[inline]
-    fn write_byte<C>(&mut self, cx: &mut C, b: u8) -> Result<(), C::Error>
+    fn write_byte<C>(&mut self, cx: &C, b: u8) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -91,7 +91,7 @@ where
     }
 
     #[inline]
-    fn write_buffer<C, B>(&mut self, cx: &mut C, buffer: B) -> Result<(), C::Error>
+    fn write_buffer<C, B>(&mut self, cx: &C, buffer: B) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
         B: Buffer,
@@ -100,7 +100,7 @@ where
     }
 
     #[inline]
-    fn write_bytes<C>(&mut self, cx: &mut C, bytes: &[u8]) -> Result<(), C::Error>
+    fn write_bytes<C>(&mut self, cx: &C, bytes: &[u8]) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -108,7 +108,7 @@ where
     }
 
     #[inline]
-    fn write_byte<C>(&mut self, cx: &mut C, b: u8) -> Result<(), C::Error>
+    fn write_byte<C>(&mut self, cx: &C, b: u8) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -127,7 +127,7 @@ impl Writer for Vec<u8> {
     }
 
     #[inline]
-    fn write_buffer<C, B>(&mut self, cx: &mut C, buffer: B) -> Result<(), C::Error>
+    fn write_buffer<C, B>(&mut self, cx: &C, buffer: B) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
         B: Buffer,
@@ -137,7 +137,7 @@ impl Writer for Vec<u8> {
     }
 
     #[inline]
-    fn write_bytes<C>(&mut self, cx: &mut C, bytes: &[u8]) -> Result<(), C::Error>
+    fn write_bytes<C>(&mut self, cx: &C, bytes: &[u8]) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -147,7 +147,7 @@ impl Writer for Vec<u8> {
     }
 
     #[inline]
-    fn write_byte<C>(&mut self, cx: &mut C, b: u8) -> Result<(), C::Error>
+    fn write_byte<C>(&mut self, cx: &C, b: u8) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -167,7 +167,7 @@ impl Writer for &mut [u8] {
     }
 
     #[inline]
-    fn write_buffer<C, B>(&mut self, cx: &mut C, buffer: B) -> Result<(), C::Error>
+    fn write_buffer<C, B>(&mut self, cx: &C, buffer: B) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
         B: Buffer,
@@ -177,7 +177,7 @@ impl Writer for &mut [u8] {
     }
 
     #[inline]
-    fn write_bytes<C>(&mut self, cx: &mut C, bytes: &[u8]) -> Result<(), C::Error>
+    fn write_bytes<C>(&mut self, cx: &C, bytes: &[u8]) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -196,7 +196,7 @@ impl Writer for &mut [u8] {
     }
 
     #[inline]
-    fn write_byte<C>(&mut self, cx: &mut C, b: u8) -> Result<(), C::Error>
+    fn write_byte<C>(&mut self, cx: &C, b: u8) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -250,7 +250,7 @@ where
     }
 
     #[inline(always)]
-    fn write_buffer<C, B>(&mut self, cx: &mut C, buffer: B) -> Result<(), C::Error>
+    fn write_buffer<C, B>(&mut self, cx: &C, buffer: B) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
         B: Buffer,
@@ -263,7 +263,7 @@ where
     }
 
     #[inline(always)]
-    fn write_bytes<C>(&mut self, cx: &mut C, bytes: &[u8]) -> Result<(), C::Error>
+    fn write_bytes<C>(&mut self, cx: &C, bytes: &[u8]) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {

--- a/crates/musli-common/src/writer.rs
+++ b/crates/musli-common/src/writer.rs
@@ -255,7 +255,7 @@ where
         C: Context<Input = Self::Error>,
         B: Buffer,
     {
-        if !self.buffer.copy_back(buffer) {
+        if !self.buffer.write(buffer.as_slice()) {
             return Err(cx.message("Buffer overflow"));
         }
 

--- a/crates/musli-common/src/writer.rs
+++ b/crates/musli-common/src/writer.rs
@@ -38,7 +38,7 @@ impl fmt::Display for SliceOverflow {
 /// The trait governing how a writer works.
 pub trait Writer {
     /// The error type raised by the writer.
-    type Error;
+    type Error: 'static;
 
     /// Reborrowed type.
     ///
@@ -133,7 +133,7 @@ impl Writer for Vec<u8> {
         B: Buffer,
     {
         // SAFETY: the buffer never outlives this function call.
-        self.write_bytes(cx, unsafe { buffer.as_slice() })
+        self.write_bytes(cx, buffer.as_slice())
     }
 
     #[inline]
@@ -173,7 +173,7 @@ impl Writer for &mut [u8] {
         B: Buffer,
     {
         // SAFETY: the buffer never outlives this function call.
-        self.write_bytes(cx, unsafe { buffer.as_slice() })
+        self.write_bytes(cx, buffer.as_slice())
     }
 
     #[inline]
@@ -234,7 +234,7 @@ impl<T, E> BufferWriter<T, E> {
     }
 }
 
-impl<T, E> Writer for BufferWriter<T, E>
+impl<T, E: 'static> Writer for BufferWriter<T, E>
 where
     T: Buffer,
 {

--- a/crates/musli-descriptive/Cargo.toml
+++ b/crates/musli-descriptive/Cargo.toml
@@ -3,7 +3,7 @@ name = "musli-descriptive"
 version = "0.0.96"
 authors = ["John-John Tedro <udoprog@tedro.se>"]
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.73"
 description = """
 A fully self-descriptive format for Müsli.
 """

--- a/crates/musli-descriptive/Cargo.toml
+++ b/crates/musli-descriptive/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["encoding"]
 
 [features]
 default = ["std", "simdutf8"]
-std = ["musli/std", "musli-common/std", "musli-storage/std", "alloc"]
+std = ["alloc", "musli/std", "musli-common/std", "musli-storage/std"]
 alloc = ["musli/alloc", "musli-common/alloc", "musli-storage/alloc"]
 test = []
 simdutf8 = ["musli-common/simdutf8"]

--- a/crates/musli-descriptive/src/de.rs
+++ b/crates/musli-descriptive/src/de.rs
@@ -47,7 +47,7 @@ where
     Error: From<R::Error>,
 {
     /// Skip over any sequences of values.
-    pub(crate) fn skip_any<C>(&mut self, cx: &mut C) -> Result<(), C::Error>
+    pub(crate) fn skip_any<C>(&mut self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -111,7 +111,7 @@ where
 
     // Standard function for decoding a pair sequence.
     #[inline]
-    fn shared_decode_map<C>(mut self, cx: &mut C) -> Result<RemainingSelfDecoder<R, F>, C::Error>
+    fn shared_decode_map<C>(mut self, cx: &C) -> Result<RemainingSelfDecoder<R, F>, C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -122,10 +122,7 @@ where
 
     // Standard function for decoding a pair sequence.
     #[inline]
-    fn shared_decode_sequence<C>(
-        mut self,
-        cx: &mut C,
-    ) -> Result<RemainingSelfDecoder<R, F>, C::Error>
+    fn shared_decode_sequence<C>(mut self, cx: &C) -> Result<RemainingSelfDecoder<R, F>, C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -136,7 +133,7 @@ where
 
     /// Decode the length of a prefix.
     #[inline]
-    fn decode_prefix<C>(&mut self, cx: &mut C, kind: Kind, mark: C::Mark) -> Result<usize, C::Error>
+    fn decode_prefix<C>(&mut self, cx: &C, kind: Kind, mark: C::Mark) -> Result<usize, C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -161,7 +158,7 @@ where
 
     /// Decode the length of a prefix.
     #[inline]
-    fn decode_pack_length<C>(&mut self, cx: &mut C, start: C::Mark) -> Result<usize, C::Error>
+    fn decode_pack_length<C>(&mut self, cx: &C, start: C::Mark) -> Result<usize, C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -216,7 +213,7 @@ where
     }
 
     #[inline]
-    fn type_hint<C>(&mut self, cx: &mut C) -> Result<TypeHint, C::Error>
+    fn type_hint<C>(&mut self, cx: &C) -> Result<TypeHint, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -282,7 +279,7 @@ where
     }
 
     #[inline]
-    fn decode_unit<C>(mut self, cx: &mut C) -> Result<(), C::Error>
+    fn decode_unit<C>(mut self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -291,7 +288,7 @@ where
     }
 
     #[inline]
-    fn decode_pack<C>(mut self, cx: &mut C) -> Result<Self::Pack, C::Error>
+    fn decode_pack<C>(mut self, cx: &C) -> Result<Self::Pack, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -301,7 +298,7 @@ where
     }
 
     #[inline]
-    fn decode_array<C, const N: usize>(mut self, cx: &mut C) -> Result<[u8; N], C::Error>
+    fn decode_array<C, const N: usize>(mut self, cx: &C) -> Result<[u8; N], C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -321,7 +318,7 @@ where
     }
 
     #[inline]
-    fn decode_bytes<C, V>(mut self, cx: &mut C, visitor: V) -> Result<V::Ok, C::Error>
+    fn decode_bytes<C, V>(mut self, cx: &C, visitor: V) -> Result<V::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
         V: ValueVisitor<'de, C, [u8]>,
@@ -332,7 +329,7 @@ where
     }
 
     #[inline]
-    fn decode_string<C, V>(mut self, cx: &mut C, visitor: V) -> Result<V::Ok, C::Error>
+    fn decode_string<C, V>(mut self, cx: &C, visitor: V) -> Result<V::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
         V: ValueVisitor<'de, C, str>,
@@ -353,20 +350,20 @@ where
 
             #[cfg(feature = "alloc")]
             #[inline]
-            fn visit_owned(self, cx: &mut C, bytes: Vec<u8>) -> Result<Self::Ok, C::Error> {
+            fn visit_owned(self, cx: &C, bytes: Vec<u8>) -> Result<Self::Ok, C::Error> {
                 let string =
                     musli_common::str::from_utf8_owned(bytes).map_err(|err| cx.custom(err))?;
                 self.0.visit_owned(cx, string)
             }
 
             #[inline]
-            fn visit_borrowed(self, cx: &mut C, bytes: &'de [u8]) -> Result<Self::Ok, C::Error> {
+            fn visit_borrowed(self, cx: &C, bytes: &'de [u8]) -> Result<Self::Ok, C::Error> {
                 let string = musli_common::str::from_utf8(bytes).map_err(|err| cx.custom(err))?;
                 self.0.visit_borrowed(cx, string)
             }
 
             #[inline]
-            fn visit_ref(self, cx: &mut C, bytes: &[u8]) -> Result<Self::Ok, C::Error> {
+            fn visit_ref(self, cx: &C, bytes: &[u8]) -> Result<Self::Ok, C::Error> {
                 let string = musli_common::str::from_utf8(bytes).map_err(|err| cx.custom(err))?;
                 self.0.visit_ref(cx, string)
             }
@@ -378,7 +375,7 @@ where
     }
 
     #[inline]
-    fn decode_bool<C>(mut self, cx: &mut C) -> Result<bool, C::Error>
+    fn decode_bool<C>(mut self, cx: &C) -> Result<bool, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -401,7 +398,7 @@ where
     }
 
     #[inline]
-    fn decode_char<C>(mut self, cx: &mut C) -> Result<char, C::Error>
+    fn decode_char<C>(mut self, cx: &C) -> Result<char, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -423,7 +420,7 @@ where
     }
 
     #[inline]
-    fn decode_number<C, V>(mut self, cx: &mut C, visitor: V) -> Result<V::Ok, C::Error>
+    fn decode_number<C, V>(mut self, cx: &C, visitor: V) -> Result<V::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
         V: NumberVisitor<'de, C>,
@@ -487,7 +484,7 @@ where
     }
 
     #[inline]
-    fn decode_u8<C>(self, cx: &mut C) -> Result<u8, C::Error>
+    fn decode_u8<C>(self, cx: &C) -> Result<u8, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -495,7 +492,7 @@ where
     }
 
     #[inline]
-    fn decode_u16<C>(self, cx: &mut C) -> Result<u16, C::Error>
+    fn decode_u16<C>(self, cx: &C) -> Result<u16, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -503,7 +500,7 @@ where
     }
 
     #[inline]
-    fn decode_u32<C>(self, cx: &mut C) -> Result<u32, C::Error>
+    fn decode_u32<C>(self, cx: &C) -> Result<u32, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -511,7 +508,7 @@ where
     }
 
     #[inline]
-    fn decode_u64<C>(self, cx: &mut C) -> Result<u64, C::Error>
+    fn decode_u64<C>(self, cx: &C) -> Result<u64, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -519,7 +516,7 @@ where
     }
 
     #[inline]
-    fn decode_u128<C>(self, cx: &mut C) -> Result<u128, C::Error>
+    fn decode_u128<C>(self, cx: &C) -> Result<u128, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -527,7 +524,7 @@ where
     }
 
     #[inline]
-    fn decode_i8<C>(self, cx: &mut C) -> Result<i8, C::Error>
+    fn decode_i8<C>(self, cx: &C) -> Result<i8, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -535,7 +532,7 @@ where
     }
 
     #[inline]
-    fn decode_i16<C>(self, cx: &mut C) -> Result<i16, C::Error>
+    fn decode_i16<C>(self, cx: &C) -> Result<i16, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -543,7 +540,7 @@ where
     }
 
     #[inline]
-    fn decode_i32<C>(self, cx: &mut C) -> Result<i32, C::Error>
+    fn decode_i32<C>(self, cx: &C) -> Result<i32, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -551,7 +548,7 @@ where
     }
 
     #[inline]
-    fn decode_i64<C>(self, cx: &mut C) -> Result<i64, C::Error>
+    fn decode_i64<C>(self, cx: &C) -> Result<i64, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -559,7 +556,7 @@ where
     }
 
     #[inline]
-    fn decode_i128<C>(self, cx: &mut C) -> Result<i128, C::Error>
+    fn decode_i128<C>(self, cx: &C) -> Result<i128, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -567,7 +564,7 @@ where
     }
 
     #[inline]
-    fn decode_usize<C>(self, cx: &mut C) -> Result<usize, C::Error>
+    fn decode_usize<C>(self, cx: &C) -> Result<usize, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -575,7 +572,7 @@ where
     }
 
     #[inline]
-    fn decode_isize<C>(self, cx: &mut C) -> Result<isize, C::Error>
+    fn decode_isize<C>(self, cx: &C) -> Result<isize, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -585,7 +582,7 @@ where
     /// Decode a 32-bit floating point value by reading the 32-bit in-memory
     /// IEEE 754 encoding byte-by-byte.
     #[inline]
-    fn decode_f32<C>(self, cx: &mut C) -> Result<f32, C::Error>
+    fn decode_f32<C>(self, cx: &C) -> Result<f32, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -596,7 +593,7 @@ where
     /// Decode a 64-bit floating point value by reading the 64-bit in-memory
     /// IEEE 754 encoding byte-by-byte.
     #[inline]
-    fn decode_f64<C>(self, cx: &mut C) -> Result<f64, C::Error>
+    fn decode_f64<C>(self, cx: &C) -> Result<f64, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -605,7 +602,7 @@ where
     }
 
     #[inline]
-    fn decode_option<C>(mut self, cx: &mut C) -> Result<Option<Self::Some>, C::Error>
+    fn decode_option<C>(mut self, cx: &C) -> Result<Option<Self::Some>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -629,7 +626,7 @@ where
     }
 
     #[inline]
-    fn decode_sequence<C>(self, cx: &mut C) -> Result<Self::Sequence, C::Error>
+    fn decode_sequence<C>(self, cx: &C) -> Result<Self::Sequence, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -637,7 +634,7 @@ where
     }
 
     #[inline]
-    fn decode_tuple<C>(mut self, cx: &mut C, len: usize) -> Result<Self::Tuple, C::Error>
+    fn decode_tuple<C>(mut self, cx: &C, len: usize) -> Result<Self::Tuple, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -654,7 +651,7 @@ where
     }
 
     #[inline]
-    fn decode_map<C>(self, cx: &mut C) -> Result<Self::Map, C::Error>
+    fn decode_map<C>(self, cx: &C) -> Result<Self::Map, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -662,7 +659,7 @@ where
     }
 
     #[inline]
-    fn decode_struct<C>(self, cx: &mut C, _: usize) -> Result<Self::Struct, C::Error>
+    fn decode_struct<C>(self, cx: &C, _: usize) -> Result<Self::Struct, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -670,7 +667,7 @@ where
     }
 
     #[inline]
-    fn decode_variant<C>(mut self, cx: &mut C) -> Result<Self::Variant, C::Error>
+    fn decode_variant<C>(mut self, cx: &C) -> Result<Self::Variant, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -689,7 +686,7 @@ where
     }
 
     #[inline]
-    fn decode_any<C, V>(mut self, cx: &mut C, visitor: V) -> Result<V::Ok, C::Error>
+    fn decode_any<C, V>(mut self, cx: &C, visitor: V) -> Result<V::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
         V: Visitor<'de, Error = Self::Error>,
@@ -815,7 +812,7 @@ where
     type Decoder<'this> = StorageDecoder<<Limit<R> as Reader<'de>>::Mut<'this>, F, Error> where Self: 'this;
 
     #[inline]
-    fn next<C>(&mut self, _: &mut C) -> Result<Self::Decoder<'_>, C::Error>
+    fn next<C>(&mut self, _: &C) -> Result<Self::Decoder<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -823,7 +820,7 @@ where
     }
 
     #[inline]
-    fn end<C>(mut self, cx: &mut C) -> Result<(), C::Error>
+    fn end<C>(mut self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -844,7 +841,7 @@ where
     type Decoder<'this> = SelfDecoder<R::Mut<'this>, F> where Self: 'this;
 
     #[inline]
-    fn next<C>(&mut self, _: &mut C) -> Result<Self::Decoder<'_>, C::Error>
+    fn next<C>(&mut self, _: &C) -> Result<Self::Decoder<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -852,7 +849,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<(), C::Error>
+    fn end<C>(self, _: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -885,7 +882,7 @@ where
     }
 
     #[inline]
-    fn next<C>(&mut self, _: &mut C) -> Result<Option<Self::Decoder<'_>>, C::Error>
+    fn next<C>(&mut self, _: &C) -> Result<Option<Self::Decoder<'_>>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -898,7 +895,7 @@ where
     }
 
     #[inline]
-    fn end<C>(mut self, cx: &mut C) -> Result<(), C::Error>
+    fn end<C>(mut self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -921,7 +918,7 @@ where
     type Second = Self;
 
     #[inline]
-    fn first<C>(&mut self, _: &mut C) -> Result<Self::First<'_>, C::Error>
+    fn first<C>(&mut self, _: &C) -> Result<Self::First<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -929,7 +926,7 @@ where
     }
 
     #[inline]
-    fn second<C>(self, _: &mut C) -> Result<Self::Second, C::Error>
+    fn second<C>(self, _: &C) -> Result<Self::Second, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -937,7 +934,7 @@ where
     }
 
     #[inline]
-    fn skip_second<C>(mut self, cx: &mut C) -> Result<bool, C::Error>
+    fn skip_second<C>(mut self, cx: &C) -> Result<bool, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -956,7 +953,7 @@ where
     type Variant<'this> = SelfDecoder<R::Mut<'this>, F> where Self: 'this;
 
     #[inline]
-    fn tag<C>(&mut self, _: &mut C) -> Result<Self::Tag<'_>, C::Error>
+    fn tag<C>(&mut self, _: &C) -> Result<Self::Tag<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -964,7 +961,7 @@ where
     }
 
     #[inline]
-    fn variant<C>(&mut self, _: &mut C) -> Result<Self::Variant<'_>, C::Error>
+    fn variant<C>(&mut self, _: &C) -> Result<Self::Variant<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -972,7 +969,7 @@ where
     }
 
     #[inline]
-    fn skip_variant<C>(&mut self, cx: &mut C) -> Result<bool, C::Error>
+    fn skip_variant<C>(&mut self, cx: &C) -> Result<bool, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -981,7 +978,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<(), C::Error>
+    fn end<C>(self, _: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -1006,7 +1003,7 @@ where
     }
 
     #[inline]
-    fn next<C>(&mut self, _: &mut C) -> Result<Option<Self::Decoder<'_>>, C::Error>
+    fn next<C>(&mut self, _: &C) -> Result<Option<Self::Decoder<'_>>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -1019,7 +1016,7 @@ where
     }
 
     #[inline]
-    fn end<C>(mut self, cx: &mut C) -> Result<(), C::Error>
+    fn end<C>(mut self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {

--- a/crates/musli-descriptive/src/en.rs
+++ b/crates/musli-descriptive/src/en.rs
@@ -88,7 +88,11 @@ where
     where
         C: Context<Input = Self::Error>,
     {
-        Ok(SelfPackEncoder::new(self.writer, cx.alloc()))
+        let Some(buf) = cx.alloc() else {
+            return Err(cx.message("Failed to allocate pack buffer"));
+        };
+
+        Ok(SelfPackEncoder::new(self.writer, buf))
     }
 
     #[inline]

--- a/crates/musli-descriptive/src/en.rs
+++ b/crates/musli-descriptive/src/en.rs
@@ -84,7 +84,7 @@ where
     }
 
     #[inline]
-    fn encode_pack<C>(self, cx: &C) -> Result<Self::Pack<C::Buf>, C::Error>
+    fn encode_pack<'a, C>(self, cx: &'a C) -> Result<Self::Pack<C::Buf<'a>>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {

--- a/crates/musli-descriptive/src/en.rs
+++ b/crates/musli-descriptive/src/en.rs
@@ -74,7 +74,7 @@ where
     }
 
     #[inline]
-    fn encode_unit<C>(mut self, cx: &mut C) -> Result<Self::Ok, C::Error>
+    fn encode_unit<C>(mut self, cx: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -84,7 +84,7 @@ where
     }
 
     #[inline]
-    fn encode_pack<C>(self, cx: &mut C) -> Result<Self::Pack<C::Buf>, C::Error>
+    fn encode_pack<C>(self, cx: &C) -> Result<Self::Pack<C::Buf>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -98,11 +98,7 @@ where
     }
 
     #[inline]
-    fn encode_array<C, const N: usize>(
-        self,
-        cx: &mut C,
-        array: [u8; N],
-    ) -> Result<Self::Ok, C::Error>
+    fn encode_array<C, const N: usize>(self, cx: &C, array: [u8; N]) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -110,7 +106,7 @@ where
     }
 
     #[inline]
-    fn encode_bytes<C>(mut self, cx: &mut C, bytes: &[u8]) -> Result<Self::Ok, C::Error>
+    fn encode_bytes<C>(mut self, cx: &C, bytes: &[u8]) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -120,11 +116,7 @@ where
     }
 
     #[inline]
-    fn encode_bytes_vectored<C>(
-        mut self,
-        cx: &mut C,
-        vectors: &[&[u8]],
-    ) -> Result<Self::Ok, C::Error>
+    fn encode_bytes_vectored<C>(mut self, cx: &C, vectors: &[&[u8]]) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -139,7 +131,7 @@ where
     }
 
     #[inline]
-    fn encode_string<C>(mut self, cx: &mut C, string: &str) -> Result<Self::Ok, C::Error>
+    fn encode_string<C>(mut self, cx: &C, string: &str) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -149,7 +141,7 @@ where
     }
 
     #[inline]
-    fn encode_usize<C>(mut self, cx: &mut C, value: usize) -> Result<Self::Ok, C::Error>
+    fn encode_usize<C>(mut self, cx: &C, value: usize) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -157,7 +149,7 @@ where
     }
 
     #[inline]
-    fn encode_isize<C>(mut self, cx: &mut C, value: isize) -> Result<Self::Ok, C::Error>
+    fn encode_isize<C>(mut self, cx: &C, value: isize) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -165,7 +157,7 @@ where
     }
 
     #[inline]
-    fn encode_bool<C>(mut self, cx: &mut C, value: bool) -> Result<Self::Ok, C::Error>
+    fn encode_bool<C>(mut self, cx: &C, value: bool) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -177,7 +169,7 @@ where
     }
 
     #[inline]
-    fn encode_char<C>(mut self, cx: &mut C, value: char) -> Result<Self::Ok, C::Error>
+    fn encode_char<C>(mut self, cx: &C, value: char) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -187,7 +179,7 @@ where
     }
 
     #[inline]
-    fn encode_u8<C>(mut self, cx: &mut C, value: u8) -> Result<Self::Ok, C::Error>
+    fn encode_u8<C>(mut self, cx: &C, value: u8) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -195,7 +187,7 @@ where
     }
 
     #[inline]
-    fn encode_u16<C>(mut self, cx: &mut C, value: u16) -> Result<Self::Ok, C::Error>
+    fn encode_u16<C>(mut self, cx: &C, value: u16) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -203,7 +195,7 @@ where
     }
 
     #[inline]
-    fn encode_u32<C>(mut self, cx: &mut C, value: u32) -> Result<Self::Ok, C::Error>
+    fn encode_u32<C>(mut self, cx: &C, value: u32) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -211,7 +203,7 @@ where
     }
 
     #[inline]
-    fn encode_u64<C>(mut self, cx: &mut C, value: u64) -> Result<Self::Ok, C::Error>
+    fn encode_u64<C>(mut self, cx: &C, value: u64) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -219,7 +211,7 @@ where
     }
 
     #[inline]
-    fn encode_u128<C>(mut self, cx: &mut C, value: u128) -> Result<Self::Ok, C::Error>
+    fn encode_u128<C>(mut self, cx: &C, value: u128) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -227,7 +219,7 @@ where
     }
 
     #[inline]
-    fn encode_i8<C>(mut self, cx: &mut C, value: i8) -> Result<Self::Ok, C::Error>
+    fn encode_i8<C>(mut self, cx: &C, value: i8) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -235,7 +227,7 @@ where
     }
 
     #[inline]
-    fn encode_i16<C>(mut self, cx: &mut C, value: i16) -> Result<Self::Ok, C::Error>
+    fn encode_i16<C>(mut self, cx: &C, value: i16) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -243,7 +235,7 @@ where
     }
 
     #[inline]
-    fn encode_i32<C>(mut self, cx: &mut C, value: i32) -> Result<Self::Ok, C::Error>
+    fn encode_i32<C>(mut self, cx: &C, value: i32) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -251,7 +243,7 @@ where
     }
 
     #[inline]
-    fn encode_i64<C>(mut self, cx: &mut C, value: i64) -> Result<Self::Ok, C::Error>
+    fn encode_i64<C>(mut self, cx: &C, value: i64) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -259,7 +251,7 @@ where
     }
 
     #[inline]
-    fn encode_i128<C>(mut self, cx: &mut C, value: i128) -> Result<Self::Ok, C::Error>
+    fn encode_i128<C>(mut self, cx: &C, value: i128) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -267,7 +259,7 @@ where
     }
 
     #[inline]
-    fn encode_f32<C>(mut self, cx: &mut C, value: f32) -> Result<Self::Ok, C::Error>
+    fn encode_f32<C>(mut self, cx: &C, value: f32) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -275,7 +267,7 @@ where
     }
 
     #[inline]
-    fn encode_f64<C>(mut self, cx: &mut C, value: f64) -> Result<Self::Ok, C::Error>
+    fn encode_f64<C>(mut self, cx: &C, value: f64) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -283,7 +275,7 @@ where
     }
 
     #[inline]
-    fn encode_some<C>(mut self, cx: &mut C) -> Result<Self::Some, C::Error>
+    fn encode_some<C>(mut self, cx: &C) -> Result<Self::Some, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -293,7 +285,7 @@ where
     }
 
     #[inline]
-    fn encode_none<C>(mut self, cx: &mut C) -> Result<Self::Ok, C::Error>
+    fn encode_none<C>(mut self, cx: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -303,7 +295,7 @@ where
     }
 
     #[inline]
-    fn encode_sequence<C>(mut self, cx: &mut C, len: usize) -> Result<Self::Sequence, C::Error>
+    fn encode_sequence<C>(mut self, cx: &C, len: usize) -> Result<Self::Sequence, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -312,7 +304,7 @@ where
     }
 
     #[inline]
-    fn encode_tuple<C>(mut self, cx: &mut C, len: usize) -> Result<Self::Sequence, C::Error>
+    fn encode_tuple<C>(mut self, cx: &C, len: usize) -> Result<Self::Sequence, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -321,7 +313,7 @@ where
     }
 
     #[inline]
-    fn encode_map<C>(mut self, cx: &mut C, len: usize) -> Result<Self::Map, C::Error>
+    fn encode_map<C>(mut self, cx: &C, len: usize) -> Result<Self::Map, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -330,7 +322,7 @@ where
     }
 
     #[inline]
-    fn encode_struct<C>(mut self, cx: &mut C, len: usize) -> Result<Self::Struct, C::Error>
+    fn encode_struct<C>(mut self, cx: &C, len: usize) -> Result<Self::Struct, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -339,7 +331,7 @@ where
     }
 
     #[inline]
-    fn encode_variant<C>(mut self, cx: &mut C) -> Result<Self::Variant, C::Error>
+    fn encode_variant<C>(mut self, cx: &C) -> Result<Self::Variant, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -360,7 +352,7 @@ where
     type Encoder<'this> = StorageEncoder<&'this mut BufferWriter<B, W::Error>, F, Error> where Self: 'this;
 
     #[inline]
-    fn next<C>(&mut self, _: &mut C) -> Result<Self::Encoder<'_>, C::Error>
+    fn next<C>(&mut self, _: &C) -> Result<Self::Encoder<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -368,7 +360,7 @@ where
     }
 
     #[inline]
-    fn end<C>(mut self, cx: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(mut self, cx: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -420,7 +412,7 @@ where
     type Encoder<'this> = SelfEncoder<W::Mut<'this>, F> where Self: 'this;
 
     #[inline]
-    fn next<C>(&mut self, _: &mut C) -> Result<Self::Encoder<'_>, C::Error>
+    fn next<C>(&mut self, _: &C) -> Result<Self::Encoder<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -428,7 +420,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(self, _: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -446,7 +438,7 @@ where
     type Encoder<'this> = SelfEncoder<W::Mut<'this>, F> where Self: 'this;
 
     #[inline]
-    fn next<C>(&mut self, _: &mut C) -> Result<Self::Encoder<'_>, C::Error>
+    fn next<C>(&mut self, _: &C) -> Result<Self::Encoder<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -454,7 +446,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(self, _: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -473,7 +465,7 @@ where
     type Second<'this> = SelfEncoder<W::Mut<'this>, F> where Self: 'this;
 
     #[inline]
-    fn first<C>(&mut self, _: &mut C) -> Result<Self::First<'_>, C::Error>
+    fn first<C>(&mut self, _: &C) -> Result<Self::First<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -481,7 +473,7 @@ where
     }
 
     #[inline]
-    fn second<C>(&mut self, _: &mut C) -> Result<Self::Second<'_>, C::Error>
+    fn second<C>(&mut self, _: &C) -> Result<Self::Second<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -489,7 +481,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(self, _: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -508,7 +500,7 @@ where
     type Variant<'this> = SelfEncoder<W::Mut<'this>, F> where Self: 'this;
 
     #[inline]
-    fn tag<C>(&mut self, _: &mut C) -> Result<Self::Tag<'_>, C::Error>
+    fn tag<C>(&mut self, _: &C) -> Result<Self::Tag<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -516,7 +508,7 @@ where
     }
 
     #[inline]
-    fn variant<C>(&mut self, _: &mut C) -> Result<Self::Variant<'_>, C::Error>
+    fn variant<C>(&mut self, _: &C) -> Result<Self::Variant<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -524,7 +516,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(self, _: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -535,7 +527,7 @@ where
 /// Encode a length prefix.
 #[inline]
 fn encode_prefix<C, W, const F: Options>(
-    cx: &mut C,
+    cx: &C,
     mut writer: W,
     kind: Kind,
     len: usize,

--- a/crates/musli-descriptive/src/integer_encoding.rs
+++ b/crates/musli-descriptive/src/integer_encoding.rs
@@ -11,7 +11,7 @@ use crate::tag::{Kind, Tag};
 
 #[inline]
 pub(crate) fn encode_typed_unsigned<C, W, T>(
-    cx: &mut C,
+    cx: &C,
     writer: W,
     bits: u8,
     value: T,
@@ -26,7 +26,7 @@ where
 }
 
 #[inline]
-pub(crate) fn decode_typed_unsigned<'de, C, R, T>(cx: &mut C, reader: R) -> Result<T, C::Error>
+pub(crate) fn decode_typed_unsigned<'de, C, R, T>(cx: &C, reader: R) -> Result<T, C::Error>
 where
     C: Context<Input = Error>,
     R: Reader<'de>,
@@ -38,7 +38,7 @@ where
 
 #[inline]
 fn encode_typed<C, W, T>(
-    cx: &mut C,
+    cx: &C,
     mut writer: W,
     kind: Kind,
     bits: u8,
@@ -55,7 +55,7 @@ where
 }
 
 #[inline]
-fn decode_typed<'de, C, R, T>(cx: &mut C, mut reader: R, kind: Kind) -> Result<T, C::Error>
+fn decode_typed<'de, C, R, T>(cx: &C, mut reader: R, kind: Kind) -> Result<T, C::Error>
 where
     C: Context<Input = Error>,
     R: Reader<'de>,
@@ -73,7 +73,7 @@ where
 
 #[inline]
 pub(crate) fn encode_typed_signed<C, W, T>(
-    cx: &mut C,
+    cx: &C,
     writer: W,
     bits: u8,
     value: T,
@@ -88,7 +88,7 @@ where
 }
 
 #[inline]
-pub(crate) fn decode_typed_signed<'de, C, R, T>(cx: &mut C, reader: R) -> Result<T, C::Error>
+pub(crate) fn decode_typed_signed<'de, C, R, T>(cx: &C, reader: R) -> Result<T, C::Error>
 where
     C: Context<Input = Error>,
     R: Reader<'de>,

--- a/crates/musli-descriptive/src/tag.rs
+++ b/crates/musli-descriptive/src/tag.rs
@@ -227,7 +227,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,

--- a/crates/musli-descriptive/src/test.rs
+++ b/crates/musli-descriptive/src/test.rs
@@ -31,7 +31,7 @@ where
     M: Mode,
     T: Decode<'de, M>,
 {
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,

--- a/crates/musli-json/Cargo.toml
+++ b/crates/musli-json/Cargo.toml
@@ -3,7 +3,7 @@ name = "musli-json"
 version = "0.0.96"
 authors = ["John-John Tedro <udoprog@tedro.se>"]
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.73"
 description = """
 JSON support for Müsli.
 """

--- a/crates/musli-json/src/de.rs
+++ b/crates/musli-json/src/de.rs
@@ -197,7 +197,10 @@ where
         C: Context<Input = Self::Error>,
     {
         let start = cx.mark();
-        let mut scratch = cx.alloc();
+
+        let Some(mut scratch) = cx.alloc() else {
+            return Err(cx.message("Failed to allocate scratch buffer"));
+        };
 
         let string = match self.parser.parse_string(cx, true, &mut scratch)? {
             StringReference::Borrowed(string) => string,
@@ -380,7 +383,9 @@ where
         C: Context<Input = Self::Error>,
         V: ValueVisitor<'de, C, str>,
     {
-        let mut scratch = cx.alloc();
+        let Some(mut scratch) = cx.alloc() else {
+            return Err(cx.message("Failed to allocate scratch buffer"));
+        };
 
         match self.parser.parse_string(cx, true, &mut scratch)? {
             StringReference::Borrowed(borrowed) => visitor.visit_borrowed(cx, borrowed),
@@ -525,7 +530,9 @@ where
         C: Context<Input = Error>,
         V: ValueVisitor<'de, C, [u8]>,
     {
-        let mut scratch = cx.alloc();
+        let Some(mut scratch) = cx.alloc() else {
+            return Err(cx.message("Failed to allocate scratch buffer"));
+        };
 
         match self.parser.parse_string(cx, true, &mut scratch)? {
             StringReference::Borrowed(string) => visitor.visit_borrowed(cx, string.as_bytes()),

--- a/crates/musli-json/src/de.rs
+++ b/crates/musli-json/src/de.rs
@@ -27,9 +27,8 @@ use crate::reader::integer::{Signed, Unsigned};
 use crate::reader::SliceParser;
 use crate::reader::{integer, string, Parser, StringReference, Token};
 
-use musli_common::options;
-
-const BUFFER_OPTIONS: options::Options = options::new().build();
+#[cfg(feature = "musli-value")]
+const BUFFER_OPTIONS: musli_common::options::Options = musli_common::options::new().build();
 
 /// A JSON decoder for Müsli.
 pub struct JsonDecoder<P> {

--- a/crates/musli-json/src/de.rs
+++ b/crates/musli-json/src/de.rs
@@ -47,7 +47,7 @@ where
     }
 
     /// Skip over any values.
-    pub(crate) fn skip_any<C>(mut self, cx: &mut C) -> Result<(), C::Error>
+    pub(crate) fn skip_any<C>(mut self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -88,7 +88,7 @@ where
     }
 
     #[inline]
-    fn parse_true<C>(mut self, cx: &mut C) -> Result<(), C::Error>
+    fn parse_true<C>(mut self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -97,7 +97,7 @@ where
     }
 
     #[inline]
-    fn parse_false<C>(mut self, cx: &mut C) -> Result<(), C::Error>
+    fn parse_false<C>(mut self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -106,7 +106,7 @@ where
     }
 
     #[inline]
-    fn parse_null<C>(mut self, cx: &mut C) -> Result<(), C::Error>
+    fn parse_null<C>(mut self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -137,7 +137,7 @@ where
     }
 
     #[inline]
-    fn type_hint<C>(&mut self, cx: &mut C) -> Result<TypeHint, C::Error>
+    fn type_hint<C>(&mut self, cx: &C) -> Result<TypeHint, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -155,7 +155,7 @@ where
 
     #[cfg(feature = "musli-value")]
     #[inline]
-    fn decode_buffer<M, C>(self, cx: &mut C) -> Result<Self::Buffer, C::Error>
+    fn decode_buffer<M, C>(self, cx: &C) -> Result<Self::Buffer, C::Error>
     where
         M: Mode,
         C: Context<Input = Self::Error>,
@@ -166,7 +166,7 @@ where
     }
 
     #[inline]
-    fn decode_unit<C>(self, cx: &mut C) -> Result<(), C::Error>
+    fn decode_unit<C>(self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -174,7 +174,7 @@ where
     }
 
     #[inline]
-    fn decode_bool<C>(mut self, cx: &mut C) -> Result<bool, C::Error>
+    fn decode_bool<C>(mut self, cx: &C) -> Result<bool, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -192,7 +192,7 @@ where
     }
 
     #[inline]
-    fn decode_char<C>(mut self, cx: &mut C) -> Result<char, C::Error>
+    fn decode_char<C>(mut self, cx: &C) -> Result<char, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -214,7 +214,7 @@ where
     }
 
     #[inline]
-    fn decode_u8<C>(mut self, cx: &mut C) -> Result<u8, C::Error>
+    fn decode_u8<C>(mut self, cx: &C) -> Result<u8, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -222,7 +222,7 @@ where
     }
 
     #[inline]
-    fn decode_u16<C>(mut self, cx: &mut C) -> Result<u16, C::Error>
+    fn decode_u16<C>(mut self, cx: &C) -> Result<u16, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -230,7 +230,7 @@ where
     }
 
     #[inline]
-    fn decode_u32<C>(mut self, cx: &mut C) -> Result<u32, C::Error>
+    fn decode_u32<C>(mut self, cx: &C) -> Result<u32, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -238,7 +238,7 @@ where
     }
 
     #[inline]
-    fn decode_u64<C>(mut self, cx: &mut C) -> Result<u64, C::Error>
+    fn decode_u64<C>(mut self, cx: &C) -> Result<u64, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -246,7 +246,7 @@ where
     }
 
     #[inline]
-    fn decode_u128<C>(mut self, cx: &mut C) -> Result<u128, C::Error>
+    fn decode_u128<C>(mut self, cx: &C) -> Result<u128, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -254,7 +254,7 @@ where
     }
 
     #[inline]
-    fn decode_i8<C>(mut self, cx: &mut C) -> Result<i8, C::Error>
+    fn decode_i8<C>(mut self, cx: &C) -> Result<i8, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -262,7 +262,7 @@ where
     }
 
     #[inline]
-    fn decode_i16<C>(mut self, cx: &mut C) -> Result<i16, C::Error>
+    fn decode_i16<C>(mut self, cx: &C) -> Result<i16, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -270,7 +270,7 @@ where
     }
 
     #[inline]
-    fn decode_i32<C>(mut self, cx: &mut C) -> Result<i32, C::Error>
+    fn decode_i32<C>(mut self, cx: &C) -> Result<i32, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -278,7 +278,7 @@ where
     }
 
     #[inline]
-    fn decode_i64<C>(mut self, cx: &mut C) -> Result<i64, C::Error>
+    fn decode_i64<C>(mut self, cx: &C) -> Result<i64, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -286,7 +286,7 @@ where
     }
 
     #[inline]
-    fn decode_i128<C>(mut self, cx: &mut C) -> Result<i128, C::Error>
+    fn decode_i128<C>(mut self, cx: &C) -> Result<i128, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -294,7 +294,7 @@ where
     }
 
     #[inline]
-    fn decode_usize<C>(mut self, cx: &mut C) -> Result<usize, C::Error>
+    fn decode_usize<C>(mut self, cx: &C) -> Result<usize, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -302,7 +302,7 @@ where
     }
 
     #[inline]
-    fn decode_isize<C>(mut self, cx: &mut C) -> Result<isize, C::Error>
+    fn decode_isize<C>(mut self, cx: &C) -> Result<isize, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -310,7 +310,7 @@ where
     }
 
     #[inline]
-    fn decode_f32<C>(mut self, cx: &mut C) -> Result<f32, C::Error>
+    fn decode_f32<C>(mut self, cx: &C) -> Result<f32, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -318,7 +318,7 @@ where
     }
 
     #[inline]
-    fn decode_f64<C>(mut self, cx: &mut C) -> Result<f64, C::Error>
+    fn decode_f64<C>(mut self, cx: &C) -> Result<f64, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -326,7 +326,7 @@ where
     }
 
     #[inline]
-    fn decode_array<C, const N: usize>(self, cx: &mut C) -> Result<[u8; N], C::Error>
+    fn decode_array<C, const N: usize>(self, cx: &C) -> Result<[u8; N], C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -349,7 +349,7 @@ where
     }
 
     #[inline]
-    fn decode_number<C, V>(mut self, cx: &mut C, visitor: V) -> Result<V::Ok, C::Error>
+    fn decode_number<C, V>(mut self, cx: &C, visitor: V) -> Result<V::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
         V: NumberVisitor<'de, C>,
@@ -359,7 +359,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn decode_bytes<C, V>(self, cx: &mut C, visitor: V) -> Result<V::Ok, C::Error>
+    fn decode_bytes<C, V>(self, cx: &C, visitor: V) -> Result<V::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
         V: ValueVisitor<'de, C, [u8]>,
@@ -375,7 +375,7 @@ where
     }
 
     #[inline]
-    fn decode_string<C, V>(mut self, cx: &mut C, visitor: V) -> Result<V::Ok, C::Error>
+    fn decode_string<C, V>(mut self, cx: &C, visitor: V) -> Result<V::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
         V: ValueVisitor<'de, C, str>,
@@ -389,7 +389,7 @@ where
     }
 
     #[inline]
-    fn decode_option<C>(mut self, cx: &mut C) -> Result<Option<Self::Some>, C::Error>
+    fn decode_option<C>(mut self, cx: &C) -> Result<Option<Self::Some>, C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -402,7 +402,7 @@ where
     }
 
     #[inline]
-    fn decode_pack<C>(self, cx: &mut C) -> Result<Self::Pack, C::Error>
+    fn decode_pack<C>(self, cx: &C) -> Result<Self::Pack, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -410,7 +410,7 @@ where
     }
 
     #[inline]
-    fn decode_sequence<C>(self, cx: &mut C) -> Result<Self::Sequence, C::Error>
+    fn decode_sequence<C>(self, cx: &C) -> Result<Self::Sequence, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -418,7 +418,7 @@ where
     }
 
     #[inline]
-    fn decode_tuple<C>(self, cx: &mut C, len: usize) -> Result<Self::Tuple, C::Error>
+    fn decode_tuple<C>(self, cx: &C, len: usize) -> Result<Self::Tuple, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -426,7 +426,7 @@ where
     }
 
     #[inline]
-    fn decode_map<C>(self, cx: &mut C) -> Result<Self::Map, C::Error>
+    fn decode_map<C>(self, cx: &C) -> Result<Self::Map, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -434,7 +434,7 @@ where
     }
 
     #[inline]
-    fn decode_struct<C>(self, cx: &mut C, len: usize) -> Result<Self::Struct, C::Error>
+    fn decode_struct<C>(self, cx: &C, len: usize) -> Result<Self::Struct, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -442,7 +442,7 @@ where
     }
 
     #[inline]
-    fn decode_variant<C>(self, cx: &mut C) -> Result<Self::Variant, C::Error>
+    fn decode_variant<C>(self, cx: &C) -> Result<Self::Variant, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -450,7 +450,7 @@ where
     }
 
     #[inline]
-    fn decode_any<C, V>(mut self, cx: &mut C, visitor: V) -> Result<V::Ok, C::Error>
+    fn decode_any<C, V>(mut self, cx: &C, visitor: V) -> Result<V::Ok, C::Error>
     where
         C: Context<Input = Error>,
         V: Visitor<'de, Error = Self::Error>,
@@ -501,7 +501,7 @@ where
     P: Parser<'de>,
 {
     #[inline]
-    fn skip_any<C>(self, cx: &mut C) -> Result<(), C::Error>
+    fn skip_any<C>(self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -520,7 +520,7 @@ where
     }
 
     #[inline]
-    fn decode_escaped_bytes<C, V>(mut self, cx: &mut C, visitor: V) -> Result<V::Ok, C::Error>
+    fn decode_escaped_bytes<C, V>(mut self, cx: &C, visitor: V) -> Result<V::Ok, C::Error>
     where
         C: Context<Input = Error>,
         V: ValueVisitor<'de, C, [u8]>,
@@ -559,7 +559,7 @@ where
     }
 
     #[inline]
-    fn visit_ref(self, cx: &mut C, bytes: &[u8]) -> Result<Self::Ok, C::Error> {
+    fn visit_ref(self, cx: &C, bytes: &[u8]) -> Result<Self::Ok, C::Error> {
         parse_unsigned(cx, &mut SliceParser::new(bytes))
     }
 }
@@ -589,7 +589,7 @@ where
     }
 
     #[inline]
-    fn visit_ref(self, cx: &mut C, bytes: &[u8]) -> Result<Self::Ok, C::Error> {
+    fn visit_ref(self, cx: &C, bytes: &[u8]) -> Result<Self::Ok, C::Error> {
         parse_signed(cx, &mut SliceParser::new(bytes))
     }
 }
@@ -608,7 +608,7 @@ where
     }
 
     #[inline]
-    fn type_hint<C>(&mut self, cx: &mut C) -> Result<TypeHint, C::Error>
+    fn type_hint<C>(&mut self, cx: &C) -> Result<TypeHint, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -616,7 +616,7 @@ where
     }
 
     #[inline]
-    fn decode_u8<C>(self, cx: &mut C) -> Result<u8, C::Error>
+    fn decode_u8<C>(self, cx: &C) -> Result<u8, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -624,7 +624,7 @@ where
     }
 
     #[inline]
-    fn decode_u16<C>(self, cx: &mut C) -> Result<u16, C::Error>
+    fn decode_u16<C>(self, cx: &C) -> Result<u16, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -632,7 +632,7 @@ where
     }
 
     #[inline]
-    fn decode_u32<C>(self, cx: &mut C) -> Result<u32, C::Error>
+    fn decode_u32<C>(self, cx: &C) -> Result<u32, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -640,7 +640,7 @@ where
     }
 
     #[inline]
-    fn decode_u64<C>(self, cx: &mut C) -> Result<u64, C::Error>
+    fn decode_u64<C>(self, cx: &C) -> Result<u64, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -648,7 +648,7 @@ where
     }
 
     #[inline]
-    fn decode_u128<C>(self, cx: &mut C) -> Result<u128, C::Error>
+    fn decode_u128<C>(self, cx: &C) -> Result<u128, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -656,7 +656,7 @@ where
     }
 
     #[inline]
-    fn decode_i8<C>(self, cx: &mut C) -> Result<i8, C::Error>
+    fn decode_i8<C>(self, cx: &C) -> Result<i8, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -664,7 +664,7 @@ where
     }
 
     #[inline]
-    fn decode_i16<C>(self, cx: &mut C) -> Result<i16, C::Error>
+    fn decode_i16<C>(self, cx: &C) -> Result<i16, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -672,7 +672,7 @@ where
     }
 
     #[inline]
-    fn decode_i32<C>(self, cx: &mut C) -> Result<i32, C::Error>
+    fn decode_i32<C>(self, cx: &C) -> Result<i32, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -680,7 +680,7 @@ where
     }
 
     #[inline]
-    fn decode_i64<C>(self, cx: &mut C) -> Result<i64, C::Error>
+    fn decode_i64<C>(self, cx: &C) -> Result<i64, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -688,7 +688,7 @@ where
     }
 
     #[inline]
-    fn decode_i128<C>(self, cx: &mut C) -> Result<i128, C::Error>
+    fn decode_i128<C>(self, cx: &C) -> Result<i128, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -696,7 +696,7 @@ where
     }
 
     #[inline]
-    fn decode_usize<C>(self, cx: &mut C) -> Result<usize, C::Error>
+    fn decode_usize<C>(self, cx: &C) -> Result<usize, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -704,7 +704,7 @@ where
     }
 
     #[inline]
-    fn decode_isize<C>(self, cx: &mut C) -> Result<isize, C::Error>
+    fn decode_isize<C>(self, cx: &C) -> Result<isize, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -712,7 +712,7 @@ where
     }
 
     #[inline]
-    fn decode_string<C, V>(self, cx: &mut C, visitor: V) -> Result<V::Ok, C::Error>
+    fn decode_string<C, V>(self, cx: &C, visitor: V) -> Result<V::Ok, C::Error>
     where
         V: ValueVisitor<'de, C, str>,
         C: Context<Input = Self::Error>,
@@ -721,7 +721,7 @@ where
     }
 
     #[inline]
-    fn decode_any<C, V>(mut self, cx: &mut C, visitor: V) -> Result<V::Ok, C::Error>
+    fn decode_any<C, V>(mut self, cx: &C, visitor: V) -> Result<V::Ok, C::Error>
     where
         C: Context<Input = V::Error>,
         V: Visitor<'de, Error = Self::Error>,
@@ -751,7 +751,7 @@ where
     P: Parser<'de>,
 {
     #[inline]
-    pub fn new<C>(cx: &mut C, len: Option<usize>, mut parser: P) -> Result<Self, C::Error>
+    pub fn new<C>(cx: &C, len: Option<usize>, mut parser: P) -> Result<Self, C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -789,7 +789,7 @@ where
     }
 
     #[inline]
-    fn next<C>(&mut self, cx: &mut C) -> Result<Option<Self::Decoder<'_>>, C::Error>
+    fn next<C>(&mut self, cx: &C) -> Result<Option<Self::Decoder<'_>>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -820,7 +820,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<(), C::Error>
+    fn end<C>(self, _: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -852,7 +852,7 @@ where
     type Second = JsonDecoder<P>;
 
     #[inline]
-    fn first<C>(&mut self, _: &mut C) -> Result<Self::First<'_>, C::Error>
+    fn first<C>(&mut self, _: &C) -> Result<Self::First<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -860,7 +860,7 @@ where
     }
 
     #[inline]
-    fn second<C>(mut self, cx: &mut C) -> Result<Self::Second, C::Error>
+    fn second<C>(mut self, cx: &C) -> Result<Self::Second, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -875,7 +875,7 @@ where
     }
 
     #[inline]
-    fn skip_second<C>(mut self, cx: &mut C) -> Result<bool, C::Error>
+    fn skip_second<C>(mut self, cx: &C) -> Result<bool, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -903,7 +903,7 @@ where
     P: Parser<'de>,
 {
     #[inline]
-    pub fn new<C>(cx: &mut C, len: Option<usize>, mut parser: P) -> Result<Self, C::Error>
+    pub fn new<C>(cx: &C, len: Option<usize>, mut parser: P) -> Result<Self, C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -940,7 +940,7 @@ where
     }
 
     #[inline]
-    fn next<C>(&mut self, cx: &mut C) -> Result<Option<Self::Decoder<'_>>, C::Error>
+    fn next<C>(&mut self, cx: &C) -> Result<Option<Self::Decoder<'_>>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -972,7 +972,7 @@ where
     }
 
     #[inline]
-    fn end<C>(mut self, cx: &mut C) -> Result<(), C::Error>
+    fn end<C>(mut self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -1002,7 +1002,7 @@ where
         Self: 'this;
 
     #[inline]
-    fn next<C>(&mut self, cx: &mut C) -> Result<Self::Decoder<'_>, C::Error>
+    fn next<C>(&mut self, cx: &C) -> Result<Self::Decoder<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -1037,7 +1037,7 @@ where
     }
 
     #[inline]
-    fn end<C>(mut self, cx: &mut C) -> Result<(), C::Error>
+    fn end<C>(mut self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -1065,7 +1065,7 @@ where
     P: Parser<'de>,
 {
     #[inline]
-    pub fn new<C>(cx: &mut C, mut parser: P) -> Result<Self, C::Error>
+    pub fn new<C>(cx: &C, mut parser: P) -> Result<Self, C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -1095,7 +1095,7 @@ where
     type Variant<'this> = JsonDecoder<P::Mut<'this>> where Self: 'this;
 
     #[inline]
-    fn tag<C>(&mut self, _: &mut C) -> Result<Self::Tag<'_>, C::Error>
+    fn tag<C>(&mut self, _: &C) -> Result<Self::Tag<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -1103,7 +1103,7 @@ where
     }
 
     #[inline]
-    fn variant<C>(&mut self, cx: &mut C) -> Result<Self::Variant<'_>, C::Error>
+    fn variant<C>(&mut self, cx: &C) -> Result<Self::Variant<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -1118,7 +1118,7 @@ where
     }
 
     #[inline]
-    fn skip_variant<C>(&mut self, cx: &mut C) -> Result<bool, C::Error>
+    fn skip_variant<C>(&mut self, cx: &C) -> Result<bool, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -1128,7 +1128,7 @@ where
     }
 
     #[inline]
-    fn end<C>(mut self, cx: &mut C) -> Result<(), C::Error>
+    fn end<C>(mut self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {

--- a/crates/musli-json/src/en.rs
+++ b/crates/musli-json/src/en.rs
@@ -48,7 +48,7 @@ where
     }
 
     #[inline]
-    fn encode_unit<C>(mut self, cx: &mut C) -> Result<Self::Ok, C::Error>
+    fn encode_unit<C>(mut self, cx: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -56,7 +56,7 @@ where
     }
 
     #[inline]
-    fn encode_bool<C>(mut self, cx: &mut C, value: bool) -> Result<Self::Ok, C::Error>
+    fn encode_bool<C>(mut self, cx: &C, value: bool) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -65,7 +65,7 @@ where
     }
 
     #[inline]
-    fn encode_char<C>(mut self, cx: &mut C, value: char) -> Result<Self::Ok, C::Error>
+    fn encode_char<C>(mut self, cx: &C, value: char) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -77,7 +77,7 @@ where
     }
 
     #[inline]
-    fn encode_u8<C>(mut self, cx: &mut C, value: u8) -> Result<Self::Ok, C::Error>
+    fn encode_u8<C>(mut self, cx: &C, value: u8) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -87,7 +87,7 @@ where
     }
 
     #[inline]
-    fn encode_u16<C>(mut self, cx: &mut C, value: u16) -> Result<Self::Ok, C::Error>
+    fn encode_u16<C>(mut self, cx: &C, value: u16) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -97,7 +97,7 @@ where
     }
 
     #[inline]
-    fn encode_u32<C>(mut self, cx: &mut C, value: u32) -> Result<Self::Ok, C::Error>
+    fn encode_u32<C>(mut self, cx: &C, value: u32) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -107,7 +107,7 @@ where
     }
 
     #[inline]
-    fn encode_u64<C>(mut self, cx: &mut C, value: u64) -> Result<Self::Ok, C::Error>
+    fn encode_u64<C>(mut self, cx: &C, value: u64) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -117,7 +117,7 @@ where
     }
 
     #[inline]
-    fn encode_u128<C>(mut self, cx: &mut C, value: u128) -> Result<Self::Ok, C::Error>
+    fn encode_u128<C>(mut self, cx: &C, value: u128) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -127,7 +127,7 @@ where
     }
 
     #[inline]
-    fn encode_i8<C>(mut self, cx: &mut C, value: i8) -> Result<Self::Ok, C::Error>
+    fn encode_i8<C>(mut self, cx: &C, value: i8) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -137,7 +137,7 @@ where
     }
 
     #[inline]
-    fn encode_i16<C>(mut self, cx: &mut C, value: i16) -> Result<Self::Ok, C::Error>
+    fn encode_i16<C>(mut self, cx: &C, value: i16) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -147,7 +147,7 @@ where
     }
 
     #[inline]
-    fn encode_i32<C>(mut self, cx: &mut C, value: i32) -> Result<Self::Ok, C::Error>
+    fn encode_i32<C>(mut self, cx: &C, value: i32) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -157,7 +157,7 @@ where
     }
 
     #[inline]
-    fn encode_i64<C>(mut self, cx: &mut C, value: i64) -> Result<Self::Ok, C::Error>
+    fn encode_i64<C>(mut self, cx: &C, value: i64) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -167,7 +167,7 @@ where
     }
 
     #[inline]
-    fn encode_i128<C>(mut self, cx: &mut C, value: i128) -> Result<Self::Ok, C::Error>
+    fn encode_i128<C>(mut self, cx: &C, value: i128) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -177,7 +177,7 @@ where
     }
 
     #[inline]
-    fn encode_usize<C>(mut self, cx: &mut C, value: usize) -> Result<Self::Ok, C::Error>
+    fn encode_usize<C>(mut self, cx: &C, value: usize) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -187,7 +187,7 @@ where
     }
 
     #[inline]
-    fn encode_isize<C>(mut self, cx: &mut C, value: isize) -> Result<Self::Ok, C::Error>
+    fn encode_isize<C>(mut self, cx: &C, value: isize) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -197,7 +197,7 @@ where
     }
 
     #[inline]
-    fn encode_f32<C>(mut self, cx: &mut C, value: f32) -> Result<Self::Ok, C::Error>
+    fn encode_f32<C>(mut self, cx: &C, value: f32) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -207,7 +207,7 @@ where
     }
 
     #[inline]
-    fn encode_f64<C>(mut self, cx: &mut C, value: f64) -> Result<Self::Ok, C::Error>
+    fn encode_f64<C>(mut self, cx: &C, value: f64) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -217,11 +217,7 @@ where
     }
 
     #[inline]
-    fn encode_array<C, const N: usize>(
-        self,
-        cx: &mut C,
-        bytes: [u8; N],
-    ) -> Result<Self::Ok, C::Error>
+    fn encode_array<C, const N: usize>(self, cx: &C, bytes: [u8; N]) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -229,7 +225,7 @@ where
     }
 
     #[inline]
-    fn encode_bytes<C>(mut self, cx: &mut C, bytes: &[u8]) -> Result<Self::Ok, C::Error>
+    fn encode_bytes<C>(mut self, cx: &C, bytes: &[u8]) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -255,7 +251,7 @@ where
     }
 
     #[inline]
-    fn encode_bytes_vectored<C>(self, cx: &mut C, bytes: &[&[u8]]) -> Result<Self::Ok, C::Error>
+    fn encode_bytes_vectored<C>(self, cx: &C, bytes: &[&[u8]]) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -271,7 +267,7 @@ where
     }
 
     #[inline]
-    fn encode_string<C>(mut self, cx: &mut C, string: &str) -> Result<Self::Ok, C::Error>
+    fn encode_string<C>(mut self, cx: &C, string: &str) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -279,7 +275,7 @@ where
     }
 
     #[inline]
-    fn encode_some<C>(self, _: &mut C) -> Result<Self::Some, C::Error>
+    fn encode_some<C>(self, _: &C) -> Result<Self::Some, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -287,7 +283,7 @@ where
     }
 
     #[inline]
-    fn encode_none<C>(self, cx: &mut C) -> Result<Self::Ok, C::Error>
+    fn encode_none<C>(self, cx: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -295,7 +291,7 @@ where
     }
 
     #[inline]
-    fn encode_pack<C>(self, cx: &mut C) -> Result<Self::Pack<C::Buf>, C::Error>
+    fn encode_pack<C>(self, cx: &C) -> Result<Self::Pack<C::Buf>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -303,7 +299,7 @@ where
     }
 
     #[inline]
-    fn encode_sequence<C>(self, cx: &mut C, _: usize) -> Result<Self::Sequence, C::Error>
+    fn encode_sequence<C>(self, cx: &C, _: usize) -> Result<Self::Sequence, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -311,7 +307,7 @@ where
     }
 
     #[inline]
-    fn encode_tuple<C>(self, cx: &mut C, _: usize) -> Result<Self::Tuple, C::Error>
+    fn encode_tuple<C>(self, cx: &C, _: usize) -> Result<Self::Tuple, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -319,7 +315,7 @@ where
     }
 
     #[inline]
-    fn encode_map<C>(self, cx: &mut C, _: usize) -> Result<Self::Map, C::Error>
+    fn encode_map<C>(self, cx: &C, _: usize) -> Result<Self::Map, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -327,7 +323,7 @@ where
     }
 
     #[inline]
-    fn encode_struct<C>(self, cx: &mut C, _: usize) -> Result<Self::Struct, C::Error>
+    fn encode_struct<C>(self, cx: &C, _: usize) -> Result<Self::Struct, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -335,7 +331,7 @@ where
     }
 
     #[inline]
-    fn encode_variant<C>(self, cx: &mut C) -> Result<Self::Variant, C::Error>
+    fn encode_variant<C>(self, cx: &C) -> Result<Self::Variant, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -356,7 +352,7 @@ where
     Error: From<W::Error>,
 {
     #[inline]
-    fn new<C>(cx: &mut C, mut writer: W) -> Result<Self, C::Error>
+    fn new<C>(cx: &C, mut writer: W) -> Result<Self, C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -384,7 +380,7 @@ where
         Self: 'this;
 
     #[inline]
-    fn next<C>(&mut self, _: &mut C) -> Result<Self::Encoder<'_>, C::Error>
+    fn next<C>(&mut self, _: &C) -> Result<Self::Encoder<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -397,7 +393,7 @@ where
     }
 
     #[inline]
-    fn end<C>(mut self, cx: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(mut self, cx: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -440,7 +436,7 @@ where
     type Second<'this> = JsonEncoder<M, W::Mut<'this>> where Self: 'this;
 
     #[inline]
-    fn first<C>(&mut self, cx: &mut C) -> Result<Self::First<'_>, C::Error>
+    fn first<C>(&mut self, cx: &C) -> Result<Self::First<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -452,7 +448,7 @@ where
     }
 
     #[inline]
-    fn second<C>(&mut self, cx: &mut C) -> Result<Self::Second<'_>, C::Error>
+    fn second<C>(&mut self, cx: &C) -> Result<Self::Second<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -461,7 +457,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(self, _: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -481,7 +477,7 @@ where
     Error: From<W::Error>,
 {
     #[inline]
-    fn new<C>(cx: &mut C, mut writer: W) -> Result<Self, C::Error>
+    fn new<C>(cx: &C, mut writer: W) -> Result<Self, C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -512,7 +508,7 @@ where
         Self: 'this;
 
     #[inline]
-    fn tag<C>(&mut self, _: &mut C) -> Result<Self::Tag<'_>, C::Error>
+    fn tag<C>(&mut self, _: &C) -> Result<Self::Tag<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -520,7 +516,7 @@ where
     }
 
     #[inline]
-    fn variant<C>(&mut self, cx: &mut C) -> Result<Self::Variant<'_>, C::Error>
+    fn variant<C>(&mut self, cx: &C) -> Result<Self::Variant<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -529,7 +525,7 @@ where
     }
 
     #[inline]
-    fn end<C>(mut self, cx: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(mut self, cx: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -574,7 +570,7 @@ where
     }
 
     #[inline]
-    fn encode_u8<C>(mut self, cx: &mut C, value: u8) -> Result<Self::Ok, C::Error>
+    fn encode_u8<C>(mut self, cx: &C, value: u8) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -582,7 +578,7 @@ where
     }
 
     #[inline]
-    fn encode_u16<C>(mut self, cx: &mut C, value: u16) -> Result<Self::Ok, C::Error>
+    fn encode_u16<C>(mut self, cx: &C, value: u16) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -590,7 +586,7 @@ where
     }
 
     #[inline]
-    fn encode_u32<C>(mut self, cx: &mut C, value: u32) -> Result<Self::Ok, C::Error>
+    fn encode_u32<C>(mut self, cx: &C, value: u32) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -598,7 +594,7 @@ where
     }
 
     #[inline]
-    fn encode_u64<C>(mut self, cx: &mut C, value: u64) -> Result<Self::Ok, C::Error>
+    fn encode_u64<C>(mut self, cx: &C, value: u64) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -606,7 +602,7 @@ where
     }
 
     #[inline]
-    fn encode_u128<C>(mut self, cx: &mut C, value: u128) -> Result<Self::Ok, C::Error>
+    fn encode_u128<C>(mut self, cx: &C, value: u128) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -614,7 +610,7 @@ where
     }
 
     #[inline]
-    fn encode_i8<C>(mut self, cx: &mut C, value: i8) -> Result<Self::Ok, C::Error>
+    fn encode_i8<C>(mut self, cx: &C, value: i8) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -622,7 +618,7 @@ where
     }
 
     #[inline]
-    fn encode_i16<C>(mut self, cx: &mut C, value: i16) -> Result<Self::Ok, C::Error>
+    fn encode_i16<C>(mut self, cx: &C, value: i16) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -630,7 +626,7 @@ where
     }
 
     #[inline]
-    fn encode_i32<C>(mut self, cx: &mut C, value: i32) -> Result<Self::Ok, C::Error>
+    fn encode_i32<C>(mut self, cx: &C, value: i32) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -638,7 +634,7 @@ where
     }
 
     #[inline]
-    fn encode_i64<C>(mut self, cx: &mut C, value: i64) -> Result<Self::Ok, C::Error>
+    fn encode_i64<C>(mut self, cx: &C, value: i64) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -646,7 +642,7 @@ where
     }
 
     #[inline]
-    fn encode_i128<C>(mut self, cx: &mut C, value: i128) -> Result<Self::Ok, C::Error>
+    fn encode_i128<C>(mut self, cx: &C, value: i128) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -654,7 +650,7 @@ where
     }
 
     #[inline]
-    fn encode_usize<C>(mut self, cx: &mut C, value: usize) -> Result<Self::Ok, C::Error>
+    fn encode_usize<C>(mut self, cx: &C, value: usize) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -662,7 +658,7 @@ where
     }
 
     #[inline]
-    fn encode_isize<C>(mut self, cx: &mut C, value: isize) -> Result<Self::Ok, C::Error>
+    fn encode_isize<C>(mut self, cx: &C, value: isize) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -670,7 +666,7 @@ where
     }
 
     #[inline]
-    fn encode_string<C>(self, cx: &mut C, string: &str) -> Result<Self::Ok, C::Error>
+    fn encode_string<C>(self, cx: &C, string: &str) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -691,7 +687,7 @@ where
     Error: From<W::Error>,
 {
     #[inline]
-    fn new<C>(cx: &mut C, mut writer: W) -> Result<Self, C::Error>
+    fn new<C>(cx: &C, mut writer: W) -> Result<Self, C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -719,7 +715,7 @@ where
         Self: 'this;
 
     #[inline]
-    fn next<C>(&mut self, cx: &mut C) -> Result<Self::Encoder<'_>, C::Error>
+    fn next<C>(&mut self, cx: &C) -> Result<Self::Encoder<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -732,7 +728,7 @@ where
     }
 
     #[inline]
-    fn end<C>(mut self, cx: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(mut self, cx: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -743,7 +739,7 @@ where
 
 /// Encode a sequence of chars as a string.
 #[inline]
-fn encode_string<C, W>(cx: &mut C, mut writer: W, bytes: &[u8]) -> Result<(), C::Error>
+fn encode_string<C, W>(cx: &C, mut writer: W, bytes: &[u8]) -> Result<(), C::Error>
 where
     C: Context<Input = Error>,
     W: Writer,
@@ -815,7 +811,7 @@ static ESCAPE: [u8; 256] = [
 // Hex digits.
 static HEX_DIGITS: [u8; 16] = *b"0123456789abcdef";
 
-fn write_escape<C, W>(cx: &mut C, writer: &mut W, escape: u8, byte: u8) -> Result<(), C::Error>
+fn write_escape<C, W>(cx: &C, writer: &mut W, escape: u8, byte: u8) -> Result<(), C::Error>
 where
     C: Context<Input = Error>,
     W: Writer,

--- a/crates/musli-json/src/en.rs
+++ b/crates/musli-json/src/en.rs
@@ -291,7 +291,7 @@ where
     }
 
     #[inline]
-    fn encode_pack<C>(self, cx: &C) -> Result<Self::Pack<C::Buf>, C::Error>
+    fn encode_pack<'a, C>(self, cx: &'a C) -> Result<Self::Pack<C::Buf<'a>>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {

--- a/crates/musli-json/src/en.rs
+++ b/crates/musli-json/src/en.rs
@@ -1,6 +1,5 @@
 use core::{fmt, marker};
 
-use musli::context::Buffer;
 use musli::en::{Encoder, PairEncoder, PairsEncoder, SequenceEncoder, VariantEncoder};
 use musli::mode::Mode;
 use musli::Context;
@@ -34,7 +33,7 @@ where
 {
     type Error = Error;
     type Ok = ();
-    type Pack<B> = JsonArrayEncoder<M, W> where B: Buffer;
+    type Pack<'this, C> = JsonArrayEncoder<M, W> where C: 'this + Context;
     type Some = Self;
     type Sequence = JsonArrayEncoder<M, W>;
     type Tuple = JsonArrayEncoder<M, W>;
@@ -291,7 +290,7 @@ where
     }
 
     #[inline]
-    fn encode_pack<'a, C>(self, cx: &'a C) -> Result<Self::Pack<C::Buf<'a>>, C::Error>
+    fn encode_pack<C>(self, cx: &C) -> Result<Self::Pack<'_, C>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {

--- a/crates/musli-json/src/encoding.rs
+++ b/crates/musli-json/src/encoding.rs
@@ -183,7 +183,7 @@ where
     /// This is the same as [`Encoding::encode`] but allows for using a
     /// configurable [`Context`].
     #[inline]
-    pub fn encode_with<C, W, T>(self, cx: &mut C, writer: W, value: &T) -> Result<(), C::Error>
+    pub fn encode_with<C, W, T>(self, cx: &C, writer: W, value: &T) -> Result<(), C::Error>
     where
         C: Context<Input = Error>,
         W: Writer,
@@ -211,7 +211,7 @@ where
     /// configurable [`Context`].
     #[cfg(feature = "alloc")]
     #[inline]
-    pub fn to_string_with<T, C>(self, cx: &mut C, value: &T) -> Result<String, C::Error>
+    pub fn to_string_with<T, C>(self, cx: &C, value: &T) -> Result<String, C::Error>
     where
         C: Context<Input = Error>,
         T: ?Sized + Encode<M>,
@@ -241,7 +241,7 @@ where
     /// This is the same as [`Encoding::decode`] but allows for using a
     /// configurable [`Context`].
     #[inline]
-    pub fn decode_with<'de, C, P, T>(self, cx: &mut C, parser: P) -> Result<T, C::Error>
+    pub fn decode_with<'de, C, P, T>(self, cx: &C, parser: P) -> Result<T, C::Error>
     where
         C: Context<Input = Error>,
         P: Parser<'de>,
@@ -266,7 +266,7 @@ where
     /// This is the same as [`Encoding::from_str`] but allows for using a
     /// configurable [`Context`].
     #[inline]
-    pub fn from_str_with<'de, C, T>(self, cx: &mut C, string: &'de str) -> Result<T, C::Error>
+    pub fn from_str_with<'de, C, T>(self, cx: &C, string: &'de str) -> Result<T, C::Error>
     where
         C: Context<Input = Error>,
         T: Decode<'de, M>,
@@ -292,7 +292,7 @@ where
     /// This is the same as [`Encoding::from_slice`] but allows for using a
     /// configurable [`Context`].
     #[inline]
-    pub fn from_slice_with<'de, C, T>(self, cx: &mut C, bytes: &'de [u8]) -> Result<T, C::Error>
+    pub fn from_slice_with<'de, C, T>(self, cx: &C, bytes: &'de [u8]) -> Result<T, C::Error>
     where
         C: Context<Input = Error>,
         T: Decode<'de, M>,

--- a/crates/musli-json/src/encoding.rs
+++ b/crates/musli-json/src/encoding.rs
@@ -200,7 +200,8 @@ where
     where
         T: ?Sized + Encode<M>,
     {
-        let alloc = musli_common::allocator::Default::default();
+        let mut buf = musli_common::allocator::buffer();
+        let alloc = musli_common::allocator::new(&mut buf);
         let cx = musli_common::context::Same::new(&alloc);
         self.to_string_with(&cx, value)
     }
@@ -230,7 +231,8 @@ where
         P: Parser<'de>,
         T: Decode<'de, M>,
     {
-        let alloc = musli_common::allocator::Default::default();
+        let mut buf = musli_common::allocator::buffer();
+        let alloc = musli_common::allocator::new(&mut buf);
         let cx = musli_common::context::Same::new(&alloc);
         self.decode_with(&cx, parser)
     }
@@ -281,7 +283,8 @@ where
     where
         T: Decode<'de, M>,
     {
-        let alloc = musli_common::allocator::Default::default();
+        let mut buf = musli_common::allocator::buffer();
+        let alloc = musli_common::allocator::new(&mut buf);
         let cx = musli_common::context::Same::new(&alloc);
         self.from_slice_with(&cx, bytes)
     }

--- a/crates/musli-json/src/encoding.rs
+++ b/crates/musli-json/src/encoding.rs
@@ -201,8 +201,8 @@ where
         T: ?Sized + Encode<M>,
     {
         let alloc = musli_common::allocator::Default::default();
-        let mut cx = musli_common::context::Same::new(&alloc);
-        self.to_string_with(&mut cx, value)
+        let cx = musli_common::context::Same::new(&alloc);
+        self.to_string_with(&cx, value)
     }
 
     /// Encode the given value to a [`String`] using the current configuration.
@@ -231,8 +231,8 @@ where
         T: Decode<'de, M>,
     {
         let alloc = musli_common::allocator::Default::default();
-        let mut cx = musli_common::context::Same::new(&alloc);
-        self.decode_with(&mut cx, parser)
+        let cx = musli_common::context::Same::new(&alloc);
+        self.decode_with(&cx, parser)
     }
 
     /// Decode the given type `T` from the given [Parser] using the current
@@ -282,8 +282,8 @@ where
         T: Decode<'de, M>,
     {
         let alloc = musli_common::allocator::Default::default();
-        let mut cx = musli_common::context::Same::new(&alloc);
-        self.from_slice_with(&mut cx, bytes)
+        let cx = musli_common::context::Same::new(&alloc);
+        self.from_slice_with(&cx, bytes)
     }
 
     /// Decode the given type `T` from the given slice using the current

--- a/crates/musli-json/src/reader/integer.rs
+++ b/crates/musli-json/src/reader/integer.rs
@@ -579,8 +579,6 @@ mod traits {
 
         fn checked_add(self, other: Self) -> Option<Self>;
 
-        fn checked_mul(self, other: Self) -> Option<Self>;
-
         fn checked_pow(self, exp: u32) -> Option<Self>;
 
         fn negate(self) -> Option<Self::Signed>;
@@ -594,8 +592,6 @@ mod traits {
 
     pub(crate) trait Signed: Sized + fmt::Debug {
         type Unsigned: Unsigned<Signed = Self>;
-
-        fn negate(self) -> Option<Self::Unsigned>;
     }
 
     pub(crate) trait FromUnsigned<T> {
@@ -703,11 +699,6 @@ mod traits {
                 }
 
                 #[inline(always)]
-                fn checked_mul(self, other: Self) -> Option<Self> {
-                    <$unsigned>::checked_mul(self, other)
-                }
-
-                #[inline(always)]
                 fn checked_pow(self, exp: u32) -> Option<Self> {
                     <$unsigned>::checked_pow(self, exp)
                 }
@@ -738,15 +729,6 @@ mod traits {
 
             impl Signed for $signed {
                 type Unsigned = $unsigned;
-
-                #[inline(always)]
-                fn negate(self) -> Option<Self::Unsigned> {
-                    if self < 0 {
-                        None
-                    } else {
-                        Some(-self as $unsigned)
-                    }
-                }
             }
         };
     }

--- a/crates/musli-json/src/reader/integer.rs
+++ b/crates/musli-json/src/reader/integer.rs
@@ -213,7 +213,7 @@ where
 }
 
 /// Implementation to skip over a well-formed JSON number.
-pub(crate) fn skip_number<'de, C, P>(cx: &mut C, p: &mut P) -> Result<(), C::Error>
+pub(crate) fn skip_number<'de, C, P>(cx: &C, p: &mut P) -> Result<(), C::Error>
 where
     C: Context<Input = Error>,
     P: ?Sized + Parser<'de>,
@@ -263,7 +263,7 @@ where
 /// Partially parse an unsigned value.
 #[cfg_attr(feature = "parse-full", allow(unused))]
 #[inline(never)]
-pub(crate) fn parse_unsigned_base<'de, T, C, P>(cx: &mut C, p: &mut P) -> Result<T, C::Error>
+pub(crate) fn parse_unsigned_base<'de, T, C, P>(cx: &C, p: &mut P) -> Result<T, C::Error>
 where
     T: Unsigned,
     C: Context<Input = Error>,
@@ -278,7 +278,7 @@ where
 /// Fully parse an unsigned value.
 #[cfg_attr(not(feature = "parse-full"), allow(unused))]
 #[inline(never)]
-pub(crate) fn parse_unsigned_full<'de, T, C, P>(cx: &mut C, p: &mut P) -> Result<T, C::Error>
+pub(crate) fn parse_unsigned_full<'de, T, C, P>(cx: &C, p: &mut P) -> Result<T, C::Error>
 where
     T: Unsigned,
     C: Context<Input = Error>,
@@ -296,7 +296,7 @@ where
 
 /// Decode a signed integer.
 #[inline(always)]
-fn decode_signed_base<'de, T, C, P>(cx: &mut C, p: &mut P) -> Result<SignedPartsBase<T>, C::Error>
+fn decode_signed_base<'de, T, C, P>(cx: &C, p: &mut P) -> Result<SignedPartsBase<T>, C::Error>
 where
     C: Context<Input = Error>,
     T: Signed,
@@ -321,7 +321,7 @@ where
 
 /// Decode a full signed integer.
 pub(crate) fn decode_signed_full<'de, T, C, P>(
-    cx: &mut C,
+    cx: &C,
     p: &mut P,
 ) -> Result<SignedPartsFull<T>, C::Error>
 where
@@ -336,10 +336,7 @@ where
 
 /// Decode a full signed integer.
 #[inline(always)]
-fn decode_signed_full_inner<'de, T, C, P>(
-    cx: &mut C,
-    p: &mut P,
-) -> Result<SignedPartsFull<T>, C::Error>
+fn decode_signed_full_inner<'de, T, C, P>(cx: &C, p: &mut P) -> Result<SignedPartsFull<T>, C::Error>
 where
     C: Context<Input = Error>,
     T: Signed,
@@ -365,7 +362,7 @@ where
 /// Fully parse a signed value.
 #[cfg_attr(feature = "parse-full", allow(unused))]
 #[inline(never)]
-pub(crate) fn parse_signed_base<'de, T, C, P>(cx: &mut C, p: &mut P) -> Result<T, C::Error>
+pub(crate) fn parse_signed_base<'de, T, C, P>(cx: &C, p: &mut P) -> Result<T, C::Error>
 where
     T: Signed,
     C: Context<Input = Error>,
@@ -384,7 +381,7 @@ where
 /// Fully parse a signed value.
 #[cfg_attr(not(feature = "parse-full"), allow(unused))]
 #[inline(never)]
-pub(crate) fn parse_signed_full<'de, T, C, P>(cx: &mut C, p: &mut P) -> Result<T, C::Error>
+pub(crate) fn parse_signed_full<'de, T, C, P>(cx: &C, p: &mut P) -> Result<T, C::Error>
 where
     T: Signed,
     C: Context<Input = Error>,
@@ -403,7 +400,7 @@ where
 /// Generically decode a single (whole) integer from a stream of bytes abiding
 /// by JSON convention for format.
 #[inline(always)]
-fn decode_unsigned_base<'de, T, C, P>(cx: &mut C, p: &mut P, start: C::Mark) -> Result<T, C::Error>
+fn decode_unsigned_base<'de, T, C, P>(cx: &C, p: &mut P, start: C::Mark) -> Result<T, C::Error>
 where
     T: Unsigned,
     C: Context<Input = Error>,
@@ -432,7 +429,7 @@ where
 /// by JSON convention for format.
 #[inline(always)]
 fn decode_unsigned_full<'de, T, C, P>(
-    cx: &mut C,
+    cx: &C,
     p: &mut P,
     start: C::Mark,
 ) -> Result<Parts<T>, C::Error>
@@ -486,7 +483,7 @@ where
 
 /// Decode an exponent.
 #[inline(always)]
-fn decode_exponent<'de, C, P>(cx: &mut C, p: &mut P, start: C::Mark) -> Result<i32, C::Error>
+fn decode_exponent<'de, C, P>(cx: &C, p: &mut P, start: C::Mark) -> Result<i32, C::Error>
 where
     C: Context<Input = Error>,
     P: ?Sized + Parser<'de>,
@@ -517,7 +514,7 @@ where
 
 /// Decode a single digit into `out`.
 #[inline(always)]
-fn digit<'de, T, C, P>(cx: &mut C, out: T, p: &mut P, start: C::Mark) -> Result<T, C::Error>
+fn digit<'de, T, C, P>(cx: &C, out: T, p: &mut P, start: C::Mark) -> Result<T, C::Error>
 where
     T: Unsigned,
     C: Context<Input = Error>,
@@ -532,7 +529,7 @@ where
 
 /// Decode sequence of zeros.
 #[inline(always)]
-fn decode_zeros<'de, C, P>(cx: &mut C, p: &mut P) -> Result<i32, C::Error>
+fn decode_zeros<'de, C, P>(cx: &C, p: &mut P) -> Result<i32, C::Error>
 where
     C: Context<Input = Error>,
     P: ?Sized + Parser<'de>,

--- a/crates/musli-json/src/reader/parser.rs
+++ b/crates/musli-json/src/reader/parser.rs
@@ -35,7 +35,7 @@ pub trait Parser<'de>: private::Sealed {
     #[doc(hidden)]
     fn parse_string<'scratch, C, S>(
         &mut self,
-        cx: &mut C,
+        cx: &C,
         validate: bool,
         scratch: &'scratch mut S,
     ) -> Result<StringReference<'de, 'scratch>, C::Error>
@@ -44,17 +44,17 @@ pub trait Parser<'de>: private::Sealed {
         S: ?Sized + Buffer;
 
     #[doc(hidden)]
-    fn read_byte<C>(&mut self, cx: &mut C) -> Result<u8, C::Error>
+    fn read_byte<C>(&mut self, cx: &C) -> Result<u8, C::Error>
     where
         C: Context<Input = Error>;
 
     #[doc(hidden)]
-    fn skip<C>(&mut self, cx: &mut C, n: usize) -> Result<(), C::Error>
+    fn skip<C>(&mut self, cx: &C, n: usize) -> Result<(), C::Error>
     where
         C: Context<Input = Error>;
 
     #[doc(hidden)]
-    fn read<C>(&mut self, cx: &mut C, buf: &mut [u8]) -> Result<(), C::Error>
+    fn read<C>(&mut self, cx: &C, buf: &mut [u8]) -> Result<(), C::Error>
     where
         C: Context<Input = Error>;
 
@@ -63,18 +63,18 @@ pub trait Parser<'de>: private::Sealed {
 
     /// Skip over whitespace.
     #[doc(hidden)]
-    fn skip_whitespace<C>(&mut self, cx: &mut C) -> Result<(), C::Error>
+    fn skip_whitespace<C>(&mut self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Error>;
 
     /// Peek the next byte.
     #[doc(hidden)]
-    fn peek_byte<C>(&mut self, cx: &mut C) -> Result<Option<u8>, C::Error>
+    fn peek_byte<C>(&mut self, cx: &C) -> Result<Option<u8>, C::Error>
     where
         C: Context<Input = Error>;
 
     #[doc(hidden)]
-    fn consume_while<C>(&mut self, cx: &mut C, m: fn(u8) -> bool) -> Result<usize, C::Error>
+    fn consume_while<C>(&mut self, cx: &C, m: fn(u8) -> bool) -> Result<usize, C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -93,7 +93,7 @@ pub trait Parser<'de>: private::Sealed {
     }
 
     #[doc(hidden)]
-    fn peek<C>(&mut self, cx: &mut C) -> Result<Token, C::Error>
+    fn peek<C>(&mut self, cx: &C) -> Result<Token, C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -108,17 +108,17 @@ pub trait Parser<'de>: private::Sealed {
     }
 
     /// Parse a 32-bit floating point number.
-    fn parse_f32<C>(&mut self, cx: &mut C) -> Result<f32, C::Error>
+    fn parse_f32<C>(&mut self, cx: &C) -> Result<f32, C::Error>
     where
         C: Context<Input = Error>;
 
     /// Parse a 64-bit floating point number.
-    fn parse_f64<C>(&mut self, cx: &mut C) -> Result<f64, C::Error>
+    fn parse_f64<C>(&mut self, cx: &C) -> Result<f64, C::Error>
     where
         C: Context<Input = Error>;
 
     #[doc(hidden)]
-    fn parse_hex_escape<C>(&mut self, cx: &mut C) -> Result<u16, C::Error>
+    fn parse_hex_escape<C>(&mut self, cx: &C) -> Result<u16, C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -142,7 +142,7 @@ pub trait Parser<'de>: private::Sealed {
     #[doc(hidden)]
     fn parse_exact<C, const N: usize>(
         &mut self,
-        cx: &mut C,
+        cx: &C,
         exact: [u8; N],
         err: Error,
     ) -> Result<(), C::Error>
@@ -164,7 +164,7 @@ pub trait Parser<'de>: private::Sealed {
     /// Parse an unknown number and try to coerce it into the best fit type
     /// through [NumberVisitor].
     #[doc(hidden)]
-    fn parse_number<C, V>(&mut self, cx: &mut C, visitor: V) -> Result<V::Ok, C::Error>
+    fn parse_number<C, V>(&mut self, cx: &C, visitor: V) -> Result<V::Ok, C::Error>
     where
         C: Context<Input = Error>,
         V: NumberVisitor<'de, C>,
@@ -249,7 +249,7 @@ where
     #[inline(always)]
     fn parse_string<'scratch, C, S>(
         &mut self,
-        cx: &mut C,
+        cx: &C,
         validate: bool,
         scratch: &'scratch mut S,
     ) -> Result<StringReference<'de, 'scratch>, C::Error>
@@ -261,7 +261,7 @@ where
     }
 
     #[inline(always)]
-    fn read_byte<C>(&mut self, cx: &mut C) -> Result<u8, C::Error>
+    fn read_byte<C>(&mut self, cx: &C) -> Result<u8, C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -269,7 +269,7 @@ where
     }
 
     #[inline(always)]
-    fn peek<C>(&mut self, cx: &mut C) -> Result<Token, C::Error>
+    fn peek<C>(&mut self, cx: &C) -> Result<Token, C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -282,7 +282,7 @@ where
     }
 
     #[inline(always)]
-    fn skip_whitespace<C>(&mut self, cx: &mut C) -> Result<(), C::Error>
+    fn skip_whitespace<C>(&mut self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -290,7 +290,7 @@ where
     }
 
     #[inline(always)]
-    fn peek_byte<C>(&mut self, cx: &mut C) -> Result<Option<u8>, C::Error>
+    fn peek_byte<C>(&mut self, cx: &C) -> Result<Option<u8>, C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -298,7 +298,7 @@ where
     }
 
     #[inline(always)]
-    fn skip<C>(&mut self, cx: &mut C, n: usize) -> Result<(), C::Error>
+    fn skip<C>(&mut self, cx: &C, n: usize) -> Result<(), C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -306,7 +306,7 @@ where
     }
 
     #[inline(always)]
-    fn read<C>(&mut self, cx: &mut C, buf: &mut [u8]) -> Result<(), C::Error>
+    fn read<C>(&mut self, cx: &C, buf: &mut [u8]) -> Result<(), C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -314,7 +314,7 @@ where
     }
 
     #[inline(always)]
-    fn parse_f32<C>(&mut self, cx: &mut C) -> Result<f32, C::Error>
+    fn parse_f32<C>(&mut self, cx: &C) -> Result<f32, C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -322,7 +322,7 @@ where
     }
 
     #[inline(always)]
-    fn parse_f64<C>(&mut self, cx: &mut C) -> Result<f64, C::Error>
+    fn parse_f64<C>(&mut self, cx: &C) -> Result<f64, C::Error>
     where
         C: Context<Input = Error>,
     {

--- a/crates/musli-json/src/reader/slice_parser.rs
+++ b/crates/musli-json/src/reader/slice_parser.rs
@@ -33,7 +33,7 @@ impl<'de> Parser<'de> for SliceParser<'de> {
     #[inline]
     fn parse_string<'scratch, C, S>(
         &mut self,
-        cx: &mut C,
+        cx: &C,
         validate: bool,
         scratch: &'scratch mut S,
     ) -> Result<StringReference<'de, 'scratch>, C::Error>
@@ -55,7 +55,7 @@ impl<'de> Parser<'de> for SliceParser<'de> {
     }
 
     #[inline]
-    fn read_byte<C>(&mut self, cx: &mut C) -> Result<u8, C::Error>
+    fn read_byte<C>(&mut self, cx: &C) -> Result<u8, C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -65,7 +65,7 @@ impl<'de> Parser<'de> for SliceParser<'de> {
     }
 
     #[inline]
-    fn skip<C>(&mut self, cx: &mut C, n: usize) -> Result<(), C::Error>
+    fn skip<C>(&mut self, cx: &C, n: usize) -> Result<(), C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -81,7 +81,7 @@ impl<'de> Parser<'de> for SliceParser<'de> {
     }
 
     #[inline]
-    fn read<C>(&mut self, cx: &mut C, buf: &mut [u8]) -> Result<(), C::Error>
+    fn read<C>(&mut self, cx: &C, buf: &mut [u8]) -> Result<(), C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -98,7 +98,7 @@ impl<'de> Parser<'de> for SliceParser<'de> {
     }
 
     #[inline]
-    fn skip_whitespace<C>(&mut self, cx: &mut C) -> Result<(), C::Error>
+    fn skip_whitespace<C>(&mut self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -119,14 +119,14 @@ impl<'de> Parser<'de> for SliceParser<'de> {
     }
 
     #[inline]
-    fn peek_byte<C>(&mut self, _: &mut C) -> Result<Option<u8>, C::Error>
+    fn peek_byte<C>(&mut self, _: &C) -> Result<Option<u8>, C::Error>
     where
         C: Context<Input = Error>,
     {
         Ok(self.slice.get(self.index).copied())
     }
 
-    fn parse_f32<C>(&mut self, cx: &mut C) -> Result<f32, C::Error>
+    fn parse_f32<C>(&mut self, cx: &C) -> Result<f32, C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -145,7 +145,7 @@ impl<'de> Parser<'de> for SliceParser<'de> {
         Ok(value)
     }
 
-    fn parse_f64<C>(&mut self, cx: &mut C) -> Result<f64, C::Error>
+    fn parse_f64<C>(&mut self, cx: &C) -> Result<f64, C::Error>
     where
         C: Context<Input = Error>,
     {

--- a/crates/musli-json/src/reader/string.rs
+++ b/crates/musli-json/src/reader/string.rs
@@ -48,7 +48,7 @@ pub enum StringReference<'de, 'scratch> {
 
 /// Specialized reader implementation from a slice.
 pub(crate) fn parse_string_slice_reader<'de, 'scratch, C, S>(
-    cx: &mut C,
+    cx: &C,
     reader: &mut SliceParser<'de>,
     validate: bool,
     start: C::Mark,
@@ -134,7 +134,7 @@ where
 
 /// Check that the given slice is valid UTF-8.
 #[inline]
-fn check_utf8<C>(cx: &mut C, bytes: &[u8], start: C::Mark) -> Result<(), C::Error>
+fn check_utf8<C>(cx: &C, bytes: &[u8], start: C::Mark) -> Result<(), C::Error>
 where
     C: Context<Input = Error>,
 {
@@ -148,7 +148,7 @@ where
 /// Parses a JSON escape sequence and appends it into the scratch space. Assumes
 /// the previous byte read was a backslash.
 fn parse_escape<C, B>(
-    cx: &mut C,
+    cx: &C,
     parser: &mut SliceParser<'_>,
     validate: bool,
     scratch: &mut B,
@@ -295,7 +295,7 @@ pub(crate) fn decode_hex_val(val: u8) -> Option<u16> {
 }
 
 /// Specialized reader implementation from a slice.
-pub(crate) fn skip_string<'de, C, P>(cx: &mut C, p: &mut P, validate: bool) -> Result<(), C::Error>
+pub(crate) fn skip_string<'de, C, P>(cx: &C, p: &mut P, validate: bool) -> Result<(), C::Error>
 where
     C: Context<Input = Error>,
     P: ?Sized + Parser<'de>,
@@ -329,7 +329,7 @@ where
 
 /// Parses a JSON escape sequence and appends it into the scratch space. Assumes
 /// the previous byte read was a backslash.
-fn skip_escape<'de, C, P>(cx: &mut C, p: &mut P, validate: bool) -> Result<(), C::Error>
+fn skip_escape<'de, C, P>(cx: &C, p: &mut P, validate: bool) -> Result<(), C::Error>
 where
     C: Context<Input = Error>,
     P: ?Sized + Parser<'de>,

--- a/crates/musli-json/src/reader/tests.rs
+++ b/crates/musli-json/src/reader/tests.rs
@@ -6,12 +6,12 @@ use crate::reader::SliceParser;
 #[test]
 fn test_decode_exponent() {
     let alloc = musli_common::allocator::Default::default();
-    let mut cx = musli_common::context::Same::new(&alloc);
+    let cx = musli_common::context::Same::new(&alloc);
 
     macro_rules! test_number {
         ($ty:ty, $num:expr, $expected:expr) => {
             assert_eq!(
-                parse_unsigned_full::<$ty, _, _>(&mut cx, &mut SliceParser::new($num.as_bytes()))
+                parse_unsigned_full::<$ty, _, _>(&cx, &mut SliceParser::new($num.as_bytes()))
                     .unwrap(),
                 $expected
             );
@@ -42,13 +42,13 @@ fn test_decode_exponent() {
 #[test]
 fn test_decode_unsigned() {
     let alloc = musli_common::allocator::Default::default();
-    let mut cx = musli_common::context::Same::new(&alloc);
+    let cx = musli_common::context::Same::new(&alloc);
 
     macro_rules! test_number {
         ($ty:ty, $num:expr) => {
             assert_eq!(
                 parse_unsigned_full::<$ty, _, _>(
-                    &mut cx,
+                    &cx,
                     &mut SliceParser::new(format!("{}", $num).as_bytes())
                 )
                 .unwrap(),
@@ -57,7 +57,7 @@ fn test_decode_unsigned() {
 
             assert_eq!(
                 parse_unsigned_full::<$ty, _, _>(
-                    &mut cx,
+                    &cx,
                     &mut SliceParser::new(format!("{}.", $num).as_bytes())
                 )
                 .unwrap(),
@@ -66,7 +66,7 @@ fn test_decode_unsigned() {
 
             assert_eq!(
                 parse_unsigned_full::<$ty, _, _>(
-                    &mut cx,
+                    &cx,
                     &mut SliceParser::new(format!("{}.0", $num).as_bytes())
                 )
                 .unwrap(),
@@ -75,7 +75,7 @@ fn test_decode_unsigned() {
 
             assert_eq!(
                 parse_unsigned_full::<$ty, _, _>(
-                    &mut cx,
+                    &cx,
                     &mut SliceParser::new(format!("{}.00000", $num).as_bytes())
                 )
                 .unwrap(),
@@ -83,7 +83,7 @@ fn test_decode_unsigned() {
             );
 
             assert!(parse_unsigned_full::<$ty, _, _>(
-                &mut cx,
+                &cx,
                 &mut SliceParser::new(format!("{}.1", $num).as_bytes())
             )
             .is_err());
@@ -109,13 +109,13 @@ fn test_decode_unsigned() {
 #[test]
 fn test_decode_signed() {
     let alloc = musli_common::allocator::Default::default();
-    let mut cx = musli_common::context::Same::new(&alloc);
+    let cx = musli_common::context::Same::new(&alloc);
 
     macro_rules! test_number {
         ($ty:ty, $num:expr) => {
             assert_eq!(
                 parse_signed_full::<$ty, _, _>(
-                    &mut cx,
+                    &cx,
                     &mut SliceParser::new(format!("{}", $num).as_bytes())
                 )
                 .unwrap(),
@@ -124,7 +124,7 @@ fn test_decode_signed() {
 
             assert_eq!(
                 parse_signed_full::<$ty, _, _>(
-                    &mut cx,
+                    &cx,
                     &mut SliceParser::new(format!("{}.", $num).as_bytes())
                 )
                 .unwrap(),
@@ -133,7 +133,7 @@ fn test_decode_signed() {
 
             assert_eq!(
                 parse_signed_full::<$ty, _, _>(
-                    &mut cx,
+                    &cx,
                     &mut SliceParser::new(format!("{}.0", $num).as_bytes())
                 )
                 .unwrap(),
@@ -142,7 +142,7 @@ fn test_decode_signed() {
 
             assert_eq!(
                 parse_signed_full::<$ty, _, _>(
-                    &mut cx,
+                    &cx,
                     &mut SliceParser::new(format!("{}.00000", $num).as_bytes())
                 )
                 .unwrap(),
@@ -150,7 +150,7 @@ fn test_decode_signed() {
             );
 
             assert!(parse_signed_full::<$ty, _, _>(
-                &mut cx,
+                &cx,
                 &mut SliceParser::new(format!("{}.1", $num).as_bytes())
             )
             .is_err());

--- a/crates/musli-json/src/reader/tests.rs
+++ b/crates/musli-json/src/reader/tests.rs
@@ -5,7 +5,8 @@ use crate::reader::SliceParser;
 
 #[test]
 fn test_decode_exponent() {
-    let alloc = musli_common::allocator::Default::default();
+    let mut buf = musli_common::allocator::buffer();
+    let alloc = musli_common::allocator::new(&mut buf);
     let cx = musli_common::context::Same::new(&alloc);
 
     macro_rules! test_number {
@@ -41,7 +42,8 @@ fn test_decode_exponent() {
 
 #[test]
 fn test_decode_unsigned() {
-    let alloc = musli_common::allocator::Default::default();
+    let mut buf = musli_common::allocator::buffer();
+    let alloc = musli_common::allocator::new(&mut buf);
     let cx = musli_common::context::Same::new(&alloc);
 
     macro_rules! test_number {
@@ -108,7 +110,8 @@ fn test_decode_unsigned() {
 
 #[test]
 fn test_decode_signed() {
-    let alloc = musli_common::allocator::Default::default();
+    let mut buf = musli_common::allocator::buffer();
+    let alloc = musli_common::allocator::new(&mut buf);
     let cx = musli_common::context::Same::new(&alloc);
 
     macro_rules! test_number {

--- a/crates/musli-json/tests/trace_collection.rs
+++ b/crates/musli-json/tests/trace_collection.rs
@@ -20,7 +20,7 @@ struct Collection {
 #[test]
 fn trace_collection() {
     let mut alloc = Alloc::default();
-    let mut cx = AllocContext::new(&alloc);
+    let cx = AllocContext::new(&alloc);
 
     let mut values = HashMap::new();
 
@@ -30,7 +30,7 @@ fn trace_collection() {
 
     let encoding = musli_json::Encoding::new();
 
-    let Ok(bytes) = encoding.to_vec_with(&mut cx, &from) else {
+    let Ok(bytes) = encoding.to_vec_with(&cx, &from) else {
         if let Some(error) = cx.errors().next() {
             panic!("{error}");
         }
@@ -38,9 +38,9 @@ fn trace_collection() {
         unreachable!()
     };
 
-    let mut cx = AllocContext::new(&alloc);
+    let cx = AllocContext::new(&alloc);
 
-    let Ok(..) = encoding.from_slice_with::<_, Collection>(&mut cx, &bytes) else {
+    let Ok(..) = encoding.from_slice_with::<_, Collection>(&cx, &bytes) else {
         if let Some(error) = cx.errors().next() {
             assert_eq!(
                 error.to_string(),

--- a/crates/musli-json/tests/trace_collection.rs
+++ b/crates/musli-json/tests/trace_collection.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use musli::{Decode, Encode};
-use musli_common::allocator::Alloc;
+use musli_common::allocator::{Alloc, HeapBuffer};
 use musli_common::context::AllocContext;
 
 #[derive(Encode)]
@@ -19,7 +19,8 @@ struct Collection {
 
 #[test]
 fn trace_collection() {
-    let mut alloc = Alloc::default();
+    let mut buf = HeapBuffer::new();
+    let alloc = Alloc::new(&mut buf);
     let cx = AllocContext::new(&alloc);
 
     let mut values = HashMap::new();

--- a/crates/musli-json/tests/trace_collection.rs
+++ b/crates/musli-json/tests/trace_collection.rs
@@ -31,7 +31,7 @@ fn trace_collection() {
     let encoding = musli_json::Encoding::new();
 
     let Ok(bytes) = encoding.to_vec_with(&mut cx, &from) else {
-        if let Some(error) = cx.iter().next() {
+        if let Some(error) = cx.errors().next() {
             panic!("{error}");
         }
 
@@ -41,7 +41,7 @@ fn trace_collection() {
     let mut cx = AllocContext::new(&alloc);
 
     let Ok(..) = encoding.from_slice_with::<_, Collection>(&mut cx, &bytes) else {
-        if let Some(error) = cx.iter().next() {
+        if let Some(error) = cx.errors().next() {
             assert_eq!(
                 error.to_string(),
                 ".values[Hello]: Invalid numeric (at bytes 15-16)"

--- a/crates/musli-json/tests/trace_complex.rs
+++ b/crates/musli-json/tests/trace_complex.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use musli::{Decode, Encode};
-use musli_common::allocator::Alloc;
+use musli_common::allocator::{Alloc, HeapBuffer};
 use musli_common::context::AllocContext;
 
 #[derive(Encode)]
@@ -33,7 +33,8 @@ struct To {
 
 #[test]
 fn trace_complex() {
-    let mut alloc = Alloc::default();
+    let mut buf = HeapBuffer::new();
+    let alloc = Alloc::new(&mut buf);
     let cx = AllocContext::new(&alloc);
 
     let mut field = HashMap::new();

--- a/crates/musli-json/tests/trace_complex.rs
+++ b/crates/musli-json/tests/trace_complex.rs
@@ -51,7 +51,7 @@ fn trace_complex() {
     let encoding = musli_json::Encoding::new();
 
     let Ok(bytes) = encoding.to_vec_with(&mut cx, &from) else {
-        if let Some(error) = cx.iter().next() {
+        if let Some(error) = cx.errors().next() {
             panic!("{error}");
         }
 
@@ -61,7 +61,7 @@ fn trace_complex() {
     let mut cx = AllocContext::new(&alloc);
 
     let Ok(..) = encoding.from_slice_with::<_, To>(&mut cx, &bytes) else {
-        if let Some(error) = cx.iter().next() {
+        if let Some(error) = cx.errors().next() {
             assert_eq!(error.to_string(), ".field[hello] = Variant2 { .vector[0] }: Expected string, found <number> (at byte 36)");
             return;
         }

--- a/crates/musli-json/tests/trace_complex.rs
+++ b/crates/musli-json/tests/trace_complex.rs
@@ -34,7 +34,7 @@ struct To {
 #[test]
 fn trace_complex() {
     let mut alloc = Alloc::default();
-    let mut cx = AllocContext::new(&alloc);
+    let cx = AllocContext::new(&alloc);
 
     let mut field = HashMap::new();
 
@@ -50,7 +50,7 @@ fn trace_complex() {
 
     let encoding = musli_json::Encoding::new();
 
-    let Ok(bytes) = encoding.to_vec_with(&mut cx, &from) else {
+    let Ok(bytes) = encoding.to_vec_with(&cx, &from) else {
         if let Some(error) = cx.errors().next() {
             panic!("{error}");
         }
@@ -58,9 +58,9 @@ fn trace_complex() {
         unreachable!()
     };
 
-    let mut cx = AllocContext::new(&alloc);
+    let cx = AllocContext::new(&alloc);
 
-    let Ok(..) = encoding.from_slice_with::<_, To>(&mut cx, &bytes) else {
+    let Ok(..) = encoding.from_slice_with::<_, To>(&cx, &bytes) else {
         if let Some(error) = cx.errors().next() {
             assert_eq!(error.to_string(), ".field[hello] = Variant2 { .vector[0] }: Expected string, found <number> (at byte 36)");
             return;

--- a/crates/musli-json/tests/trace_no_std.rs
+++ b/crates/musli-json/tests/trace_no_std.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use musli::{Decode, Encode};
-use musli_common::allocator::NoStd;
+use musli_common::allocator::{NoStd, StackBuffer};
 use musli_common::context::NoStdContext;
 
 #[derive(Encode)]
@@ -19,7 +19,8 @@ struct Collection {
 
 #[test]
 fn trace_no_std() {
-    let alloc = NoStd::<1024>::new();
+    let mut buf = StackBuffer::<1024>::new();
+    let alloc = NoStd::new(&mut buf);
     let cx = NoStdContext::new(&alloc);
 
     let mut values = HashMap::new();

--- a/crates/musli-json/tests/trace_no_std.rs
+++ b/crates/musli-json/tests/trace_no_std.rs
@@ -31,7 +31,7 @@ fn trace_no_std() {
     let encoding = musli_json::Encoding::new();
 
     let Ok(bytes) = encoding.to_vec_with(&mut cx, &from) else {
-        if let Some(error) = cx.iter().next() {
+        if let Some(error) = cx.errors().next() {
             panic!("{error}");
         }
 
@@ -41,7 +41,7 @@ fn trace_no_std() {
     let mut cx = NoStdContext::new(&alloc);
 
     let Ok(..) = encoding.from_slice_with::<_, Collection>(&mut cx, &bytes) else {
-        if let Some(error) = cx.iter().next() {
+        if let Some(error) = cx.errors().next() {
             assert_eq!(
                 error.to_string(),
                 ".values[Hello]: Invalid numeric (at bytes 15-16)"

--- a/crates/musli-json/tests/trace_no_std.rs
+++ b/crates/musli-json/tests/trace_no_std.rs
@@ -20,7 +20,7 @@ struct Collection {
 #[test]
 fn trace_no_std() {
     let alloc = NoStd::<1024>::new();
-    let mut cx = NoStdContext::new(&alloc);
+    let cx = NoStdContext::new(&alloc);
 
     let mut values = HashMap::new();
 
@@ -30,7 +30,7 @@ fn trace_no_std() {
 
     let encoding = musli_json::Encoding::new();
 
-    let Ok(bytes) = encoding.to_vec_with(&mut cx, &from) else {
+    let Ok(bytes) = encoding.to_vec_with(&cx, &from) else {
         if let Some(error) = cx.errors().next() {
             panic!("{error}");
         }
@@ -38,9 +38,9 @@ fn trace_no_std() {
         unreachable!()
     };
 
-    let mut cx = NoStdContext::new(&alloc);
+    let cx = NoStdContext::new(&alloc);
 
-    let Ok(..) = encoding.from_slice_with::<_, Collection>(&mut cx, &bytes) else {
+    let Ok(..) = encoding.from_slice_with::<_, Collection>(&cx, &bytes) else {
         if let Some(error) = cx.errors().next() {
             assert_eq!(
                 error.to_string(),

--- a/crates/musli-macros/Cargo.toml
+++ b/crates/musli-macros/Cargo.toml
@@ -3,7 +3,7 @@ name = "musli-macros"
 version = "0.0.96"
 authors = ["John-John Tedro <udoprog@tedro.se>"]
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.73"
 description = """
 Macros for Müsli.
 """

--- a/crates/musli-macros/src/de.rs
+++ b/crates/musli-macros/src/de.rs
@@ -68,7 +68,7 @@ pub(crate) fn expand_decode_entry(e: Build<'_>) -> Result<TokenStream> {
         #[allow(clippy::let_unit_value)]
         impl #impl_generics #decode_t<#lt, #mode_ident> for #type_ident #type_generics #where_clause {
             #[inline]
-            fn decode<#c_param, #d_param>(#ctx_var: &mut #c_param, #root_decoder_var: #d_param) -> #core_result<Self, <#c_param as #context_t>::Error>
+            fn decode<#c_param, #d_param>(#ctx_var: &#c_param, #root_decoder_var: #d_param) -> #core_result<Self, <#c_param as #context_t>::Error>
             where
                 #c_param: #context_t<Input = <#d_param as #decoder_t<#lt>>::Error>,
                 #d_param: #decoder_t<#lt>

--- a/crates/musli-macros/src/en.rs
+++ b/crates/musli-macros/src/en.rs
@@ -50,7 +50,7 @@ pub(crate) fn expand_encode_entry(e: Build<'_>) -> Result<TokenStream> {
         #[automatically_derived]
         impl #impl_generics #encode_t<#mode_ident> for #type_ident #type_generics #where_clause {
             #[inline]
-            fn encode<#c_param, #e_param>(&self, #ctx_var: &mut #c_param, #encoder_var: #e_param) -> #core_result<<#e_param as #encoder_t>::Ok, <#c_param as #context_t>::Error>
+            fn encode<#c_param, #e_param>(&self, #ctx_var: &#c_param, #encoder_var: #e_param) -> #core_result<<#e_param as #encoder_t>::Ok, <#c_param as #context_t>::Error>
             where
                 #c_param: #context_t<Input = <#e_param as #encoder_t>::Error>,
                 #e_param: #encoder_t

--- a/crates/musli-storage/Cargo.toml
+++ b/crates/musli-storage/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["encoding"]
 
 [features]
 default = ["std", "simdutf8"]
-std = ["musli/std", "musli-common/std", "alloc"]
+std = ["alloc", "musli/std", "musli-common/std"]
 alloc = ["musli/alloc", "musli-common/alloc"]
 test = []
 simdutf8 = ["musli-common/simdutf8"]

--- a/crates/musli-storage/Cargo.toml
+++ b/crates/musli-storage/Cargo.toml
@@ -3,7 +3,7 @@ name = "musli-storage"
 version = "0.0.96"
 authors = ["John-John Tedro <udoprog@tedro.se>"]
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.73"
 description = """
 Partially upgrade stable format for Müsli suitable for storage.
 """

--- a/crates/musli-storage/src/de.rs
+++ b/crates/musli-storage/src/de.rs
@@ -61,7 +61,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_unit<C>(mut self, cx: &mut C) -> Result<(), C::Error>
+    fn decode_unit<C>(mut self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -77,7 +77,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_pack<C>(self, _: &mut C) -> Result<Self::Pack, C::Error>
+    fn decode_pack<C>(self, _: &C) -> Result<Self::Pack, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -85,7 +85,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_array<C, const N: usize>(mut self, cx: &mut C) -> Result<[u8; N], C::Error>
+    fn decode_array<C, const N: usize>(mut self, cx: &C) -> Result<[u8; N], C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -93,7 +93,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_bytes<C, V>(mut self, cx: &mut C, visitor: V) -> Result<V::Ok, C::Error>
+    fn decode_bytes<C, V>(mut self, cx: &C, visitor: V) -> Result<V::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
         V: ValueVisitor<'de, C, [u8]>,
@@ -103,7 +103,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_string<C, V>(self, cx: &mut C, visitor: V) -> Result<V::Ok, C::Error>
+    fn decode_string<C, V>(self, cx: &C, visitor: V) -> Result<V::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
         V: ValueVisitor<'de, C, str>,
@@ -124,21 +124,21 @@ where
 
             #[cfg(feature = "alloc")]
             #[inline(always)]
-            fn visit_owned(self, cx: &mut C, bytes: Vec<u8>) -> Result<Self::Ok, C::Error> {
+            fn visit_owned(self, cx: &C, bytes: Vec<u8>) -> Result<Self::Ok, C::Error> {
                 let string =
                     musli_common::str::from_utf8_owned(bytes).map_err(|error| cx.custom(error))?;
                 self.0.visit_owned(cx, string)
             }
 
             #[inline(always)]
-            fn visit_borrowed(self, cx: &mut C, bytes: &'de [u8]) -> Result<Self::Ok, C::Error> {
+            fn visit_borrowed(self, cx: &C, bytes: &'de [u8]) -> Result<Self::Ok, C::Error> {
                 let string =
                     musli_common::str::from_utf8(bytes).map_err(|error| cx.custom(error))?;
                 self.0.visit_borrowed(cx, string)
             }
 
             #[inline(always)]
-            fn visit_ref(self, cx: &mut C, bytes: &[u8]) -> Result<Self::Ok, C::Error> {
+            fn visit_ref(self, cx: &C, bytes: &[u8]) -> Result<Self::Ok, C::Error> {
                 let string =
                     musli_common::str::from_utf8(bytes).map_err(|error| cx.custom(error))?;
                 self.0.visit_ref(cx, string)
@@ -149,7 +149,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_bool<C>(mut self, cx: &mut C) -> Result<bool, C::Error>
+    fn decode_bool<C>(mut self, cx: &C) -> Result<bool, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -164,7 +164,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_char<C>(self, cx: &mut C) -> Result<char, C::Error>
+    fn decode_char<C>(self, cx: &C) -> Result<char, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -178,7 +178,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_u8<C>(mut self, cx: &mut C) -> Result<u8, C::Error>
+    fn decode_u8<C>(mut self, cx: &C) -> Result<u8, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -186,7 +186,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_u16<C>(self, cx: &mut C) -> Result<u16, C::Error>
+    fn decode_u16<C>(self, cx: &C) -> Result<u16, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -194,7 +194,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_u32<C>(self, cx: &mut C) -> Result<u32, C::Error>
+    fn decode_u32<C>(self, cx: &C) -> Result<u32, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -202,7 +202,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_u64<C>(self, cx: &mut C) -> Result<u64, C::Error>
+    fn decode_u64<C>(self, cx: &C) -> Result<u64, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -210,7 +210,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_u128<C>(self, cx: &mut C) -> Result<u128, C::Error>
+    fn decode_u128<C>(self, cx: &C) -> Result<u128, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -218,7 +218,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_i8<C>(self, cx: &mut C) -> Result<i8, C::Error>
+    fn decode_i8<C>(self, cx: &C) -> Result<i8, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -226,7 +226,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_i16<C>(self, cx: &mut C) -> Result<i16, C::Error>
+    fn decode_i16<C>(self, cx: &C) -> Result<i16, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -234,7 +234,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_i32<C>(self, cx: &mut C) -> Result<i32, C::Error>
+    fn decode_i32<C>(self, cx: &C) -> Result<i32, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -242,7 +242,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_i64<C>(self, cx: &mut C) -> Result<i64, C::Error>
+    fn decode_i64<C>(self, cx: &C) -> Result<i64, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -250,7 +250,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_i128<C>(self, cx: &mut C) -> Result<i128, C::Error>
+    fn decode_i128<C>(self, cx: &C) -> Result<i128, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -258,7 +258,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_usize<C>(self, cx: &mut C) -> Result<usize, C::Error>
+    fn decode_usize<C>(self, cx: &C) -> Result<usize, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -266,7 +266,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_isize<C>(self, cx: &mut C) -> Result<isize, C::Error>
+    fn decode_isize<C>(self, cx: &C) -> Result<isize, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -276,7 +276,7 @@ where
     /// Decode a 32-bit floating point value by reading the 32-bit in-memory
     /// IEEE 754 encoding byte-by-byte.
     #[inline(always)]
-    fn decode_f32<C>(self, cx: &mut C) -> Result<f32, C::Error>
+    fn decode_f32<C>(self, cx: &C) -> Result<f32, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -287,7 +287,7 @@ where
     /// Decode a 64-bit floating point value by reading the 64-bit in-memory
     /// IEEE 754 encoding byte-by-byte.
     #[inline(always)]
-    fn decode_f64<C>(self, cx: &mut C) -> Result<f64, C::Error>
+    fn decode_f64<C>(self, cx: &C) -> Result<f64, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -296,7 +296,7 @@ where
     }
 
     #[inline]
-    fn decode_option<C>(mut self, cx: &mut C) -> Result<Option<Self::Some>, C::Error>
+    fn decode_option<C>(mut self, cx: &C) -> Result<Option<Self::Some>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -305,7 +305,7 @@ where
     }
 
     #[inline]
-    fn decode_sequence<C>(self, cx: &mut C) -> Result<Self::Sequence, C::Error>
+    fn decode_sequence<C>(self, cx: &C) -> Result<Self::Sequence, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -313,7 +313,7 @@ where
     }
 
     #[inline]
-    fn decode_tuple<C>(self, _: &mut C, _: usize) -> Result<Self::Tuple, C::Error>
+    fn decode_tuple<C>(self, _: &C, _: usize) -> Result<Self::Tuple, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -321,7 +321,7 @@ where
     }
 
     #[inline]
-    fn decode_map<C>(self, cx: &mut C) -> Result<Self::Map, C::Error>
+    fn decode_map<C>(self, cx: &C) -> Result<Self::Map, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -329,7 +329,7 @@ where
     }
 
     #[inline]
-    fn decode_struct<C>(self, cx: &mut C, _: usize) -> Result<Self::Struct, C::Error>
+    fn decode_struct<C>(self, cx: &C, _: usize) -> Result<Self::Struct, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -337,7 +337,7 @@ where
     }
 
     #[inline]
-    fn decode_variant<C>(self, _: &mut C) -> Result<Self::Variant, C::Error>
+    fn decode_variant<C>(self, _: &C) -> Result<Self::Variant, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -355,7 +355,7 @@ where
     type Decoder<'this> = StorageDecoder<R::Mut<'this>, F, E> where Self: 'this;
 
     #[inline]
-    fn next<C>(&mut self, _: &mut C) -> Result<Self::Decoder<'_>, C::Error>
+    fn next<C>(&mut self, _: &C) -> Result<Self::Decoder<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -363,7 +363,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<(), C::Error>
+    fn end<C>(self, _: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -378,7 +378,7 @@ where
     E: musli::error::Error,
 {
     #[inline]
-    fn new<C>(cx: &mut C, mut decoder: StorageDecoder<R, F, E>) -> Result<Self, C::Error>
+    fn new<C>(cx: &C, mut decoder: StorageDecoder<R, F, E>) -> Result<Self, C::Error>
     where
         C: Context<Input = E>,
     {
@@ -403,7 +403,7 @@ where
     }
 
     #[inline]
-    fn next<C>(&mut self, _: &mut C) -> Result<Option<Self::Decoder<'_>>, C::Error>
+    fn next<C>(&mut self, _: &C) -> Result<Option<Self::Decoder<'_>>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -416,7 +416,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<(), C::Error>
+    fn end<C>(self, _: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -442,7 +442,7 @@ where
     }
 
     #[inline]
-    fn next<C>(&mut self, _: &mut C) -> Result<Option<Self::Decoder<'_>>, C::Error>
+    fn next<C>(&mut self, _: &C) -> Result<Option<Self::Decoder<'_>>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -455,7 +455,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<(), C::Error>
+    fn end<C>(self, _: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -474,7 +474,7 @@ where
     type Second = Self;
 
     #[inline]
-    fn first<C>(&mut self, _: &mut C) -> Result<Self::First<'_>, C::Error>
+    fn first<C>(&mut self, _: &C) -> Result<Self::First<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -482,7 +482,7 @@ where
     }
 
     #[inline]
-    fn second<C>(self, _: &mut C) -> Result<Self::Second, C::Error>
+    fn second<C>(self, _: &C) -> Result<Self::Second, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -490,7 +490,7 @@ where
     }
 
     #[inline]
-    fn skip_second<C>(self, _: &mut C) -> Result<bool, C::Error>
+    fn skip_second<C>(self, _: &C) -> Result<bool, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -509,7 +509,7 @@ where
     type Variant<'this> = StorageDecoder<R::Mut<'this>, F, E> where Self: 'this;
 
     #[inline]
-    fn tag<C>(&mut self, _: &mut C) -> Result<Self::Tag<'_>, C::Error>
+    fn tag<C>(&mut self, _: &C) -> Result<Self::Tag<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -517,7 +517,7 @@ where
     }
 
     #[inline]
-    fn variant<C>(&mut self, _: &mut C) -> Result<Self::Variant<'_>, C::Error>
+    fn variant<C>(&mut self, _: &C) -> Result<Self::Variant<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -525,7 +525,7 @@ where
     }
 
     #[inline]
-    fn skip_variant<C>(&mut self, _: &mut C) -> Result<bool, C::Error>
+    fn skip_variant<C>(&mut self, _: &C) -> Result<bool, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -533,7 +533,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<(), C::Error>
+    fn end<C>(self, _: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {

--- a/crates/musli-storage/src/en.rs
+++ b/crates/musli-storage/src/en.rs
@@ -53,7 +53,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_unit<C>(self, cx: &mut C) -> Result<Self::Ok, C::Error>
+    fn encode_unit<C>(self, cx: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -61,7 +61,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_pack<C>(self, _: &mut C) -> Result<Self::Pack<C::Buf>, C::Error>
+    fn encode_pack<C>(self, _: &C) -> Result<Self::Pack<C::Buf>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -71,7 +71,7 @@ where
     #[inline(always)]
     fn encode_array<C, const N: usize>(
         mut self,
-        cx: &mut C,
+        cx: &C,
         array: [u8; N],
     ) -> Result<Self::Ok, C::Error>
     where
@@ -81,7 +81,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_bytes<C>(mut self, cx: &mut C, bytes: &[u8]) -> Result<Self::Ok, C::Error>
+    fn encode_bytes<C>(mut self, cx: &C, bytes: &[u8]) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -95,11 +95,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_bytes_vectored<C>(
-        mut self,
-        cx: &mut C,
-        vectors: &[&[u8]],
-    ) -> Result<Self::Ok, C::Error>
+    fn encode_bytes_vectored<C>(mut self, cx: &C, vectors: &[&[u8]]) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -114,7 +110,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_string<C>(mut self, cx: &mut C, string: &str) -> Result<Self::Ok, C::Error>
+    fn encode_string<C>(mut self, cx: &C, string: &str) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -128,7 +124,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_usize<C>(mut self, cx: &mut C, value: usize) -> Result<Self::Ok, C::Error>
+    fn encode_usize<C>(mut self, cx: &C, value: usize) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -136,7 +132,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_isize<C>(self, cx: &mut C, value: isize) -> Result<Self::Ok, C::Error>
+    fn encode_isize<C>(self, cx: &C, value: isize) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -144,7 +140,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_bool<C>(mut self, cx: &mut C, value: bool) -> Result<Self::Ok, C::Error>
+    fn encode_bool<C>(mut self, cx: &C, value: bool) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -153,7 +149,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_char<C>(self, cx: &mut C, value: char) -> Result<Self::Ok, C::Error>
+    fn encode_char<C>(self, cx: &C, value: char) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -161,7 +157,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_u8<C>(mut self, cx: &mut C, value: u8) -> Result<Self::Ok, C::Error>
+    fn encode_u8<C>(mut self, cx: &C, value: u8) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -169,7 +165,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_u16<C>(mut self, cx: &mut C, value: u16) -> Result<Self::Ok, C::Error>
+    fn encode_u16<C>(mut self, cx: &C, value: u16) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -181,7 +177,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_u32<C>(mut self, cx: &mut C, value: u32) -> Result<Self::Ok, C::Error>
+    fn encode_u32<C>(mut self, cx: &C, value: u32) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -193,7 +189,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_u64<C>(mut self, cx: &mut C, value: u64) -> Result<Self::Ok, C::Error>
+    fn encode_u64<C>(mut self, cx: &C, value: u64) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -205,7 +201,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_u128<C>(mut self, cx: &mut C, value: u128) -> Result<Self::Ok, C::Error>
+    fn encode_u128<C>(mut self, cx: &C, value: u128) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -217,7 +213,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_i8<C>(self, cx: &mut C, value: i8) -> Result<Self::Ok, C::Error>
+    fn encode_i8<C>(self, cx: &C, value: i8) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -225,7 +221,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_i16<C>(mut self, cx: &mut C, value: i16) -> Result<Self::Ok, C::Error>
+    fn encode_i16<C>(mut self, cx: &C, value: i16) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -233,7 +229,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_i32<C>(mut self, cx: &mut C, value: i32) -> Result<Self::Ok, C::Error>
+    fn encode_i32<C>(mut self, cx: &C, value: i32) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -241,7 +237,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_i64<C>(mut self, cx: &mut C, value: i64) -> Result<Self::Ok, C::Error>
+    fn encode_i64<C>(mut self, cx: &C, value: i64) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -249,7 +245,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_i128<C>(mut self, cx: &mut C, value: i128) -> Result<Self::Ok, C::Error>
+    fn encode_i128<C>(mut self, cx: &C, value: i128) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -257,7 +253,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_f32<C>(self, cx: &mut C, value: f32) -> Result<Self::Ok, C::Error>
+    fn encode_f32<C>(self, cx: &C, value: f32) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -265,7 +261,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_f64<C>(self, cx: &mut C, value: f64) -> Result<Self::Ok, C::Error>
+    fn encode_f64<C>(self, cx: &C, value: f64) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -273,7 +269,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_some<C>(mut self, cx: &mut C) -> Result<Self::Some, C::Error>
+    fn encode_some<C>(mut self, cx: &C) -> Result<Self::Some, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -282,7 +278,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_none<C>(mut self, cx: &mut C) -> Result<Self::Ok, C::Error>
+    fn encode_none<C>(mut self, cx: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -291,7 +287,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_sequence<C>(mut self, cx: &mut C, len: usize) -> Result<Self::Sequence, C::Error>
+    fn encode_sequence<C>(mut self, cx: &C, len: usize) -> Result<Self::Sequence, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -300,7 +296,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_tuple<C>(self, _: &mut C, _: usize) -> Result<Self::Sequence, C::Error>
+    fn encode_tuple<C>(self, _: &C, _: usize) -> Result<Self::Sequence, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -309,7 +305,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_map<C>(mut self, cx: &mut C, len: usize) -> Result<Self::Map, C::Error>
+    fn encode_map<C>(mut self, cx: &C, len: usize) -> Result<Self::Map, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -318,7 +314,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_struct<C>(mut self, cx: &mut C, len: usize) -> Result<Self::Struct, C::Error>
+    fn encode_struct<C>(mut self, cx: &C, len: usize) -> Result<Self::Struct, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -327,7 +323,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_variant<C>(self, _: &mut C) -> Result<Self::Variant, C::Error>
+    fn encode_variant<C>(self, _: &C) -> Result<Self::Variant, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -346,7 +342,7 @@ where
     type Encoder<'this> = StorageEncoder<W::Mut<'this>, F, E> where Self: 'this;
 
     #[inline]
-    fn next<C>(&mut self, _: &mut C) -> Result<Self::Encoder<'_>, C::Error>
+    fn next<C>(&mut self, _: &C) -> Result<Self::Encoder<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -354,7 +350,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(self, _: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -373,7 +369,7 @@ where
     type Encoder<'this> = StorageEncoder<W::Mut<'this>, F, E> where Self: 'this;
 
     #[inline]
-    fn next<C>(&mut self, _: &mut C) -> Result<Self::Encoder<'_>, C::Error>
+    fn next<C>(&mut self, _: &C) -> Result<Self::Encoder<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -381,7 +377,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(self, _: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -401,7 +397,7 @@ where
     type Second<'this> = StorageEncoder<W::Mut<'this>, F, E> where Self: 'this;
 
     #[inline]
-    fn first<C>(&mut self, _: &mut C) -> Result<Self::First<'_>, C::Error>
+    fn first<C>(&mut self, _: &C) -> Result<Self::First<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -409,7 +405,7 @@ where
     }
 
     #[inline]
-    fn second<C>(&mut self, _: &mut C) -> Result<Self::Second<'_>, C::Error>
+    fn second<C>(&mut self, _: &C) -> Result<Self::Second<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -417,7 +413,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(self, _: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -437,7 +433,7 @@ where
     type Variant<'this> = StorageEncoder<W::Mut<'this>, F, E> where Self: 'this;
 
     #[inline]
-    fn tag<C>(&mut self, _: &mut C) -> Result<Self::Tag<'_>, C::Error>
+    fn tag<C>(&mut self, _: &C) -> Result<Self::Tag<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -445,7 +441,7 @@ where
     }
 
     #[inline]
-    fn variant<C>(&mut self, _: &mut C) -> Result<Self::Variant<'_>, C::Error>
+    fn variant<C>(&mut self, _: &C) -> Result<Self::Variant<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -453,7 +449,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(self, _: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {

--- a/crates/musli-storage/src/en.rs
+++ b/crates/musli-storage/src/en.rs
@@ -1,7 +1,6 @@
 use core::fmt;
 use core::marker;
 
-use musli::context::Buffer;
 use musli::en::{Encoder, PairEncoder, PairsEncoder, SequenceEncoder, VariantEncoder};
 use musli::Context;
 use musli_common::options::{self, Options};
@@ -39,7 +38,7 @@ where
     type Ok = ();
     type Error = E;
 
-    type Pack<B> = Self where B: Buffer;
+    type Pack<'this, C> = Self where C: 'this + Context;
     type Some = Self;
     type Sequence = Self;
     type Tuple = Self;
@@ -61,7 +60,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_pack<'a, C>(self, _: &'a C) -> Result<Self::Pack<C::Buf<'a>>, C::Error>
+    fn encode_pack<C>(self, _: &C) -> Result<Self::Pack<'_, C>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {

--- a/crates/musli-storage/src/en.rs
+++ b/crates/musli-storage/src/en.rs
@@ -61,7 +61,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_pack<C>(self, _: &C) -> Result<Self::Pack<C::Buf>, C::Error>
+    fn encode_pack<'a, C>(self, _: &'a C) -> Result<Self::Pack<C::Buf<'a>>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {

--- a/crates/musli-storage/tests/storage_trace.rs
+++ b/crates/musli-storage/tests/storage_trace.rs
@@ -44,7 +44,7 @@ fn storage_trace() {
     let encoding = musli_storage::Encoding::new();
 
     let Ok(bytes) = encoding.to_vec_with(&mut cx, &from) else {
-        if let Some(error) = cx.iter().next() {
+        if let Some(error) = cx.errors().next() {
             panic!("{error}");
         }
 
@@ -52,7 +52,7 @@ fn storage_trace() {
     };
 
     let Ok(..) = encoding.from_slice_with::<_, To>(&mut cx, &bytes) else {
-        if let Some(error) = cx.iter().next() {
+        if let Some(error) = cx.errors().next() {
             assert_eq!(error.to_string(), ".field = Variant2 { .vector[0] }: Tried to read 42 bytes from slice, with 0 byte remaining (at byte 33)");
             return;
         }

--- a/crates/musli-storage/tests/storage_trace.rs
+++ b/crates/musli-storage/tests/storage_trace.rs
@@ -1,7 +1,7 @@
 #![allow(unused)]
 
 use musli::{Decode, Encode};
-use musli_common::allocator::Alloc;
+use musli_common::allocator::{Alloc, HeapBuffer};
 use musli_common::context::AllocContext;
 
 #[derive(Encode)]
@@ -30,7 +30,8 @@ struct To {
 
 #[test]
 fn storage_trace() {
-    let mut alloc = Alloc::default();
+    let mut buf = HeapBuffer::new();
+    let alloc = Alloc::new(&mut buf);
     let cx = AllocContext::new(&alloc);
 
     let from = From {

--- a/crates/musli-storage/tests/storage_trace.rs
+++ b/crates/musli-storage/tests/storage_trace.rs
@@ -31,7 +31,7 @@ struct To {
 #[test]
 fn storage_trace() {
     let mut alloc = Alloc::default();
-    let mut cx = AllocContext::new(&alloc);
+    let cx = AllocContext::new(&alloc);
 
     let from = From {
         ok: 10,
@@ -43,7 +43,7 @@ fn storage_trace() {
 
     let encoding = musli_storage::Encoding::new();
 
-    let Ok(bytes) = encoding.to_vec_with(&mut cx, &from) else {
+    let Ok(bytes) = encoding.to_vec_with(&cx, &from) else {
         if let Some(error) = cx.errors().next() {
             panic!("{error}");
         }
@@ -51,7 +51,7 @@ fn storage_trace() {
         unreachable!()
     };
 
-    let Ok(..) = encoding.from_slice_with::<_, To>(&mut cx, &bytes) else {
+    let Ok(..) = encoding.from_slice_with::<_, To>(&cx, &bytes) else {
         if let Some(error) = cx.errors().next() {
             assert_eq!(error.to_string(), ".field = Variant2 { .vector[0] }: Tried to read 42 bytes from slice, with 0 byte remaining (at byte 33)");
             return;

--- a/crates/musli-value/Cargo.toml
+++ b/crates/musli-value/Cargo.toml
@@ -3,7 +3,7 @@ name = "musli-value"
 version = "0.0.96"
 authors = ["John-John Tedro <udoprog@tedro.se>"]
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.73"
 description = """
 Buffered value support for Müsli.
 """

--- a/crates/musli-value/Cargo.toml
+++ b/crates/musli-value/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["encoding"]
 [features]
 default = ["std"]
 test = []
-std = ["musli/std", "musli-storage/std", "musli-common/std", "alloc"]
+std = ["alloc", "musli/std", "musli-storage/std", "musli-common/std"]
 alloc = ["musli/alloc", "musli-storage/alloc", "musli-common/alloc"]
 
 [dependencies]

--- a/crates/musli-value/src/de.rs
+++ b/crates/musli-value/src/de.rs
@@ -66,7 +66,7 @@ where
     }
 
     #[inline]
-    fn type_hint<C>(&mut self, _: &mut C) -> Result<TypeHint, C::Error>
+    fn type_hint<C>(&mut self, _: &C) -> Result<TypeHint, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -74,7 +74,7 @@ where
     }
 
     #[inline]
-    fn decode_buffer<M, C>(self, _: &mut C) -> Result<Self::Buffer, C::Error>
+    fn decode_buffer<M, C>(self, _: &C) -> Result<Self::Buffer, C::Error>
     where
         C: Context<Input = Self::Error>,
         M: Mode,
@@ -83,7 +83,7 @@ where
     }
 
     #[inline]
-    fn decode_unit<C>(self, cx: &mut C) -> Result<(), C::Error>
+    fn decode_unit<C>(self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -91,7 +91,7 @@ where
     }
 
     #[inline]
-    fn decode_bool<C>(self, cx: &mut C) -> Result<bool, C::Error>
+    fn decode_bool<C>(self, cx: &C) -> Result<bool, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -99,7 +99,7 @@ where
     }
 
     #[inline]
-    fn decode_char<C>(self, cx: &mut C) -> Result<char, C::Error>
+    fn decode_char<C>(self, cx: &C) -> Result<char, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -107,7 +107,7 @@ where
     }
 
     #[inline]
-    fn decode_u8<C>(self, cx: &mut C) -> Result<u8, C::Error>
+    fn decode_u8<C>(self, cx: &C) -> Result<u8, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -117,7 +117,7 @@ where
     }
 
     #[inline]
-    fn decode_u16<C>(self, cx: &mut C) -> Result<u16, C::Error>
+    fn decode_u16<C>(self, cx: &C) -> Result<u16, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -127,7 +127,7 @@ where
     }
 
     #[inline]
-    fn decode_u32<C>(self, cx: &mut C) -> Result<u32, C::Error>
+    fn decode_u32<C>(self, cx: &C) -> Result<u32, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -137,7 +137,7 @@ where
     }
 
     #[inline]
-    fn decode_u64<C>(self, cx: &mut C) -> Result<u64, C::Error>
+    fn decode_u64<C>(self, cx: &C) -> Result<u64, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -147,7 +147,7 @@ where
     }
 
     #[inline]
-    fn decode_u128<C>(self, cx: &mut C) -> Result<u128, C::Error>
+    fn decode_u128<C>(self, cx: &C) -> Result<u128, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -157,7 +157,7 @@ where
     }
 
     #[inline]
-    fn decode_i8<C>(self, cx: &mut C) -> Result<i8, C::Error>
+    fn decode_i8<C>(self, cx: &C) -> Result<i8, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -167,7 +167,7 @@ where
     }
 
     #[inline]
-    fn decode_i16<C>(self, cx: &mut C) -> Result<i16, C::Error>
+    fn decode_i16<C>(self, cx: &C) -> Result<i16, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -177,7 +177,7 @@ where
     }
 
     #[inline]
-    fn decode_i32<C>(self, cx: &mut C) -> Result<i32, C::Error>
+    fn decode_i32<C>(self, cx: &C) -> Result<i32, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -187,7 +187,7 @@ where
     }
 
     #[inline]
-    fn decode_i64<C>(self, cx: &mut C) -> Result<i64, C::Error>
+    fn decode_i64<C>(self, cx: &C) -> Result<i64, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -197,7 +197,7 @@ where
     }
 
     #[inline]
-    fn decode_i128<C>(self, cx: &mut C) -> Result<i128, C::Error>
+    fn decode_i128<C>(self, cx: &C) -> Result<i128, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -207,7 +207,7 @@ where
     }
 
     #[inline]
-    fn decode_usize<C>(self, cx: &mut C) -> Result<usize, C::Error>
+    fn decode_usize<C>(self, cx: &C) -> Result<usize, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -217,7 +217,7 @@ where
     }
 
     #[inline]
-    fn decode_isize<C>(self, cx: &mut C) -> Result<isize, C::Error>
+    fn decode_isize<C>(self, cx: &C) -> Result<isize, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -227,7 +227,7 @@ where
     }
 
     #[inline]
-    fn decode_f32<C>(self, cx: &mut C) -> Result<f32, C::Error>
+    fn decode_f32<C>(self, cx: &C) -> Result<f32, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -235,7 +235,7 @@ where
     }
 
     #[inline]
-    fn decode_f64<C>(self, cx: &mut C) -> Result<f64, C::Error>
+    fn decode_f64<C>(self, cx: &C) -> Result<f64, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -244,7 +244,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn decode_array<C, const N: usize>(self, cx: &mut C) -> Result<[u8; N], C::Error>
+    fn decode_array<C, const N: usize>(self, cx: &C) -> Result<[u8; N], C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -255,7 +255,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn decode_bytes<C, V>(self, cx: &mut C, visitor: V) -> Result<V::Ok, C::Error>
+    fn decode_bytes<C, V>(self, cx: &C, visitor: V) -> Result<V::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
         V: ValueVisitor<'de, C, [u8]>,
@@ -267,7 +267,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn decode_string<C, V>(self, cx: &mut C, visitor: V) -> Result<V::Ok, C::Error>
+    fn decode_string<C, V>(self, cx: &C, visitor: V) -> Result<V::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
         V: ValueVisitor<'de, C, str>,
@@ -279,7 +279,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn decode_option<C>(self, cx: &mut C) -> Result<Option<Self::Some>, C::Error>
+    fn decode_option<C>(self, cx: &C) -> Result<Option<Self::Some>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -290,7 +290,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn decode_pack<C>(self, cx: &mut C) -> Result<Self::Pack, C::Error>
+    fn decode_pack<C>(self, cx: &C) -> Result<Self::Pack, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -301,7 +301,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn decode_sequence<C>(self, cx: &mut C) -> Result<Self::Sequence, C::Error>
+    fn decode_sequence<C>(self, cx: &C) -> Result<Self::Sequence, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -312,7 +312,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn decode_tuple<C>(self, cx: &mut C, _: usize) -> Result<Self::Tuple, C::Error>
+    fn decode_tuple<C>(self, cx: &C, _: usize) -> Result<Self::Tuple, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -323,7 +323,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn decode_map<C>(self, cx: &mut C) -> Result<Self::Map, C::Error>
+    fn decode_map<C>(self, cx: &C) -> Result<Self::Map, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -334,7 +334,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn decode_struct<C>(self, cx: &mut C, _: usize) -> Result<Self::Struct, C::Error>
+    fn decode_struct<C>(self, cx: &C, _: usize) -> Result<Self::Struct, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -345,7 +345,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn decode_variant<C>(self, cx: &mut C) -> Result<Self::Variant, C::Error>
+    fn decode_variant<C>(self, cx: &C) -> Result<Self::Variant, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -355,7 +355,7 @@ where
     }
 
     #[inline]
-    fn decode_any<C, V>(self, cx: &mut C, visitor: V) -> Result<V::Ok, C::Error>
+    fn decode_any<C, V>(self, cx: &C, visitor: V) -> Result<V::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
         V: Visitor<'de, Error = Self::Error>,
@@ -419,7 +419,7 @@ where
     type Decoder<'this> = ValueDecoder<'this, F, E> where Self: 'this;
 
     #[inline]
-    fn as_decoder<C>(&self, _: &mut C) -> Result<Self::Decoder<'_>, C::Error>
+    fn as_decoder<C>(&self, _: &C) -> Result<Self::Decoder<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -456,7 +456,7 @@ where
         Self: 'this;
 
     #[inline]
-    fn next<C>(&mut self, cx: &mut C) -> Result<Self::Decoder<'_>, C::Error>
+    fn next<C>(&mut self, cx: &C) -> Result<Self::Decoder<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -467,7 +467,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<(), C::Error>
+    fn end<C>(self, _: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -491,7 +491,7 @@ where
     }
 
     #[inline]
-    fn next<C>(&mut self, _: &mut C) -> Result<Option<Self::Decoder<'_>>, C::Error>
+    fn next<C>(&mut self, _: &C) -> Result<Option<Self::Decoder<'_>>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -502,7 +502,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<(), C::Error>
+    fn end<C>(self, _: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -543,7 +543,7 @@ where
     }
 
     #[inline]
-    fn next<C>(&mut self, _: &mut C) -> Result<Option<Self::Decoder<'_>>, C::Error>
+    fn next<C>(&mut self, _: &C) -> Result<Option<Self::Decoder<'_>>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -551,7 +551,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<(), C::Error>
+    fn end<C>(self, _: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -588,7 +588,7 @@ where
     type Second = ValueDecoder<'de, F, E>;
 
     #[inline]
-    fn first<C>(&mut self, _: &mut C) -> Result<Self::First<'_>, C::Error>
+    fn first<C>(&mut self, _: &C) -> Result<Self::First<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -596,7 +596,7 @@ where
     }
 
     #[inline]
-    fn second<C>(self, _: &mut C) -> Result<Self::Second, C::Error>
+    fn second<C>(self, _: &C) -> Result<Self::Second, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -604,7 +604,7 @@ where
     }
 
     #[inline]
-    fn skip_second<C>(self, _: &mut C) -> Result<bool, C::Error>
+    fn skip_second<C>(self, _: &C) -> Result<bool, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -644,7 +644,7 @@ where
         Self: 'this;
 
     #[inline]
-    fn tag<C>(&mut self, _: &mut C) -> Result<Self::Tag<'_>, C::Error>
+    fn tag<C>(&mut self, _: &C) -> Result<Self::Tag<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -652,7 +652,7 @@ where
     }
 
     #[inline]
-    fn variant<C>(&mut self, _: &mut C) -> Result<Self::Variant<'_>, C::Error>
+    fn variant<C>(&mut self, _: &C) -> Result<Self::Variant<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -660,7 +660,7 @@ where
     }
 
     #[inline]
-    fn skip_variant<C>(&mut self, _: &mut C) -> Result<bool, C::Error>
+    fn skip_variant<C>(&mut self, _: &C) -> Result<bool, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -668,7 +668,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<(), C::Error>
+    fn end<C>(self, _: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {

--- a/crates/musli-value/src/en.rs
+++ b/crates/musli-value/src/en.rs
@@ -3,7 +3,6 @@ use alloc::boxed::Box;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
-use musli::context::Buffer;
 use musli::en::Encoder;
 #[cfg(feature = "alloc")]
 use musli::en::{PairEncoder, PairsEncoder, SequenceEncoder, VariantEncoder};
@@ -70,7 +69,7 @@ where
     #[cfg(feature = "alloc")]
     type Some = ValueEncoder<SomeValueWriter<O>>;
     #[cfg(feature = "alloc")]
-    type Pack<B> = SequenceValueEncoder<O> where B: Buffer;
+    type Pack<'this, C> = SequenceValueEncoder<O> where C: 'this + Context;
     #[cfg(feature = "alloc")]
     type Sequence = SequenceValueEncoder<O>;
     #[cfg(feature = "alloc")]
@@ -308,7 +307,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn encode_pack<'a, C>(self, _: &'a C) -> Result<Self::Pack<C::Buf<'a>>, C::Error>
+    fn encode_pack<C>(self, _: &'_ C) -> Result<Self::Pack<'_, C>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {

--- a/crates/musli-value/src/en.rs
+++ b/crates/musli-value/src/en.rs
@@ -88,7 +88,7 @@ where
     }
 
     #[inline]
-    fn encode_unit<C>(self, _: &mut C) -> Result<Self::Ok, C::Error>
+    fn encode_unit<C>(self, _: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -96,7 +96,7 @@ where
     }
 
     #[inline]
-    fn encode_bool<C>(self, _: &mut C, b: bool) -> Result<Self::Ok, C::Error>
+    fn encode_bool<C>(self, _: &C, b: bool) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -105,7 +105,7 @@ where
     }
 
     #[inline]
-    fn encode_char<C>(self, _: &mut C, c: char) -> Result<Self::Ok, C::Error>
+    fn encode_char<C>(self, _: &C, c: char) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -114,7 +114,7 @@ where
     }
 
     #[inline]
-    fn encode_u8<C>(self, _: &mut C, n: u8) -> Result<Self::Ok, C::Error>
+    fn encode_u8<C>(self, _: &C, n: u8) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -123,7 +123,7 @@ where
     }
 
     #[inline]
-    fn encode_u16<C>(self, _: &mut C, n: u16) -> Result<Self::Ok, C::Error>
+    fn encode_u16<C>(self, _: &C, n: u16) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -132,7 +132,7 @@ where
     }
 
     #[inline]
-    fn encode_u32<C>(self, _: &mut C, n: u32) -> Result<Self::Ok, C::Error>
+    fn encode_u32<C>(self, _: &C, n: u32) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -141,7 +141,7 @@ where
     }
 
     #[inline]
-    fn encode_u64<C>(self, _: &mut C, n: u64) -> Result<Self::Ok, C::Error>
+    fn encode_u64<C>(self, _: &C, n: u64) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -150,7 +150,7 @@ where
     }
 
     #[inline]
-    fn encode_u128<C>(self, _: &mut C, n: u128) -> Result<Self::Ok, C::Error>
+    fn encode_u128<C>(self, _: &C, n: u128) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -159,7 +159,7 @@ where
     }
 
     #[inline]
-    fn encode_i8<C>(self, _: &mut C, n: i8) -> Result<Self::Ok, C::Error>
+    fn encode_i8<C>(self, _: &C, n: i8) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -168,7 +168,7 @@ where
     }
 
     #[inline]
-    fn encode_i16<C>(self, _: &mut C, n: i16) -> Result<Self::Ok, C::Error>
+    fn encode_i16<C>(self, _: &C, n: i16) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -177,7 +177,7 @@ where
     }
 
     #[inline]
-    fn encode_i32<C>(self, _: &mut C, n: i32) -> Result<Self::Ok, C::Error>
+    fn encode_i32<C>(self, _: &C, n: i32) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -186,7 +186,7 @@ where
     }
 
     #[inline]
-    fn encode_i64<C>(self, _: &mut C, n: i64) -> Result<Self::Ok, C::Error>
+    fn encode_i64<C>(self, _: &C, n: i64) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -195,7 +195,7 @@ where
     }
 
     #[inline]
-    fn encode_i128<C>(self, _: &mut C, n: i128) -> Result<Self::Ok, C::Error>
+    fn encode_i128<C>(self, _: &C, n: i128) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -204,7 +204,7 @@ where
     }
 
     #[inline]
-    fn encode_usize<C>(self, _: &mut C, n: usize) -> Result<Self::Ok, C::Error>
+    fn encode_usize<C>(self, _: &C, n: usize) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -213,7 +213,7 @@ where
     }
 
     #[inline]
-    fn encode_isize<C>(self, _: &mut C, n: isize) -> Result<Self::Ok, C::Error>
+    fn encode_isize<C>(self, _: &C, n: isize) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -222,7 +222,7 @@ where
     }
 
     #[inline]
-    fn encode_f32<C>(self, _: &mut C, n: f32) -> Result<Self::Ok, C::Error>
+    fn encode_f32<C>(self, _: &C, n: f32) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -231,7 +231,7 @@ where
     }
 
     #[inline]
-    fn encode_f64<C>(self, _: &mut C, n: f64) -> Result<Self::Ok, C::Error>
+    fn encode_f64<C>(self, _: &C, n: f64) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -241,11 +241,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn encode_array<C, const N: usize>(
-        self,
-        _: &mut C,
-        array: [u8; N],
-    ) -> Result<Self::Ok, C::Error>
+    fn encode_array<C, const N: usize>(self, _: &C, array: [u8; N]) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -255,7 +251,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn encode_bytes<C>(self, _: &mut C, bytes: &[u8]) -> Result<Self::Ok, C::Error>
+    fn encode_bytes<C>(self, _: &C, bytes: &[u8]) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -265,7 +261,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn encode_bytes_vectored<C>(self, _: &mut C, input: &[&[u8]]) -> Result<Self::Ok, C::Error>
+    fn encode_bytes_vectored<C>(self, _: &C, input: &[&[u8]]) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -281,7 +277,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn encode_string<C>(self, _: &mut C, string: &str) -> Result<Self::Ok, C::Error>
+    fn encode_string<C>(self, _: &C, string: &str) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -291,7 +287,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn encode_some<C>(self, _: &mut C) -> Result<Self::Some, C::Error>
+    fn encode_some<C>(self, _: &C) -> Result<Self::Some, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -302,7 +298,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn encode_none<C>(self, _: &mut C) -> Result<Self::Ok, C::Error>
+    fn encode_none<C>(self, _: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -312,7 +308,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn encode_pack<C>(self, _: &mut C) -> Result<Self::Pack<C::Buf>, C::Error>
+    fn encode_pack<C>(self, _: &C) -> Result<Self::Pack<C::Buf>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -321,7 +317,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn encode_sequence<C>(self, _: &mut C, _: usize) -> Result<Self::Sequence, C::Error>
+    fn encode_sequence<C>(self, _: &C, _: usize) -> Result<Self::Sequence, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -330,7 +326,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn encode_tuple<C>(self, _: &mut C, _: usize) -> Result<Self::Tuple, C::Error>
+    fn encode_tuple<C>(self, _: &C, _: usize) -> Result<Self::Tuple, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -339,7 +335,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn encode_map<C>(self, _: &mut C, _: usize) -> Result<Self::Map, C::Error>
+    fn encode_map<C>(self, _: &C, _: usize) -> Result<Self::Map, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -348,7 +344,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn encode_struct<C>(self, _: &mut C, _: usize) -> Result<Self::Struct, C::Error>
+    fn encode_struct<C>(self, _: &C, _: usize) -> Result<Self::Struct, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -357,7 +353,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn encode_variant<C>(self, _: &mut C) -> Result<Self::Variant, C::Error>
+    fn encode_variant<C>(self, _: &C) -> Result<Self::Variant, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -395,14 +391,14 @@ where
     where
         Self: 'this;
 
-    fn next<C>(&mut self, _: &mut C) -> Result<Self::Encoder<'_>, C::Error>
+    fn next<C>(&mut self, _: &C) -> Result<Self::Encoder<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
         Ok(ValueEncoder::new(&mut self.values))
     }
 
-    fn end<C>(self, _: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(self, _: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -441,14 +437,14 @@ where
     where
         Self: 'this;
 
-    fn next<C>(&mut self, _: &mut C) -> Result<Self::Encoder<'_>, C::Error>
+    fn next<C>(&mut self, _: &C) -> Result<Self::Encoder<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
         Ok(PairValueEncoder::new(&mut self.values))
     }
 
-    fn end<C>(self, _: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(self, _: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -487,7 +483,7 @@ impl<'a> PairEncoder for PairValueEncoder<'a> {
     type Second<'this> = ValueEncoder<&'this mut Value> where Self: 'this;
 
     #[inline]
-    fn first<C>(&mut self, _: &mut C) -> Result<Self::First<'_>, C::Error>
+    fn first<C>(&mut self, _: &C) -> Result<Self::First<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -495,7 +491,7 @@ impl<'a> PairEncoder for PairValueEncoder<'a> {
     }
 
     #[inline]
-    fn second<C>(&mut self, _: &mut C) -> Result<Self::Second<'_>, C::Error>
+    fn second<C>(&mut self, _: &C) -> Result<Self::Second<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -503,7 +499,7 @@ impl<'a> PairEncoder for PairValueEncoder<'a> {
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(self, _: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -546,21 +542,21 @@ where
     where
         Self: 'this;
 
-    fn tag<C>(&mut self, _: &mut C) -> Result<Self::Tag<'_>, C::Error>
+    fn tag<C>(&mut self, _: &C) -> Result<Self::Tag<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
         Ok(ValueEncoder::new(&mut self.pair.0))
     }
 
-    fn variant<C>(&mut self, _: &mut C) -> Result<Self::Variant<'_>, C::Error>
+    fn variant<C>(&mut self, _: &C) -> Result<Self::Variant<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
         Ok(ValueEncoder::new(&mut self.pair.1))
     }
 
-    fn end<C>(self, _: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(self, _: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {

--- a/crates/musli-value/src/en.rs
+++ b/crates/musli-value/src/en.rs
@@ -308,7 +308,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn encode_pack<C>(self, _: &C) -> Result<Self::Pack<C::Buf>, C::Error>
+    fn encode_pack<'a, C>(self, _: &'a C) -> Result<Self::Pack<C::Buf<'a>>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {

--- a/crates/musli-value/src/lib.rs
+++ b/crates/musli-value/src/lib.rs
@@ -39,7 +39,8 @@ where
     T: Encode,
 {
     let mut output = Value::Unit;
-    let alloc = musli_common::allocator::Default::default();
+    let mut buf = musli_common::allocator::buffer();
+    let alloc = musli_common::allocator::new(&mut buf);
     let cx = musli_common::context::Same::new(&alloc);
     value.encode(&cx, ValueEncoder::new(&mut output))?;
     Ok(output)
@@ -50,7 +51,8 @@ pub fn decode<'de, T>(value: &'de Value) -> Result<T, Error>
 where
     T: Decode<'de>,
 {
-    let alloc = musli_common::allocator::Default::default();
+    let mut buf = musli_common::allocator::buffer();
+    let alloc = musli_common::allocator::new(&mut buf);
     let cx = musli_common::context::Same::new(&alloc);
     T::decode(&cx, value.decoder::<DEFAULT_OPTIONS, _>())
 }

--- a/crates/musli-value/src/lib.rs
+++ b/crates/musli-value/src/lib.rs
@@ -40,8 +40,8 @@ where
 {
     let mut output = Value::Unit;
     let alloc = musli_common::allocator::Default::default();
-    let mut cx = musli_common::context::Same::new(&alloc);
-    value.encode(&mut cx, ValueEncoder::new(&mut output))?;
+    let cx = musli_common::context::Same::new(&alloc);
+    value.encode(&cx, ValueEncoder::new(&mut output))?;
     Ok(output)
 }
 
@@ -51,6 +51,6 @@ where
     T: Decode<'de>,
 {
     let alloc = musli_common::allocator::Default::default();
-    let mut cx = musli_common::context::Same::new(&alloc);
-    T::decode(&mut cx, value.decoder::<DEFAULT_OPTIONS, _>())
+    let cx = musli_common::context::Same::new(&alloc);
+    T::decode(&cx, value.decoder::<DEFAULT_OPTIONS, _>())
 }

--- a/crates/musli-value/src/value.rs
+++ b/crates/musli-value/src/value.rs
@@ -166,7 +166,7 @@ impl<M> Encode<M> for Number
 where
     M: Mode,
 {
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -236,7 +236,7 @@ where
     }
 
     #[inline]
-    fn visit_unit<C>(self, _: &mut C) -> Result<Self::Ok, C::Error>
+    fn visit_unit<C>(self, _: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -244,7 +244,7 @@ where
     }
 
     #[inline]
-    fn visit_bool<C>(self, _: &mut C, value: bool) -> Result<Self::Ok, C::Error>
+    fn visit_bool<C>(self, _: &C, value: bool) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -252,7 +252,7 @@ where
     }
 
     #[inline]
-    fn visit_char<C>(self, _: &mut C, value: char) -> Result<Self::Ok, C::Error>
+    fn visit_char<C>(self, _: &C, value: char) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -260,7 +260,7 @@ where
     }
 
     #[inline]
-    fn visit_u8<C>(self, _: &mut C, value: u8) -> Result<Self::Ok, C::Error>
+    fn visit_u8<C>(self, _: &C, value: u8) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -268,7 +268,7 @@ where
     }
 
     #[inline]
-    fn visit_u16<C>(self, _: &mut C, value: u16) -> Result<Self::Ok, C::Error>
+    fn visit_u16<C>(self, _: &C, value: u16) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -276,7 +276,7 @@ where
     }
 
     #[inline]
-    fn visit_u32<C>(self, _: &mut C, value: u32) -> Result<Self::Ok, C::Error>
+    fn visit_u32<C>(self, _: &C, value: u32) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -284,7 +284,7 @@ where
     }
 
     #[inline]
-    fn visit_u64<C>(self, _: &mut C, value: u64) -> Result<Self::Ok, C::Error>
+    fn visit_u64<C>(self, _: &C, value: u64) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -292,7 +292,7 @@ where
     }
 
     #[inline]
-    fn visit_u128<C>(self, _: &mut C, value: u128) -> Result<Self::Ok, C::Error>
+    fn visit_u128<C>(self, _: &C, value: u128) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -300,7 +300,7 @@ where
     }
 
     #[inline]
-    fn visit_i8<C>(self, _: &mut C, value: i8) -> Result<Self::Ok, C::Error>
+    fn visit_i8<C>(self, _: &C, value: i8) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -308,7 +308,7 @@ where
     }
 
     #[inline]
-    fn visit_i16<C>(self, _: &mut C, value: i16) -> Result<Self::Ok, C::Error>
+    fn visit_i16<C>(self, _: &C, value: i16) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -316,7 +316,7 @@ where
     }
 
     #[inline]
-    fn visit_i32<C>(self, _: &mut C, value: i32) -> Result<Self::Ok, C::Error>
+    fn visit_i32<C>(self, _: &C, value: i32) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -324,7 +324,7 @@ where
     }
 
     #[inline]
-    fn visit_i64<C>(self, _: &mut C, value: i64) -> Result<Self::Ok, C::Error>
+    fn visit_i64<C>(self, _: &C, value: i64) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -332,7 +332,7 @@ where
     }
 
     #[inline]
-    fn visit_i128<C>(self, _: &mut C, value: i128) -> Result<Self::Ok, C::Error>
+    fn visit_i128<C>(self, _: &C, value: i128) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -340,7 +340,7 @@ where
     }
 
     #[inline]
-    fn visit_usize<C>(self, _: &mut C, value: usize) -> Result<Self::Ok, C::Error>
+    fn visit_usize<C>(self, _: &C, value: usize) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -348,7 +348,7 @@ where
     }
 
     #[inline]
-    fn visit_isize<C>(self, _: &mut C, value: isize) -> Result<Self::Ok, C::Error>
+    fn visit_isize<C>(self, _: &C, value: isize) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -356,7 +356,7 @@ where
     }
 
     #[inline]
-    fn visit_f32<C>(self, _: &mut C, value: f32) -> Result<Self::Ok, C::Error>
+    fn visit_f32<C>(self, _: &C, value: f32) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -364,7 +364,7 @@ where
     }
 
     #[inline]
-    fn visit_f64<C>(self, _: &mut C, value: f64) -> Result<Self::Ok, C::Error>
+    fn visit_f64<C>(self, _: &C, value: f64) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -373,7 +373,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn visit_option<C, D>(self, cx: &mut C, decoder: Option<D>) -> Result<Self::Ok, C::Error>
+    fn visit_option<C, D>(self, cx: &C, decoder: Option<D>) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
         D: Decoder<'de, Error = Self::Error>,
@@ -388,7 +388,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn visit_sequence<C, D>(self, cx: &mut C, mut seq: D) -> Result<Self::Ok, C::Error>
+    fn visit_sequence<C, D>(self, cx: &C, mut seq: D) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
         D: SequenceDecoder<'de, Error = Self::Error>,
@@ -405,7 +405,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn visit_map<C, D>(self, cx: &mut C, mut map: D) -> Result<Self::Ok, C::Error>
+    fn visit_map<C, D>(self, cx: &C, mut map: D) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
         D: PairsDecoder<'de, Error = Self::Error>,
@@ -426,7 +426,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn visit_bytes<C>(self, _: &mut C, _: SizeHint) -> Result<Self::Bytes<C>, C::Error>
+    fn visit_bytes<C>(self, _: &C, _: SizeHint) -> Result<Self::Bytes<C>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -435,7 +435,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn visit_string<C>(self, _: &mut C, _: SizeHint) -> Result<Self::String<C>, C::Error>
+    fn visit_string<C>(self, _: &C, _: SizeHint) -> Result<Self::String<C>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -444,7 +444,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn visit_number<C>(self, _: &mut C, _: NumberHint) -> Result<Self::Number<C>, C::Error>
+    fn visit_number<C>(self, _: &C, _: NumberHint) -> Result<Self::Number<C>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -453,7 +453,7 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn visit_variant<C, D>(self, cx: &mut C, mut variant: D) -> Result<Self::Ok, C::Error>
+    fn visit_variant<C, D>(self, cx: &C, mut variant: D) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
         D: VariantDecoder<'de, Error = Self::Error>,
@@ -471,7 +471,7 @@ impl<'de, M> Decode<'de, M> for Value
 where
     M: Mode,
 {
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,
@@ -497,12 +497,12 @@ where
 
     #[cfg(feature = "alloc")]
     #[inline]
-    fn visit_owned(self, _: &mut C, bytes: Vec<u8>) -> Result<Self::Ok, C::Error> {
+    fn visit_owned(self, _: &C, bytes: Vec<u8>) -> Result<Self::Ok, C::Error> {
         Ok(Value::Bytes(bytes))
     }
 
     #[inline]
-    fn visit_ref(self, _: &mut C, bytes: &[u8]) -> Result<Self::Ok, C::Error> {
+    fn visit_ref(self, _: &C, bytes: &[u8]) -> Result<Self::Ok, C::Error> {
         Ok(Value::Bytes(bytes.to_vec()))
     }
 }
@@ -523,12 +523,12 @@ where
     }
 
     #[inline]
-    fn visit_owned(self, _: &mut C, string: String) -> Result<Self::Ok, C::Error> {
+    fn visit_owned(self, _: &C, string: String) -> Result<Self::Ok, C::Error> {
         Ok(Value::String(string))
     }
 
     #[inline]
-    fn visit_ref(self, _: &mut C, string: &str) -> Result<Self::Ok, C::Error> {
+    fn visit_ref(self, _: &C, string: &str) -> Result<Self::Ok, C::Error> {
         Ok(Value::String(string.to_owned()))
     }
 }
@@ -547,72 +547,72 @@ where
     }
 
     #[inline]
-    fn visit_u8(self, _: &mut C, value: u8) -> Result<Self::Ok, C::Error> {
+    fn visit_u8(self, _: &C, value: u8) -> Result<Self::Ok, C::Error> {
         Ok(Value::Number(Number::U8(value)))
     }
 
     #[inline]
-    fn visit_u16(self, _: &mut C, value: u16) -> Result<Self::Ok, C::Error> {
+    fn visit_u16(self, _: &C, value: u16) -> Result<Self::Ok, C::Error> {
         Ok(Value::Number(Number::U16(value)))
     }
 
     #[inline]
-    fn visit_u32(self, _: &mut C, value: u32) -> Result<Self::Ok, C::Error> {
+    fn visit_u32(self, _: &C, value: u32) -> Result<Self::Ok, C::Error> {
         Ok(Value::Number(Number::U32(value)))
     }
 
     #[inline]
-    fn visit_u64(self, _: &mut C, value: u64) -> Result<Self::Ok, C::Error> {
+    fn visit_u64(self, _: &C, value: u64) -> Result<Self::Ok, C::Error> {
         Ok(Value::Number(Number::U64(value)))
     }
 
     #[inline]
-    fn visit_u128(self, _: &mut C, value: u128) -> Result<Self::Ok, C::Error> {
+    fn visit_u128(self, _: &C, value: u128) -> Result<Self::Ok, C::Error> {
         Ok(Value::Number(Number::U128(value)))
     }
 
     #[inline]
-    fn visit_i8(self, _: &mut C, value: i8) -> Result<Self::Ok, C::Error> {
+    fn visit_i8(self, _: &C, value: i8) -> Result<Self::Ok, C::Error> {
         Ok(Value::Number(Number::I8(value)))
     }
 
     #[inline]
-    fn visit_i16(self, _: &mut C, value: i16) -> Result<Self::Ok, C::Error> {
+    fn visit_i16(self, _: &C, value: i16) -> Result<Self::Ok, C::Error> {
         Ok(Value::Number(Number::I16(value)))
     }
 
     #[inline]
-    fn visit_i32(self, _: &mut C, value: i32) -> Result<Self::Ok, C::Error> {
+    fn visit_i32(self, _: &C, value: i32) -> Result<Self::Ok, C::Error> {
         Ok(Value::Number(Number::I32(value)))
     }
 
     #[inline]
-    fn visit_i64(self, _: &mut C, value: i64) -> Result<Self::Ok, C::Error> {
+    fn visit_i64(self, _: &C, value: i64) -> Result<Self::Ok, C::Error> {
         Ok(Value::Number(Number::I64(value)))
     }
 
     #[inline]
-    fn visit_i128(self, _: &mut C, value: i128) -> Result<Self::Ok, C::Error> {
+    fn visit_i128(self, _: &C, value: i128) -> Result<Self::Ok, C::Error> {
         Ok(Value::Number(Number::I128(value)))
     }
 
     #[inline]
-    fn visit_f32(self, _: &mut C, value: f32) -> Result<Self::Ok, C::Error> {
+    fn visit_f32(self, _: &C, value: f32) -> Result<Self::Ok, C::Error> {
         Ok(Value::Number(Number::F32(value)))
     }
 
     #[inline]
-    fn visit_f64(self, _: &mut C, value: f64) -> Result<Self::Ok, C::Error> {
+    fn visit_f64(self, _: &C, value: f64) -> Result<Self::Ok, C::Error> {
         Ok(Value::Number(Number::F64(value)))
     }
 
     #[inline]
-    fn visit_usize(self, _: &mut C, value: usize) -> Result<Self::Ok, C::Error> {
+    fn visit_usize(self, _: &C, value: usize) -> Result<Self::Ok, C::Error> {
         Ok(Value::Number(Number::Usize(value)))
     }
 
     #[inline]
-    fn visit_isize(self, _: &mut C, value: isize) -> Result<Self::Ok, C::Error> {
+    fn visit_isize(self, _: &C, value: isize) -> Result<Self::Ok, C::Error> {
         Ok(Value::Number(Number::Isize(value)))
     }
 }
@@ -621,7 +621,7 @@ impl<M> Encode<M> for Value
 where
     M: Mode,
 {
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -699,7 +699,7 @@ where
     type Decoder<'this> = ValueDecoder<'this, F, E> where Self: 'this;
 
     #[inline]
-    fn as_decoder<C>(&self, _: &mut C) -> Result<Self::Decoder<'_>, C::Error>
+    fn as_decoder<C>(&self, _: &C) -> Result<Self::Decoder<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {

--- a/crates/musli-wire/Cargo.toml
+++ b/crates/musli-wire/Cargo.toml
@@ -3,7 +3,7 @@ name = "musli-wire"
 version = "0.0.96"
 authors = ["John-John Tedro <udoprog@tedro.se>"]
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.73"
 description = """
 Fully upgrade stable format for Müsli suitable for network communication.
 """

--- a/crates/musli-wire/Cargo.toml
+++ b/crates/musli-wire/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["encoding"]
 
 [features]
 default = ["std", "simdutf8"]
-std = ["musli/std", "musli-common/std", "musli-storage/std", "alloc"]
+std = ["alloc", "musli/std", "musli-common/std", "musli-storage/std"]
 alloc = ["musli/alloc", "musli-common/alloc", "musli-storage/alloc"]
 test = []
 simdutf8 = ["musli-common/simdutf8"]

--- a/crates/musli-wire/src/de.rs
+++ b/crates/musli-wire/src/de.rs
@@ -36,7 +36,7 @@ where
     Error: From<R::Error>,
 {
     /// Skip over any sequences of values.
-    pub(crate) fn skip_any<C>(&mut self, cx: &mut C) -> Result<(), C::Error>
+    pub(crate) fn skip_any<C>(&mut self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -78,7 +78,7 @@ where
     }
 
     #[inline]
-    fn decode_sequence_len<C>(&mut self, cx: &mut C) -> Result<usize, C::Error>
+    fn decode_sequence_len<C>(&mut self, cx: &C) -> Result<usize, C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -101,7 +101,7 @@ where
     #[inline]
     fn shared_decode_pair_sequence<C>(
         mut self,
-        cx: &mut C,
+        cx: &C,
     ) -> Result<RemainingWireDecoder<R, F>, C::Error>
     where
         C: Context<Input = Error>,
@@ -112,10 +112,7 @@ where
 
     // Standard function for decoding a pair sequence.
     #[inline]
-    fn shared_decode_sequence<C>(
-        mut self,
-        cx: &mut C,
-    ) -> Result<RemainingWireDecoder<R, F>, C::Error>
+    fn shared_decode_sequence<C>(mut self, cx: &C) -> Result<RemainingWireDecoder<R, F>, C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -125,7 +122,7 @@ where
 
     /// Decode the length of a prefix.
     #[inline]
-    fn decode_len<C>(&mut self, cx: &mut C, start: C::Mark) -> Result<usize, C::Error>
+    fn decode_len<C>(&mut self, cx: &C, start: C::Mark) -> Result<usize, C::Error>
     where
         C: Context<Input = Error>,
     {
@@ -180,7 +177,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_unit<C>(mut self, cx: &mut C) -> Result<(), C::Error>
+    fn decode_unit<C>(mut self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -189,7 +186,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_pack<C>(mut self, cx: &mut C) -> Result<Self::Pack, C::Error>
+    fn decode_pack<C>(mut self, cx: &C) -> Result<Self::Pack, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -199,7 +196,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_array<C, const N: usize>(mut self, cx: &mut C) -> Result<[u8; N], C::Error>
+    fn decode_array<C, const N: usize>(mut self, cx: &C) -> Result<[u8; N], C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -220,7 +217,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_bytes<C, V>(mut self, cx: &mut C, visitor: V) -> Result<V::Ok, C::Error>
+    fn decode_bytes<C, V>(mut self, cx: &C, visitor: V) -> Result<V::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
         V: ValueVisitor<'de, C, [u8]>,
@@ -231,7 +228,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_string<C, V>(self, cx: &mut C, visitor: V) -> Result<V::Ok, C::Error>
+    fn decode_string<C, V>(self, cx: &C, visitor: V) -> Result<V::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
         V: ValueVisitor<'de, C, str>,
@@ -252,20 +249,20 @@ where
 
             #[cfg(feature = "alloc")]
             #[inline(always)]
-            fn visit_owned(self, cx: &mut C, bytes: Vec<u8>) -> Result<Self::Ok, C::Error> {
+            fn visit_owned(self, cx: &C, bytes: Vec<u8>) -> Result<Self::Ok, C::Error> {
                 let string =
                     musli_common::str::from_utf8_owned(bytes).map_err(|err| cx.custom(err))?;
                 self.0.visit_owned(cx, string)
             }
 
             #[inline(always)]
-            fn visit_borrowed(self, cx: &mut C, bytes: &'de [u8]) -> Result<Self::Ok, C::Error> {
+            fn visit_borrowed(self, cx: &C, bytes: &'de [u8]) -> Result<Self::Ok, C::Error> {
                 let string = musli_common::str::from_utf8(bytes).map_err(|err| cx.custom(err))?;
                 self.0.visit_borrowed(cx, string)
             }
 
             #[inline(always)]
-            fn visit_ref(self, cx: &mut C, bytes: &[u8]) -> Result<Self::Ok, C::Error> {
+            fn visit_ref(self, cx: &C, bytes: &[u8]) -> Result<Self::Ok, C::Error> {
                 let string = musli_common::str::from_utf8(bytes).map_err(|err| cx.custom(err))?;
                 self.0.visit_ref(cx, string)
             }
@@ -275,7 +272,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_bool<C>(mut self, cx: &mut C) -> Result<bool, C::Error>
+    fn decode_bool<C>(mut self, cx: &C) -> Result<bool, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -292,7 +289,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_char<C>(self, cx: &mut C) -> Result<char, C::Error>
+    fn decode_char<C>(self, cx: &C) -> Result<char, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -305,7 +302,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_u8<C>(self, cx: &mut C) -> Result<u8, C::Error>
+    fn decode_u8<C>(self, cx: &C) -> Result<u8, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -313,7 +310,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_u16<C>(self, cx: &mut C) -> Result<u16, C::Error>
+    fn decode_u16<C>(self, cx: &C) -> Result<u16, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -321,7 +318,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_u32<C>(self, cx: &mut C) -> Result<u32, C::Error>
+    fn decode_u32<C>(self, cx: &C) -> Result<u32, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -329,7 +326,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_u64<C>(self, cx: &mut C) -> Result<u64, C::Error>
+    fn decode_u64<C>(self, cx: &C) -> Result<u64, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -337,7 +334,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_u128<C>(self, cx: &mut C) -> Result<u128, C::Error>
+    fn decode_u128<C>(self, cx: &C) -> Result<u128, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -345,7 +342,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_i8<C>(self, cx: &mut C) -> Result<i8, C::Error>
+    fn decode_i8<C>(self, cx: &C) -> Result<i8, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -353,7 +350,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_i16<C>(self, cx: &mut C) -> Result<i16, C::Error>
+    fn decode_i16<C>(self, cx: &C) -> Result<i16, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -361,7 +358,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_i32<C>(self, cx: &mut C) -> Result<i32, C::Error>
+    fn decode_i32<C>(self, cx: &C) -> Result<i32, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -369,7 +366,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_i64<C>(self, cx: &mut C) -> Result<i64, C::Error>
+    fn decode_i64<C>(self, cx: &C) -> Result<i64, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -377,7 +374,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_i128<C>(self, cx: &mut C) -> Result<i128, C::Error>
+    fn decode_i128<C>(self, cx: &C) -> Result<i128, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -385,7 +382,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_usize<C>(self, cx: &mut C) -> Result<usize, C::Error>
+    fn decode_usize<C>(self, cx: &C) -> Result<usize, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -393,7 +390,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_isize<C>(self, cx: &mut C) -> Result<isize, C::Error>
+    fn decode_isize<C>(self, cx: &C) -> Result<isize, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -403,7 +400,7 @@ where
     /// Decode a 32-bit floating point value by reading the 32-bit in-memory
     /// IEEE 754 encoding byte-by-byte.
     #[inline(always)]
-    fn decode_f32<C>(self, cx: &mut C) -> Result<f32, C::Error>
+    fn decode_f32<C>(self, cx: &C) -> Result<f32, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -414,7 +411,7 @@ where
     /// Decode a 64-bit floating point value by reading the 64-bit in-memory
     /// IEEE 754 encoding byte-by-byte.
     #[inline(always)]
-    fn decode_f64<C>(self, cx: &mut C) -> Result<f64, C::Error>
+    fn decode_f64<C>(self, cx: &C) -> Result<f64, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -423,7 +420,7 @@ where
     }
 
     #[inline(always)]
-    fn decode_option<C>(mut self, cx: &mut C) -> Result<Option<Self::Some>, C::Error>
+    fn decode_option<C>(mut self, cx: &C) -> Result<Option<Self::Some>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -441,7 +438,7 @@ where
     }
 
     #[inline]
-    fn decode_sequence<C>(self, cx: &mut C) -> Result<Self::Sequence, C::Error>
+    fn decode_sequence<C>(self, cx: &C) -> Result<Self::Sequence, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -449,7 +446,7 @@ where
     }
 
     #[inline]
-    fn decode_tuple<C>(mut self, cx: &mut C, len: usize) -> Result<Self::Tuple, C::Error>
+    fn decode_tuple<C>(mut self, cx: &C, len: usize) -> Result<Self::Tuple, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -465,7 +462,7 @@ where
     }
 
     #[inline]
-    fn decode_map<C>(self, cx: &mut C) -> Result<Self::Map, C::Error>
+    fn decode_map<C>(self, cx: &C) -> Result<Self::Map, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -473,7 +470,7 @@ where
     }
 
     #[inline]
-    fn decode_struct<C>(self, cx: &mut C, _: usize) -> Result<Self::Struct, C::Error>
+    fn decode_struct<C>(self, cx: &C, _: usize) -> Result<Self::Struct, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -481,7 +478,7 @@ where
     }
 
     #[inline]
-    fn decode_variant<C>(mut self, cx: &mut C) -> Result<Self::Variant, C::Error>
+    fn decode_variant<C>(mut self, cx: &C) -> Result<Self::Variant, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -507,7 +504,7 @@ where
     type Decoder<'this> = StorageDecoder<<Limit<R> as Reader<'de>>::Mut<'this>, F, Error> where Self: 'this;
 
     #[inline]
-    fn next<C>(&mut self, _: &mut C) -> Result<Self::Decoder<'_>, C::Error>
+    fn next<C>(&mut self, _: &C) -> Result<Self::Decoder<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -515,7 +512,7 @@ where
     }
 
     #[inline]
-    fn end<C>(mut self, cx: &mut C) -> Result<(), C::Error>
+    fn end<C>(mut self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -552,7 +549,7 @@ where
     }
 
     #[inline]
-    fn next<C>(&mut self, _: &mut C) -> Result<Option<Self::Decoder<'_>>, C::Error>
+    fn next<C>(&mut self, _: &C) -> Result<Option<Self::Decoder<'_>>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -565,7 +562,7 @@ where
     }
 
     #[inline]
-    fn end<C>(mut self, cx: &mut C) -> Result<(), C::Error>
+    fn end<C>(mut self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -588,7 +585,7 @@ where
     type Second = Self;
 
     #[inline]
-    fn first<C>(&mut self, _: &mut C) -> Result<Self::First<'_>, C::Error>
+    fn first<C>(&mut self, _: &C) -> Result<Self::First<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -596,7 +593,7 @@ where
     }
 
     #[inline]
-    fn second<C>(self, _: &mut C) -> Result<Self::Second, C::Error>
+    fn second<C>(self, _: &C) -> Result<Self::Second, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -604,7 +601,7 @@ where
     }
 
     #[inline]
-    fn skip_second<C>(mut self, cx: &mut C) -> Result<bool, C::Error>
+    fn skip_second<C>(mut self, cx: &C) -> Result<bool, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -623,7 +620,7 @@ where
     type Variant<'this> = WireDecoder<R::Mut<'this>, F> where Self: 'this;
 
     #[inline]
-    fn tag<C>(&mut self, _: &mut C) -> Result<Self::Tag<'_>, C::Error>
+    fn tag<C>(&mut self, _: &C) -> Result<Self::Tag<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -631,7 +628,7 @@ where
     }
 
     #[inline]
-    fn variant<C>(&mut self, _: &mut C) -> Result<Self::Variant<'_>, C::Error>
+    fn variant<C>(&mut self, _: &C) -> Result<Self::Variant<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -639,7 +636,7 @@ where
     }
 
     #[inline]
-    fn skip_variant<C>(&mut self, cx: &mut C) -> Result<bool, C::Error>
+    fn skip_variant<C>(&mut self, cx: &C) -> Result<bool, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -648,7 +645,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<(), C::Error>
+    fn end<C>(self, _: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -673,7 +670,7 @@ where
     }
 
     #[inline]
-    fn next<C>(&mut self, _: &mut C) -> Result<Option<Self::Decoder<'_>>, C::Error>
+    fn next<C>(&mut self, _: &C) -> Result<Option<Self::Decoder<'_>>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -686,7 +683,7 @@ where
     }
 
     #[inline]
-    fn end<C>(mut self, cx: &mut C) -> Result<(), C::Error>
+    fn end<C>(mut self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -779,7 +776,7 @@ where
     type Decoder<'this> = WireDecoder<R::Mut<'this>, F> where Self: 'this;
 
     #[inline]
-    fn next<C>(&mut self, cx: &mut C) -> Result<Self::Decoder<'_>, C::Error>
+    fn next<C>(&mut self, cx: &C) -> Result<Self::Decoder<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -792,7 +789,7 @@ where
     }
 
     #[inline]
-    fn end<C>(mut self, cx: &mut C) -> Result<(), C::Error>
+    fn end<C>(mut self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {

--- a/crates/musli-wire/src/en.rs
+++ b/crates/musli-wire/src/en.rs
@@ -80,7 +80,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_pack<C>(self, cx: &C) -> Result<Self::Pack<C::Buf>, C::Error>
+    fn encode_pack<'a, C>(self, cx: &'a C) -> Result<Self::Pack<C::Buf<'a>>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {

--- a/crates/musli-wire/src/en.rs
+++ b/crates/musli-wire/src/en.rs
@@ -84,7 +84,11 @@ where
     where
         C: Context<Input = Self::Error>,
     {
-        Ok(WirePackEncoder::new(self.writer, cx.alloc()))
+        let Some(buf) = cx.alloc() else {
+            return Err(cx.message("Failed to allocate pack buffer"));
+        };
+
+        Ok(WirePackEncoder::new(self.writer, buf))
     }
 
     #[inline(always)]

--- a/crates/musli-wire/src/en.rs
+++ b/crates/musli-wire/src/en.rs
@@ -70,7 +70,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_unit<C>(mut self, cx: &mut C) -> Result<Self::Ok, C::Error>
+    fn encode_unit<C>(mut self, cx: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -80,7 +80,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_pack<C>(self, cx: &mut C) -> Result<Self::Pack<C::Buf>, C::Error>
+    fn encode_pack<C>(self, cx: &C) -> Result<Self::Pack<C::Buf>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -94,11 +94,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_array<C, const N: usize>(
-        self,
-        cx: &mut C,
-        array: [u8; N],
-    ) -> Result<Self::Ok, C::Error>
+    fn encode_array<C, const N: usize>(self, cx: &C, array: [u8; N]) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -106,7 +102,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_bytes<C>(mut self, cx: &mut C, bytes: &[u8]) -> Result<Self::Ok, C::Error>
+    fn encode_bytes<C>(mut self, cx: &C, bytes: &[u8]) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -116,11 +112,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_bytes_vectored<C>(
-        mut self,
-        cx: &mut C,
-        vectors: &[&[u8]],
-    ) -> Result<Self::Ok, C::Error>
+    fn encode_bytes_vectored<C>(mut self, cx: &C, vectors: &[&[u8]]) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -135,7 +127,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_string<C>(self, cx: &mut C, string: &str) -> Result<Self::Ok, C::Error>
+    fn encode_string<C>(self, cx: &C, string: &str) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -143,7 +135,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_usize<C>(mut self, cx: &mut C, value: usize) -> Result<Self::Ok, C::Error>
+    fn encode_usize<C>(mut self, cx: &C, value: usize) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -151,7 +143,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_isize<C>(mut self, cx: &mut C, value: isize) -> Result<Self::Ok, C::Error>
+    fn encode_isize<C>(mut self, cx: &C, value: isize) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -159,7 +151,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_bool<C>(mut self, cx: &mut C, value: bool) -> Result<Self::Ok, C::Error>
+    fn encode_bool<C>(mut self, cx: &C, value: bool) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -170,7 +162,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_char<C>(self, cx: &mut C, value: char) -> Result<Self::Ok, C::Error>
+    fn encode_char<C>(self, cx: &C, value: char) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -178,7 +170,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_u8<C>(mut self, cx: &mut C, value: u8) -> Result<Self::Ok, C::Error>
+    fn encode_u8<C>(mut self, cx: &C, value: u8) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -186,7 +178,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_u16<C>(mut self, cx: &mut C, value: u16) -> Result<Self::Ok, C::Error>
+    fn encode_u16<C>(mut self, cx: &C, value: u16) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -194,7 +186,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_u32<C>(mut self, cx: &mut C, value: u32) -> Result<Self::Ok, C::Error>
+    fn encode_u32<C>(mut self, cx: &C, value: u32) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -202,7 +194,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_u64<C>(mut self, cx: &mut C, value: u64) -> Result<Self::Ok, C::Error>
+    fn encode_u64<C>(mut self, cx: &C, value: u64) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -210,7 +202,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_u128<C>(mut self, cx: &mut C, value: u128) -> Result<Self::Ok, C::Error>
+    fn encode_u128<C>(mut self, cx: &C, value: u128) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -218,7 +210,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_i8<C>(self, cx: &mut C, value: i8) -> Result<Self::Ok, C::Error>
+    fn encode_i8<C>(self, cx: &C, value: i8) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -226,7 +218,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_i16<C>(mut self, cx: &mut C, value: i16) -> Result<Self::Ok, C::Error>
+    fn encode_i16<C>(mut self, cx: &C, value: i16) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -234,7 +226,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_i32<C>(mut self, cx: &mut C, value: i32) -> Result<Self::Ok, C::Error>
+    fn encode_i32<C>(mut self, cx: &C, value: i32) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -242,7 +234,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_i64<C>(mut self, cx: &mut C, value: i64) -> Result<Self::Ok, C::Error>
+    fn encode_i64<C>(mut self, cx: &C, value: i64) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -250,7 +242,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_i128<C>(mut self, cx: &mut C, value: i128) -> Result<Self::Ok, C::Error>
+    fn encode_i128<C>(mut self, cx: &C, value: i128) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -258,7 +250,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_f32<C>(self, cx: &mut C, value: f32) -> Result<Self::Ok, C::Error>
+    fn encode_f32<C>(self, cx: &C, value: f32) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -266,7 +258,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_f64<C>(self, cx: &mut C, value: f64) -> Result<Self::Ok, C::Error>
+    fn encode_f64<C>(self, cx: &C, value: f64) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -274,7 +266,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_some<C>(mut self, cx: &mut C) -> Result<Self::Some, C::Error>
+    fn encode_some<C>(mut self, cx: &C) -> Result<Self::Some, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -284,7 +276,7 @@ where
     }
 
     #[inline(always)]
-    fn encode_none<C>(mut self, cx: &mut C) -> Result<Self::Ok, C::Error>
+    fn encode_none<C>(mut self, cx: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -294,7 +286,7 @@ where
     }
 
     #[inline]
-    fn encode_sequence<C>(mut self, cx: &mut C, len: usize) -> Result<Self::Sequence, C::Error>
+    fn encode_sequence<C>(mut self, cx: &C, len: usize) -> Result<Self::Sequence, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -309,7 +301,7 @@ where
     }
 
     #[inline]
-    fn encode_tuple<C>(mut self, cx: &mut C, len: usize) -> Result<Self::Tuple, C::Error>
+    fn encode_tuple<C>(mut self, cx: &C, len: usize) -> Result<Self::Tuple, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -324,7 +316,7 @@ where
     }
 
     #[inline]
-    fn encode_map<C>(mut self, cx: &mut C, len: usize) -> Result<Self::Map, C::Error>
+    fn encode_map<C>(mut self, cx: &C, len: usize) -> Result<Self::Map, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -343,7 +335,7 @@ where
     }
 
     #[inline]
-    fn encode_struct<C>(mut self, cx: &mut C, len: usize) -> Result<Self::Struct, C::Error>
+    fn encode_struct<C>(mut self, cx: &C, len: usize) -> Result<Self::Struct, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -362,7 +354,7 @@ where
     }
 
     #[inline]
-    fn encode_variant<C>(mut self, cx: &mut C) -> Result<Self::Variant, C::Error>
+    fn encode_variant<C>(mut self, cx: &C) -> Result<Self::Variant, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -383,7 +375,7 @@ where
     type Encoder<'this> = StorageEncoder<&'this mut BufferWriter<B, W::Error>, F, Error> where Self: 'this, B: Buffer;
 
     #[inline]
-    fn next<C>(&mut self, _: &mut C) -> Result<Self::Encoder<'_>, C::Error>
+    fn next<C>(&mut self, _: &C) -> Result<Self::Encoder<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -391,7 +383,7 @@ where
     }
 
     #[inline]
-    fn end<C>(mut self, cx: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(mut self, cx: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -443,7 +435,7 @@ where
     type Encoder<'this> = WireEncoder<W::Mut<'this>, F> where Self: 'this;
 
     #[inline]
-    fn next<C>(&mut self, _: &mut C) -> Result<Self::Encoder<'_>, C::Error>
+    fn next<C>(&mut self, _: &C) -> Result<Self::Encoder<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -451,7 +443,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(self, _: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -469,7 +461,7 @@ where
     type Encoder<'this> = WireEncoder<W::Mut<'this>, F> where Self: 'this;
 
     #[inline]
-    fn next<C>(&mut self, _: &mut C) -> Result<Self::Encoder<'_>, C::Error>
+    fn next<C>(&mut self, _: &C) -> Result<Self::Encoder<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -477,7 +469,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(self, _: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -496,7 +488,7 @@ where
     type Second<'this> = WireEncoder<W::Mut<'this>, F> where Self: 'this;
 
     #[inline]
-    fn first<C>(&mut self, _: &mut C) -> Result<Self::First<'_>, C::Error>
+    fn first<C>(&mut self, _: &C) -> Result<Self::First<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -504,7 +496,7 @@ where
     }
 
     #[inline]
-    fn second<C>(&mut self, _: &mut C) -> Result<Self::Second<'_>, C::Error>
+    fn second<C>(&mut self, _: &C) -> Result<Self::Second<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -512,7 +504,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(self, _: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -531,7 +523,7 @@ where
     type Variant<'this> = WireEncoder<W::Mut<'this>, F> where Self: 'this;
 
     #[inline]
-    fn tag<C>(&mut self, _: &mut C) -> Result<Self::Tag<'_>, C::Error>
+    fn tag<C>(&mut self, _: &C) -> Result<Self::Tag<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -539,7 +531,7 @@ where
     }
 
     #[inline]
-    fn variant<C>(&mut self, _: &mut C) -> Result<Self::Variant<'_>, C::Error>
+    fn variant<C>(&mut self, _: &C) -> Result<Self::Variant<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -547,7 +539,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(self, _: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -557,11 +549,7 @@ where
 
 /// Encode a length prefix.
 #[inline]
-fn encode_prefix<C, W, const F: Options>(
-    cx: &mut C,
-    writer: &mut W,
-    len: usize,
-) -> Result<(), C::Error>
+fn encode_prefix<C, W, const F: Options>(cx: &C, writer: &mut W, len: usize) -> Result<(), C::Error>
 where
     C: Context<Input = W::Error>,
     W: Writer,

--- a/crates/musli-wire/src/tag.rs
+++ b/crates/musli-wire/src/tag.rs
@@ -150,7 +150,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,

--- a/crates/musli-wire/src/test.rs
+++ b/crates/musli-wire/src/test.rs
@@ -31,7 +31,7 @@ where
     M: Mode,
     T: Decode<'de, M>,
 {
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,

--- a/crates/musli-wire/src/wire_int.rs
+++ b/crates/musli-wire/src/wire_int.rs
@@ -11,7 +11,7 @@ use crate::writer::Writer;
 /// Governs how usize lengths are encoded into a [Writer].
 #[inline]
 pub(crate) fn encode_length<C, W, const F: Options>(
-    cx: &mut C,
+    cx: &C,
     mut writer: W,
     value: usize,
 ) -> Result<(), C::Error>
@@ -52,7 +52,7 @@ where
 /// Governs how usize lengths are decoded from a [Reader].
 #[inline]
 pub(crate) fn decode_length<'de, C, R, const F: Options>(
-    cx: &mut C,
+    cx: &C,
     mut reader: R,
 ) -> Result<usize, C::Error>
 where
@@ -105,7 +105,7 @@ where
 /// Governs how unsigned integers are encoded into a [Writer].
 #[inline]
 pub(crate) fn encode_unsigned<C, W, T, const F: Options>(
-    cx: &mut C,
+    cx: &C,
     mut writer: W,
     value: T,
 ) -> Result<(), C::Error>
@@ -134,7 +134,7 @@ where
 /// Governs how unsigned integers are decoded from a [Reader].
 #[inline]
 pub(crate) fn decode_unsigned<'de, C, R, T, const F: Options>(
-    cx: &mut C,
+    cx: &C,
     mut reader: R,
 ) -> Result<T, C::Error>
 where
@@ -171,7 +171,7 @@ where
 /// Governs how signed integers are encoded into a [Writer].
 #[inline]
 pub(crate) fn encode_signed<C, W, T, const F: Options>(
-    cx: &mut C,
+    cx: &C,
     writer: W,
     value: T,
 ) -> Result<(), C::Error>
@@ -188,7 +188,7 @@ where
 /// Governs how signed integers are decoded from a [Reader].
 #[inline]
 pub(crate) fn decode_signed<'de, C, R, T, const F: Options>(
-    cx: &mut C,
+    cx: &C,
     reader: R,
 ) -> Result<T, C::Error>
 where

--- a/crates/musli-zerocopy-macros/Cargo.toml
+++ b/crates/musli-zerocopy-macros/Cargo.toml
@@ -3,7 +3,7 @@ name = "musli-zerocopy-macros"
 version = "0.0.96"
 authors = ["John-John Tedro <udoprog@tedro.se>"]
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.73"
 description = """
 Macros for Müsli zero-copy.
 """

--- a/crates/musli-zerocopy/Cargo.toml
+++ b/crates/musli-zerocopy/Cargo.toml
@@ -3,7 +3,7 @@ name = "musli-zerocopy"
 version = "0.0.96"
 authors = ["John-John Tedro <udoprog@tedro.se>"]
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.73"
 description = """
 Refreshingly simple zero copy primitives by Müsli.
 """

--- a/crates/musli-zerocopy/Cargo.toml
+++ b/crates/musli-zerocopy/Cargo.toml
@@ -19,7 +19,6 @@ categories = ["encoding"]
 default = ["std"]
 std = ["alloc"]
 alloc = []
-nightly = []
 
 [dependencies]
 musli-zerocopy-macros = { version = "=0.0.96", path = "../musli-zerocopy-macros" }

--- a/crates/musli-zerocopy/src/lib.rs
+++ b/crates/musli-zerocopy/src/lib.rs
@@ -523,8 +523,8 @@
 #![allow(clippy::module_inception)]
 #![allow(clippy::enum_variant_names)]
 #![deny(missing_docs)]
-#![cfg_attr(all(feature = "nightly", test), feature(repr128))]
-#![cfg_attr(all(feature = "nightly", test), allow(incomplete_features))]
+#![cfg_attr(all(rune_nightly), feature(repr128))]
+#![cfg_attr(all(rune_nightly), allow(incomplete_features))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/crates/musli-zerocopy/src/tests.rs
+++ b/crates/musli-zerocopy/src/tests.rs
@@ -267,7 +267,7 @@ fn enum_boundaries() -> Result<()> {
         __illegal_enum_u64
     );
     // nightly: feature(repr128)
-    #[cfg(feature = "nightly")]
+    #[cfg(rune_nightly)]
     test_case!(
         U128,
         u128,
@@ -295,7 +295,7 @@ fn enum_boundaries() -> Result<()> {
         __illegal_enum_i64,
     );
     // nightly: feature(repr128)
-    #[cfg(feature = "nightly")]
+    #[cfg(rune_nightly)]
     test_case!(
         I128,
         i128,
@@ -347,7 +347,7 @@ fn test_signed_wraparound() -> Result<()> {
     test_case!(I32, i32, i32, __illegal_enum_i32);
     test_case!(I64, i64, i64, __illegal_enum_i64);
     // nightly: feature(repr128)
-    #[cfg(feature = "nightly")]
+    #[cfg(rune_nightly)]
     test_case!(I128, i128, i128, __illegal_enum_i128);
     Ok(())
 }
@@ -392,7 +392,7 @@ fn test_neg0() -> Result<()> {
     test_case!(I32, i32, i32, __illegal_enum_i32);
     test_case!(I64, i64, i64, __illegal_enum_i64);
     // nightly: feature(repr128)
-    #[cfg(feature = "nightly")]
+    #[cfg(rune_nightly)]
     test_case!(I128, i128, i128, __illegal_enum_i128);
     Ok(())
 }

--- a/crates/musli/Cargo.toml
+++ b/crates/musli/Cargo.toml
@@ -17,8 +17,8 @@ categories = ["encoding"]
 
 [features]
 default = ["std"]
-std = ["alloc"]
-alloc = []
+std = ["alloc", "musli-wire/std", "musli-value/std", "musli-storage/std", "musli-json/std"]
+alloc = ["musli-wire/alloc", "musli-value/alloc", "musli-storage/alloc", "musli-json/alloc"]
 
 [dependencies]
 musli-macros = { version = "=0.0.96", path = "../musli-macros" }

--- a/crates/musli/Cargo.toml
+++ b/crates/musli/Cargo.toml
@@ -3,7 +3,7 @@ name = "musli"
 version = "0.0.96"
 authors = ["John-John Tedro <udoprog@tedro.se>"]
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.73"
 description = """
 Müsli is a flexible and generic binary serialization framework.
 """

--- a/crates/musli/README.md
+++ b/crates/musli/README.md
@@ -127,7 +127,7 @@ struct MyType {
 }
 
 impl<'de, M> Decode<'de, M> for MyType where M: Mode {
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,

--- a/crates/musli/src/compat.rs
+++ b/crates/musli/src/compat.rs
@@ -39,7 +39,7 @@ where
     T: Encode<M>,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -62,7 +62,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -75,7 +75,7 @@ impl<'de, M> Decode<'de, M> for Sequence<()>
 where
     M: Mode,
 {
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,
@@ -106,7 +106,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -120,7 +120,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,

--- a/crates/musli/src/compat/alloc.rs
+++ b/crates/musli/src/compat/alloc.rs
@@ -17,7 +17,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -31,7 +31,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,
@@ -50,12 +50,12 @@ where
             }
 
             #[inline]
-            fn visit_borrowed(self, _: &mut C, bytes: &'de [u8]) -> Result<Self::Ok, C::Error> {
+            fn visit_borrowed(self, _: &C, bytes: &'de [u8]) -> Result<Self::Ok, C::Error> {
                 Ok(bytes.to_vec())
             }
 
             #[inline]
-            fn visit_ref(self, _: &mut C, bytes: &[u8]) -> Result<Self::Ok, C::Error> {
+            fn visit_ref(self, _: &C, bytes: &[u8]) -> Result<Self::Ok, C::Error> {
                 Ok(bytes.to_vec())
             }
         }
@@ -69,7 +69,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -84,7 +84,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,

--- a/crates/musli/src/context.rs
+++ b/crates/musli/src/context.rs
@@ -18,9 +18,6 @@ pub trait Buffer {
     /// value indicates that we are out of buffer capacity.
     fn write(&mut self, bytes: &[u8]) -> bool;
 
-    /// Write bytes at the given offset.
-    fn write_at(&mut self, at: usize, bytes: &[u8]) -> bool;
-
     /// Write a single byte.
     ///
     /// Returns `true` if the bytes could be successfully written. A `false`
@@ -28,30 +25,6 @@ pub trait Buffer {
     #[inline(always)]
     fn push(&mut self, byte: u8) -> bool {
         self.write(&[byte])
-    }
-
-    /// Copy *back* from another buffer.
-    ///
-    /// The provided argument has the following guarantees:
-    /// * It's a buffer from a completely different allocator, at which point
-    ///   `raw_parts` must return a base pointer which differs from the current
-    ///   buffer, or;
-    /// * It's a buffer from the same allocator, at which point `raw_parts`
-    ///   returns the same base pointer. The `other` argument is then located
-    ///   *after* the current buffer in memory as relative to its base pointer.
-    ///   If this does not hold, an implementor must panic.
-    ///
-    /// The latter property is guaranteed by how the allocator functions.
-    ///
-    /// Calling `copy_back` multiple times does not lead to any unsafety, but if
-    /// both the source and target buffer come from the same allocator the
-    /// resulting content might become garbled.
-    #[inline]
-    fn copy_back<B>(&mut self, other: B) -> bool
-    where
-        B: Buffer,
-    {
-        self.write(other.as_slice())
     }
 
     /// Get the length of the buffer in bytes.
@@ -69,19 +42,6 @@ pub trait Buffer {
 impl Buffer for [u8] {
     #[inline(always)]
     fn write(&mut self, _: &[u8]) -> bool {
-        false
-    }
-
-    #[inline(always)]
-    fn write_at(&mut self, _: usize, _: &[u8]) -> bool {
-        false
-    }
-
-    #[inline(always)]
-    fn copy_back<B>(&mut self, _: B) -> bool
-    where
-        B: Buffer,
-    {
         false
     }
 

--- a/crates/musli/src/context.rs
+++ b/crates/musli/src/context.rs
@@ -72,7 +72,7 @@ pub trait Context {
         Self: 'this;
 
     /// Allocate a buffer.
-    fn alloc(&self) -> Self::Buf<'_>;
+    fn alloc(&self) -> Option<Self::Buf<'_>>;
 
     /// Adapt the current context so that it can convert an error from a
     /// different type convertible to the current input
@@ -259,6 +259,13 @@ pub trait Context {
         self.message(format_args!(
             "invalid variant field tag: variant: {variant:?}, tag: {tag:?}",
         ))
+    }
+
+    /// Missing variant field required to decode.
+    #[allow(unused_variables)]
+    #[inline(always)]
+    fn alloc_failed(&self) -> Self::Error {
+        self.message("Failed to allocate")
     }
 
     /// Indicate that we've entered a struct with the given `name`.
@@ -455,7 +462,7 @@ where
     type Buf<'this> = C::Buf<'this> where Self: 'this;
 
     #[inline(always)]
-    fn alloc(&self) -> Self::Buf<'_> {
+    fn alloc(&self) -> Option<Self::Buf<'_>> {
         self.context.alloc()
     }
 

--- a/crates/musli/src/de/decode.rs
+++ b/crates/musli/src/de/decode.rs
@@ -12,7 +12,7 @@ where
     M: Mode,
 {
     /// Decode the given input.
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>;
@@ -31,7 +31,7 @@ where
     M: Mode,
 {
     /// Decode the given input.
-    fn trace_decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn trace_decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>;

--- a/crates/musli/src/de/decoder.rs
+++ b/crates/musli/src/de/decoder.rs
@@ -17,7 +17,7 @@ pub trait AsDecoder {
         Self: 'this;
 
     /// Borrow self as a new decoder.
-    fn as_decoder<C>(&self, cx: &mut C) -> Result<Self::Decoder<'_>, C::Error>
+    fn as_decoder<C>(&self, cx: &C) -> Result<Self::Decoder<'_>, C::Error>
     where
         C: Context<Input = Self::Error>;
 }
@@ -34,14 +34,14 @@ pub trait PackDecoder<'de> {
 
     /// Return decoder to unpack the next element.
     #[must_use = "decoders must be consumed"]
-    fn next<C>(&mut self, cx: &mut C) -> Result<Self::Decoder<'_>, C::Error>
+    fn next<C>(&mut self, cx: &C) -> Result<Self::Decoder<'_>, C::Error>
     where
         C: Context<Input = Self::Error>;
 
     /// Stop decoding the current pack.
     ///
     /// This is required to call after a pack has finished decoding.
-    fn end<C>(self, cx: &mut C) -> Result<(), C::Error>
+    fn end<C>(self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>;
 }
@@ -61,14 +61,14 @@ pub trait SequenceDecoder<'de> {
 
     /// Decode the next element.
     #[must_use = "decoders must be consumed"]
-    fn next<C>(&mut self, cx: &mut C) -> Result<Option<Self::Decoder<'_>>, C::Error>
+    fn next<C>(&mut self, cx: &C) -> Result<Option<Self::Decoder<'_>>, C::Error>
     where
         C: Context<Input = Self::Error>;
 
     /// Stop decoding the current sequence.
     ///
     /// This is required to call after a sequence has finished decoding.
-    fn end<C>(self, cx: &mut C) -> Result<(), C::Error>
+    fn end<C>(self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>;
 }
@@ -92,7 +92,7 @@ pub trait PairsDecoder<'de> {
     /// Decode the next key. This returns `Ok(None)` where there are no more
     /// elements to decode.
     #[must_use = "decoders must be consumed"]
-    fn next<C>(&mut self, cx: &mut C) -> Result<Option<Self::Decoder<'_>>, C::Error>
+    fn next<C>(&mut self, cx: &C) -> Result<Option<Self::Decoder<'_>>, C::Error>
     where
         C: Context<Input = Self::Error>;
 
@@ -100,7 +100,7 @@ pub trait PairsDecoder<'de> {
     ///
     /// If there are any remaining elements in the sequence of pairs, this
     /// indicates that they should be flushed.
-    fn end<C>(self, cx: &mut C) -> Result<(), C::Error>
+    fn end<C>(self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>;
 }
@@ -123,20 +123,20 @@ pub trait PairDecoder<'de> {
     /// If this is a map the first value would be the key of the map, if this is
     /// a struct the first value would be the field of the struct.
     #[must_use = "decoders must be consumed"]
-    fn first<C>(&mut self, cx: &mut C) -> Result<Self::First<'_>, C::Error>
+    fn first<C>(&mut self, cx: &C) -> Result<Self::First<'_>, C::Error>
     where
         C: Context<Input = Self::Error>;
 
     /// Decode the second value in the pair..
     #[must_use = "decoders must be consumed"]
-    fn second<C>(self, cx: &mut C) -> Result<Self::Second, C::Error>
+    fn second<C>(self, cx: &C) -> Result<Self::Second, C::Error>
     where
         C: Context<Input = Self::Error>;
 
     /// Indicate that the second value should be skipped.
     ///
     /// The boolean returned indicates if the value was skipped or not.
-    fn skip_second<C>(self, cx: &mut C) -> Result<bool, C::Error>
+    fn skip_second<C>(self, cx: &C) -> Result<bool, C::Error>
     where
         C: Context<Input = Self::Error>;
 }
@@ -161,25 +161,25 @@ pub trait VariantDecoder<'de> {
     /// If this is a map the first value would be the key of the map, if this is
     /// a struct the first value would be the field of the struct.
     #[must_use = "decoders must be consumed"]
-    fn tag<C>(&mut self, cx: &mut C) -> Result<Self::Tag<'_>, C::Error>
+    fn tag<C>(&mut self, cx: &C) -> Result<Self::Tag<'_>, C::Error>
     where
         C: Context<Input = Self::Error>;
 
     /// Decode the second value in the pair..
     #[must_use = "decoders must be consumed"]
-    fn variant<C>(&mut self, cx: &mut C) -> Result<Self::Variant<'_>, C::Error>
+    fn variant<C>(&mut self, cx: &C) -> Result<Self::Variant<'_>, C::Error>
     where
         C: Context<Input = Self::Error>;
 
     /// Indicate that the second value should be skipped.
     ///
     /// The boolean returned indicates if the value was skipped or not.
-    fn skip_variant<C>(&mut self, cx: &mut C) -> Result<bool, C::Error>
+    fn skip_variant<C>(&mut self, cx: &C) -> Result<bool, C::Error>
     where
         C: Context<Input = Self::Error>;
 
     /// End the pair decoder.
-    fn end<C>(self, cx: &mut C) -> Result<(), C::Error>
+    fn end<C>(self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>;
 }
@@ -240,7 +240,7 @@ pub trait Decoder<'de>: Sized {
     ///         write!(f, "32-bit unsigned integers")
     ///     }
     ///
-    ///     fn decode_u32<C>(self, _: &mut C) -> Result<u32, C::Error>
+    ///     fn decode_u32<C>(self, _: &C) -> Result<u32, C::Error>
     ///     where
     ///         C: Context<Input = Self::Error>
     ///     {
@@ -257,7 +257,7 @@ pub trait Decoder<'de>: Sized {
     /// detailed (`a 32-bit unsigned integer`) to vague (`a number`).
     ///
     /// This is used to construct dynamic containers of types.
-    fn type_hint<C>(&mut self, _: &mut C) -> Result<TypeHint, C::Error>
+    fn type_hint<C>(&mut self, _: &C) -> Result<TypeHint, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -292,7 +292,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     ///
     /// impl<'de, M> Decode<'de, M> for MyVariantType where M: Mode {
-    ///     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    ///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     ///     where
     ///         C: Context<Input = D::Error>,
     ///         D: Decoder<'de>,
@@ -306,7 +306,7 @@ pub trait Decoder<'de>: Sized {
     ///                 return Err(cx.missing_variant_tag("MyVariantType"));
     ///             };
     ///
-    ///             let found = e.first(cx)?.decode_string(cx, musli::utils::visit_owned_fn("a string that is 'type'", |cx: &mut C, string: &str| {
+    ///             let found = e.first(cx)?.decode_string(cx, musli::utils::visit_owned_fn("a string that is 'type'", |cx: &C, string: &str| {
     ///                 Ok(string == "type")
     ///             }))?;
     ///
@@ -326,7 +326,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     /// ```
     #[inline]
-    fn decode_buffer<M, C>(self, cx: &mut C) -> Result<Self::Buffer, C::Error>
+    fn decode_buffer<M, C>(self, cx: &C) -> Result<Self::Buffer, C::Error>
     where
         M: Mode,
         C: Context<Input = Self::Error>,
@@ -347,7 +347,7 @@ pub trait Decoder<'de>: Sized {
     /// struct UnitType;
     ///
     /// impl<'de, M> Decode<'de, M> for UnitType where M: Mode {
-    ///     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    ///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     ///     where
     ///         C: Context<Input = D::Error>,
     ///         D: Decoder<'de>,
@@ -358,7 +358,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     /// ```
     #[inline]
-    fn decode_unit<C>(self, cx: &mut C) -> Result<(), C::Error>
+    fn decode_unit<C>(self, cx: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -380,7 +380,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     ///
     /// impl<'de, M> Decode<'de, M> for MyType where M: Mode {
-    ///     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    ///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     ///     where
     ///         C: Context<Input = D::Error>,
     ///         D: Decoder<'de>,
@@ -392,7 +392,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     /// ```
     #[inline]
-    fn decode_bool<C>(self, cx: &mut C) -> Result<bool, C::Error>
+    fn decode_bool<C>(self, cx: &C) -> Result<bool, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -414,7 +414,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     ///
     /// impl<'de, M> Decode<'de, M> for MyType where M: Mode {
-    ///     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    ///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     ///     where
     ///         C: Context<Input = D::Error>,
     ///         D: Decoder<'de>,
@@ -426,7 +426,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     /// ```
     #[inline]
-    fn decode_char<C>(self, cx: &mut C) -> Result<char, C::Error>
+    fn decode_char<C>(self, cx: &C) -> Result<char, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -448,7 +448,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     ///
     /// impl<'de, M> Decode<'de, M> for MyType where M: Mode {
-    ///     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    ///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     ///     where
     ///         C: Context<Input = D::Error>,
     ///         D: Decoder<'de>,
@@ -460,7 +460,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     /// ```
     #[inline]
-    fn decode_u8<C>(self, cx: &mut C) -> Result<u8, C::Error>
+    fn decode_u8<C>(self, cx: &C) -> Result<u8, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -482,7 +482,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     ///
     /// impl<'de, M> Decode<'de, M> for MyType where M: Mode {
-    ///     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    ///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     ///     where
     ///         C: Context<Input = D::Error>,
     ///         D: Decoder<'de>,
@@ -494,7 +494,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     /// ```
     #[inline]
-    fn decode_u16<C>(self, cx: &mut C) -> Result<u16, C::Error>
+    fn decode_u16<C>(self, cx: &C) -> Result<u16, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -517,7 +517,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     ///
     /// impl<'de, M> Decode<'de, M> for MyType where M: Mode {
-    ///     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    ///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     ///     where
     ///         C: Context<Input = D::Error>,
     ///         D: Decoder<'de>,
@@ -529,7 +529,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     /// ```
     #[inline]
-    fn decode_u32<C>(self, cx: &mut C) -> Result<u32, C::Error>
+    fn decode_u32<C>(self, cx: &C) -> Result<u32, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -551,7 +551,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     ///
     /// impl<'de, M> Decode<'de, M> for MyType where M: Mode {
-    ///     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    ///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     ///     where
     ///         C: Context<Input = D::Error>,
     ///         D: Decoder<'de>,
@@ -563,7 +563,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     /// ```
     #[inline]
-    fn decode_u64<C>(self, cx: &mut C) -> Result<u64, C::Error>
+    fn decode_u64<C>(self, cx: &C) -> Result<u64, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -585,7 +585,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     ///
     /// impl<'de, M> Decode<'de, M> for MyType where M: Mode {
-    ///     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    ///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     ///     where
     ///         C: Context<Input = D::Error>,
     ///         D: Decoder<'de>,
@@ -597,7 +597,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     /// ```
     #[inline]
-    fn decode_u128<C>(self, cx: &mut C) -> Result<u128, C::Error>
+    fn decode_u128<C>(self, cx: &C) -> Result<u128, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -619,7 +619,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     ///
     /// impl<'de, M> Decode<'de, M> for MyType where M: Mode {
-    ///     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    ///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     ///     where
     ///         C: Context<Input = D::Error>,
     ///         D: Decoder<'de>,
@@ -631,7 +631,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     /// ```
     #[inline]
-    fn decode_i8<C>(self, cx: &mut C) -> Result<i8, C::Error>
+    fn decode_i8<C>(self, cx: &C) -> Result<i8, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -653,7 +653,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     ///
     /// impl<'de, M> Decode<'de, M> for MyType where M: Mode {
-    ///     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    ///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     ///     where
     ///         C: Context<Input = D::Error>,
     ///         D: Decoder<'de>,
@@ -665,7 +665,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     /// ```
     #[inline]
-    fn decode_i16<C>(self, cx: &mut C) -> Result<i16, C::Error>
+    fn decode_i16<C>(self, cx: &C) -> Result<i16, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -687,7 +687,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     ///
     /// impl<'de, M> Decode<'de, M> for MyType where M: Mode {
-    ///     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    ///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     ///     where
     ///         C: Context<Input = D::Error>,
     ///         D: Decoder<'de>,
@@ -699,7 +699,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     /// ```
     #[inline]
-    fn decode_i32<C>(self, cx: &mut C) -> Result<i32, C::Error>
+    fn decode_i32<C>(self, cx: &C) -> Result<i32, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -721,7 +721,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     ///
     /// impl<'de, M> Decode<'de, M> for MyType where M: Mode {
-    ///     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    ///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     ///     where
     ///         C: Context<Input = D::Error>,
     ///         D: Decoder<'de>,
@@ -733,7 +733,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     /// ```
     #[inline]
-    fn decode_i64<C>(self, cx: &mut C) -> Result<i64, C::Error>
+    fn decode_i64<C>(self, cx: &C) -> Result<i64, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -755,7 +755,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     ///
     /// impl<'de, M> Decode<'de, M> for MyType where M: Mode {
-    ///     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    ///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     ///     where
     ///         C: Context<Input = D::Error>,
     ///         D: Decoder<'de>,
@@ -767,7 +767,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     /// ```
     #[inline]
-    fn decode_i128<C>(self, cx: &mut C) -> Result<i128, C::Error>
+    fn decode_i128<C>(self, cx: &C) -> Result<i128, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -789,7 +789,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     ///
     /// impl<'de, M> Decode<'de, M> for MyType where M: Mode {
-    ///     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    ///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     ///     where
     ///         C: Context<Input = D::Error>,
     ///         D: Decoder<'de>,
@@ -801,7 +801,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     /// ```
     #[inline]
-    fn decode_usize<C>(self, cx: &mut C) -> Result<usize, C::Error>
+    fn decode_usize<C>(self, cx: &C) -> Result<usize, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -823,7 +823,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     ///
     /// impl<'de, M> Decode<'de, M> for MyType where M: Mode {
-    ///     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    ///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     ///     where
     ///         C: Context<Input = D::Error>,
     ///         D: Decoder<'de>,
@@ -835,7 +835,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     /// ```
     #[inline]
-    fn decode_isize<C>(self, cx: &mut C) -> Result<isize, C::Error>
+    fn decode_isize<C>(self, cx: &C) -> Result<isize, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -857,7 +857,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     ///
     /// impl<'de, M> Decode<'de, M> for MyType where M: Mode {
-    ///     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    ///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     ///     where
     ///         C: Context<Input = D::Error>,
     ///         D: Decoder<'de>,
@@ -869,7 +869,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     /// ```
     #[inline]
-    fn decode_f32<C>(self, cx: &mut C) -> Result<f32, C::Error>
+    fn decode_f32<C>(self, cx: &C) -> Result<f32, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -891,7 +891,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     ///
     /// impl<'de, M> Decode<'de, M> for MyType where M: Mode {
-    ///     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    ///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     ///     where
     ///         C: Context<Input = D::Error>,
     ///         D: Decoder<'de>,
@@ -903,7 +903,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     /// ```
     #[inline]
-    fn decode_f64<C>(self, cx: &mut C) -> Result<f64, C::Error>
+    fn decode_f64<C>(self, cx: &C) -> Result<f64, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -916,7 +916,7 @@ pub trait Decoder<'de>: Sized {
     /// Decode an unknown number using a visitor that can handle arbitrary
     /// precision numbers.
     #[inline]
-    fn decode_number<C, V>(self, cx: &mut C, _: V) -> Result<V::Ok, C::Error>
+    fn decode_number<C, V>(self, cx: &C, _: V) -> Result<V::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
         V: NumberVisitor<'de, C>,
@@ -939,7 +939,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     ///
     /// impl<'de, M> Decode<'de, M> for MyType where M: Mode {
-    ///     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    ///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     ///     where
     ///         C: Context<Input = D::Error>,
     ///         D: Decoder<'de>,
@@ -951,7 +951,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     /// ```
     #[inline]
-    fn decode_array<C, const N: usize>(self, cx: &mut C) -> Result<[u8; N], C::Error>
+    fn decode_array<C, const N: usize>(self, cx: &C) -> Result<[u8; N], C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -978,7 +978,7 @@ pub trait Decoder<'de>: Sized {
     ///
     /// impl<'de, M> Decode<'de, M> for BytesReference<'de> where M: Mode {
     ///     #[inline]
-    ///     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    ///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     ///     where
     ///         C: Context<Input = D::Error>,
     ///         D: Decoder<'de>,
@@ -997,7 +997,7 @@ pub trait Decoder<'de>: Sized {
     ///             }
     ///
     ///             #[inline]
-    ///             fn visit_borrowed(self, _: &mut C, bytes: &'de [u8]) -> Result<Self::Ok, C::Error> {
+    ///             fn visit_borrowed(self, _: &C, bytes: &'de [u8]) -> Result<Self::Ok, C::Error> {
     ///                 Ok(bytes)
     ///             }
     ///         }
@@ -1016,7 +1016,7 @@ pub trait Decoder<'de>: Sized {
     /// # Ok::<_, musli_value::Error>(())
     /// ```
     #[inline]
-    fn decode_bytes<C, V>(self, cx: &mut C, _: V) -> Result<V::Ok, C::Error>
+    fn decode_bytes<C, V>(self, cx: &C, _: V) -> Result<V::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
         V: ValueVisitor<'de, C, [u8]>,
@@ -1045,7 +1045,7 @@ pub trait Decoder<'de>: Sized {
     ///
     /// impl<'de, M> Decode<'de, M> for StringReference<'de> where M: Mode {
     ///     #[inline]
-    ///     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    ///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     ///     where
     ///         C: Context<Input = D::Error>,
     ///         D: Decoder<'de>,
@@ -1064,7 +1064,7 @@ pub trait Decoder<'de>: Sized {
     ///             }
     ///
     ///             #[inline]
-    ///             fn visit_borrowed(self, cx: &mut C, bytes: &'de str) -> Result<Self::Ok, C::Error> {
+    ///             fn visit_borrowed(self, cx: &C, bytes: &'de str) -> Result<Self::Ok, C::Error> {
     ///                 Ok(bytes)
     ///             }
     ///         }
@@ -1083,7 +1083,7 @@ pub trait Decoder<'de>: Sized {
     /// # Ok::<_, musli_value::Error>(())
     /// ```
     #[inline]
-    fn decode_string<C, V>(self, cx: &mut C, _: V) -> Result<V::Ok, C::Error>
+    fn decode_string<C, V>(self, cx: &C, _: V) -> Result<V::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
         V: ValueVisitor<'de, C, str>,
@@ -1106,7 +1106,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     ///
     /// impl<'de, M> Decode<'de, M> for MyType where M: Mode {
-    ///     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    ///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     ///     where
     ///         C: Context<Input = D::Error>,
     ///         D: Decoder<'de>,
@@ -1125,7 +1125,7 @@ pub trait Decoder<'de>: Sized {
     /// ```
     #[inline]
     #[must_use = "decoders must be consumed"]
-    fn decode_option<C>(self, cx: &mut C) -> Result<Option<Self::Some>, C::Error>
+    fn decode_option<C>(self, cx: &C) -> Result<Option<Self::Some>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -1153,7 +1153,7 @@ pub trait Decoder<'de>: Sized {
     ///
     /// impl<'de, M> Decode<'de, M> for PackedStruct where M: Mode {
     ///     #[inline]
-    ///     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    ///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     ///     where
     ///         C: Context<Input = D::Error>,
     ///         D: Decoder<'de>,
@@ -1171,7 +1171,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     /// ```
     #[inline]
-    fn decode_pack<C>(self, cx: &mut C) -> Result<Self::Pack, C::Error>
+    fn decode_pack<C>(self, cx: &C) -> Result<Self::Pack, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -1194,7 +1194,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     ///
     /// impl<'de, M> Decode<'de, M> for MyType where M: Mode {
-    ///     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    ///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     ///     where
     ///         C: Context<Input = D::Error>,
     ///         D: Decoder<'de>,
@@ -1215,7 +1215,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     /// ```
     #[inline]
-    fn decode_sequence<C>(self, cx: &mut C) -> Result<Self::Sequence, C::Error>
+    fn decode_sequence<C>(self, cx: &C) -> Result<Self::Sequence, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -1239,7 +1239,7 @@ pub trait Decoder<'de>: Sized {
     /// struct TupleStruct(String, u32);
     ///
     /// impl<'de, M> Decode<'de, M> for TupleStruct where M: Mode {
-    ///     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    ///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     ///     where
     ///         C: Context<Input = D::Error>,
     ///         D: Decoder<'de>,
@@ -1253,11 +1253,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     /// ```
     #[inline]
-    fn decode_tuple<C>(
-        self,
-        cx: &mut C,
-        #[allow(unused)] len: usize,
-    ) -> Result<Self::Tuple, C::Error>
+    fn decode_tuple<C>(self, cx: &C, #[allow(unused)] len: usize) -> Result<Self::Tuple, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -1285,7 +1281,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     ///
     /// impl<'de, M> Decode<'de, M> for MapStruct where M: Mode {
-    ///     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    ///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     ///     where
     ///         C: Context<Input = D::Error>,
     ///         D: Decoder<'de>,
@@ -1308,7 +1304,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     /// ```
     #[inline]
-    fn decode_map<C>(self, cx: &mut C) -> Result<Self::Map, C::Error>
+    fn decode_map<C>(self, cx: &C) -> Result<Self::Map, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -1340,7 +1336,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     ///
     /// impl<'de, M> Decode<'de, M> for Struct where M: Mode {
-    ///     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    ///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     ///     where
     ///         C: Context<Input = D::Error>,
     ///         D: Decoder<'de>,
@@ -1376,7 +1372,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     /// ```
     #[inline]
-    fn decode_struct<C>(self, cx: &mut C, _: usize) -> Result<Self::Struct, C::Error>
+    fn decode_struct<C>(self, cx: &C, _: usize) -> Result<Self::Struct, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -1403,7 +1399,7 @@ pub trait Decoder<'de>: Sized {
     /// where
     ///     M: Mode
     /// {
-    ///     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    ///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     ///     where
     ///         C: Context<Input = D::Error>,
     ///         D: Decoder<'de>,
@@ -1429,7 +1425,7 @@ pub trait Decoder<'de>: Sized {
     /// }
     /// ```
     #[inline]
-    fn decode_variant<C>(self, cx: &mut C) -> Result<Self::Variant, C::Error>
+    fn decode_variant<C>(self, cx: &C) -> Result<Self::Variant, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -1444,7 +1440,7 @@ pub trait Decoder<'de>: Sized {
     /// If the current encoding does not support dynamic decoding,
     /// [`Visitor::visit_any`] will be called with the current decoder.
     #[inline]
-    fn decode_any<C, V>(self, cx: &mut C, _: V) -> Result<V::Ok, C::Error>
+    fn decode_any<C, V>(self, cx: &C, _: V) -> Result<V::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
         V: Visitor<'de, Error = Self::Error>,

--- a/crates/musli/src/de/number_visitor.rs
+++ b/crates/musli/src/de/number_visitor.rs
@@ -20,7 +20,7 @@ where
 
     /// Visit `u8`.
     #[inline]
-    fn visit_u8(self, cx: &mut C, _: u8) -> Result<Self::Ok, C::Error> {
+    fn visit_u8(self, cx: &C, _: u8) -> Result<Self::Ok, C::Error> {
         Err(cx.message(expecting::bad_visitor_type(
             &expecting::Unsigned8,
             &ExpectingWrapper::new(self),
@@ -29,7 +29,7 @@ where
 
     /// Visit `u16`.
     #[inline]
-    fn visit_u16(self, cx: &mut C, _: u16) -> Result<Self::Ok, C::Error> {
+    fn visit_u16(self, cx: &C, _: u16) -> Result<Self::Ok, C::Error> {
         Err(cx.message(expecting::bad_visitor_type(
             &expecting::Unsigned16,
             &ExpectingWrapper::new(self),
@@ -38,7 +38,7 @@ where
 
     /// Visit `u32`.
     #[inline]
-    fn visit_u32(self, cx: &mut C, _: u32) -> Result<Self::Ok, C::Error> {
+    fn visit_u32(self, cx: &C, _: u32) -> Result<Self::Ok, C::Error> {
         Err(cx.message(expecting::bad_visitor_type(
             &expecting::Unsigned32,
             &ExpectingWrapper::new(self),
@@ -47,7 +47,7 @@ where
 
     /// Visit `u64`.
     #[inline]
-    fn visit_u64(self, cx: &mut C, _: u64) -> Result<Self::Ok, C::Error> {
+    fn visit_u64(self, cx: &C, _: u64) -> Result<Self::Ok, C::Error> {
         Err(cx.message(expecting::bad_visitor_type(
             &expecting::Unsigned64,
             &ExpectingWrapper::new(self),
@@ -56,7 +56,7 @@ where
 
     /// Visit `u128`.
     #[inline]
-    fn visit_u128(self, cx: &mut C, _: u128) -> Result<Self::Ok, C::Error> {
+    fn visit_u128(self, cx: &C, _: u128) -> Result<Self::Ok, C::Error> {
         Err(cx.message(expecting::bad_visitor_type(
             &expecting::Unsigned128,
             &ExpectingWrapper::new(self),
@@ -65,7 +65,7 @@ where
 
     /// Visit `i8`.
     #[inline]
-    fn visit_i8(self, cx: &mut C, _: i8) -> Result<Self::Ok, C::Error> {
+    fn visit_i8(self, cx: &C, _: i8) -> Result<Self::Ok, C::Error> {
         Err(cx.message(expecting::bad_visitor_type(
             &expecting::Signed8,
             &ExpectingWrapper::new(self),
@@ -74,7 +74,7 @@ where
 
     /// Visit `i16`.
     #[inline]
-    fn visit_i16(self, cx: &mut C, _: i16) -> Result<Self::Ok, C::Error> {
+    fn visit_i16(self, cx: &C, _: i16) -> Result<Self::Ok, C::Error> {
         Err(cx.message(expecting::bad_visitor_type(
             &expecting::Signed16,
             &ExpectingWrapper::new(self),
@@ -83,7 +83,7 @@ where
 
     /// Visit `i32`.
     #[inline]
-    fn visit_i32(self, cx: &mut C, _: i32) -> Result<Self::Ok, C::Error> {
+    fn visit_i32(self, cx: &C, _: i32) -> Result<Self::Ok, C::Error> {
         Err(cx.message(expecting::bad_visitor_type(
             &expecting::Signed32,
             &ExpectingWrapper::new(self),
@@ -92,7 +92,7 @@ where
 
     /// Visit `i64`.
     #[inline]
-    fn visit_i64(self, cx: &mut C, _: i64) -> Result<Self::Ok, C::Error> {
+    fn visit_i64(self, cx: &C, _: i64) -> Result<Self::Ok, C::Error> {
         Err(cx.message(expecting::bad_visitor_type(
             &expecting::Signed64,
             &ExpectingWrapper::new(self),
@@ -101,7 +101,7 @@ where
 
     /// Visit `i128`.
     #[inline]
-    fn visit_i128(self, cx: &mut C, _: i128) -> Result<Self::Ok, C::Error> {
+    fn visit_i128(self, cx: &C, _: i128) -> Result<Self::Ok, C::Error> {
         Err(cx.message(expecting::bad_visitor_type(
             &expecting::Signed128,
             &ExpectingWrapper::new(self),
@@ -110,7 +110,7 @@ where
 
     /// Visit `f32`.
     #[inline]
-    fn visit_f32(self, cx: &mut C, _: f32) -> Result<Self::Ok, C::Error> {
+    fn visit_f32(self, cx: &C, _: f32) -> Result<Self::Ok, C::Error> {
         Err(cx.message(expecting::bad_visitor_type(
             &expecting::Float32,
             &ExpectingWrapper::new(self),
@@ -119,7 +119,7 @@ where
 
     /// Visit `f64`.
     #[inline]
-    fn visit_f64(self, cx: &mut C, _: f64) -> Result<Self::Ok, C::Error> {
+    fn visit_f64(self, cx: &C, _: f64) -> Result<Self::Ok, C::Error> {
         Err(cx.message(expecting::bad_visitor_type(
             &expecting::Float64,
             &ExpectingWrapper::new(self),
@@ -128,7 +128,7 @@ where
 
     /// Visit `usize`.
     #[inline]
-    fn visit_usize(self, cx: &mut C, _: usize) -> Result<Self::Ok, C::Error> {
+    fn visit_usize(self, cx: &C, _: usize) -> Result<Self::Ok, C::Error> {
         Err(cx.message(expecting::bad_visitor_type(
             &expecting::Usize,
             &ExpectingWrapper::new(self),
@@ -137,7 +137,7 @@ where
 
     /// Visit `isize`.
     #[inline]
-    fn visit_isize(self, cx: &mut C, _: isize) -> Result<Self::Ok, C::Error> {
+    fn visit_isize(self, cx: &C, _: isize) -> Result<Self::Ok, C::Error> {
         Err(cx.message(expecting::bad_visitor_type(
             &expecting::Isize,
             &ExpectingWrapper::new(self),
@@ -146,7 +146,7 @@ where
 
     /// Visit bytes constituting a raw number.
     #[inline]
-    fn visit_bytes(self, cx: &mut C, _: &'de [u8]) -> Result<Self::Ok, C::Error> {
+    fn visit_bytes(self, cx: &C, _: &'de [u8]) -> Result<Self::Ok, C::Error> {
         Err(cx.message(expecting::bad_visitor_type(
             &expecting::Number,
             &ExpectingWrapper::new(self),
@@ -156,7 +156,7 @@ where
     /// Fallback used when the type is either not implemented for this visitor
     /// or the underlying format doesn't know which type to decode.
     #[inline]
-    fn visit_any<D>(self, cx: &mut C, _: D, hint: TypeHint) -> Result<Self::Ok, C::Error>
+    fn visit_any<D>(self, cx: &C, _: D, hint: TypeHint) -> Result<Self::Ok, C::Error>
     where
         D: Decoder<'de, Error = C::Input>,
     {

--- a/crates/musli/src/de/value_visitor.rs
+++ b/crates/musli/src/de/value_visitor.rs
@@ -38,20 +38,20 @@ where
 
     /// Visit an owned value.
     #[inline]
-    fn visit_owned(self, cx: &mut C, value: T::Owned) -> Result<Self::Ok, C::Error> {
+    fn visit_owned(self, cx: &C, value: T::Owned) -> Result<Self::Ok, C::Error> {
         self.visit_ref(cx, value.borrow())
     }
 
     /// Visit a string that is borrowed directly from the source data.
     #[inline]
-    fn visit_borrowed(self, cx: &mut C, value: &'de T) -> Result<Self::Ok, C::Error> {
+    fn visit_borrowed(self, cx: &C, value: &'de T) -> Result<Self::Ok, C::Error> {
         self.visit_ref(cx, value)
     }
 
     /// Visit a value reference that is provided from the decoder in any manner
     /// possible. Which might require additional decoding work.
     #[inline]
-    fn visit_ref(self, cx: &mut C, _: &T) -> Result<Self::Ok, C::Error> {
+    fn visit_ref(self, cx: &C, _: &T) -> Result<Self::Ok, C::Error> {
         Err(cx.message(expecting::bad_visitor_type(
             &expecting::AnyValue,
             &ExpectingWrapper::new(self),
@@ -61,7 +61,7 @@ where
     /// Fallback used when the type is either not implemented for this visitor
     /// or the underlying format doesn't know which type to decode.
     #[inline]
-    fn visit_any<D>(self, cx: &mut C, _: D, hint: TypeHint) -> Result<Self::Ok, C::Error>
+    fn visit_any<D>(self, cx: &C, _: D, hint: TypeHint) -> Result<Self::Ok, C::Error>
     where
         D: Decoder<'de, Error = C::Input>,
     {

--- a/crates/musli/src/de/visitor.rs
+++ b/crates/musli/src/de/visitor.rs
@@ -45,7 +45,7 @@ pub trait Visitor<'de>: Sized {
 
     /// Fallback used when the type is either not implemented for this visitor
     /// or the underlying format doesn't know which type to decode.
-    fn visit_any<C, D>(self, cx: &mut C, _: D, hint: TypeHint) -> Result<Self::Ok, C::Error>
+    fn visit_any<C, D>(self, cx: &C, _: D, hint: TypeHint) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
         D: Decoder<'de, Error = Self::Error>,
@@ -55,7 +55,7 @@ pub trait Visitor<'de>: Sized {
 
     /// Indicates that the visited type is a `unit`.
     #[inline]
-    fn visit_unit<C>(self, cx: &mut C) -> Result<Self::Ok, C::Error>
+    fn visit_unit<C>(self, cx: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -67,7 +67,7 @@ pub trait Visitor<'de>: Sized {
 
     /// Indicates that the visited type is a `bool`.
     #[inline]
-    fn visit_bool<C>(self, cx: &mut C, _: bool) -> Result<Self::Ok, C::Error>
+    fn visit_bool<C>(self, cx: &C, _: bool) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -79,7 +79,7 @@ pub trait Visitor<'de>: Sized {
 
     /// Indicates that the visited type is a `char`.
     #[inline]
-    fn visit_char<C>(self, cx: &mut C, _: char) -> Result<Self::Ok, C::Error>
+    fn visit_char<C>(self, cx: &C, _: char) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -91,7 +91,7 @@ pub trait Visitor<'de>: Sized {
 
     /// Indicates that the visited type is a `u8`.
     #[inline]
-    fn visit_u8<C>(self, cx: &mut C, _: u8) -> Result<Self::Ok, C::Error>
+    fn visit_u8<C>(self, cx: &C, _: u8) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -103,7 +103,7 @@ pub trait Visitor<'de>: Sized {
 
     /// Indicates that the visited type is a `u16`.
     #[inline]
-    fn visit_u16<C>(self, cx: &mut C, _: u16) -> Result<Self::Ok, C::Error>
+    fn visit_u16<C>(self, cx: &C, _: u16) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -115,7 +115,7 @@ pub trait Visitor<'de>: Sized {
 
     /// Indicates that the visited type is a `u32`.
     #[inline]
-    fn visit_u32<C>(self, cx: &mut C, _: u32) -> Result<Self::Ok, C::Error>
+    fn visit_u32<C>(self, cx: &C, _: u32) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -127,7 +127,7 @@ pub trait Visitor<'de>: Sized {
 
     /// Indicates that the visited type is a `u64`.
     #[inline]
-    fn visit_u64<C>(self, cx: &mut C, _: u64) -> Result<Self::Ok, C::Error>
+    fn visit_u64<C>(self, cx: &C, _: u64) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -139,7 +139,7 @@ pub trait Visitor<'de>: Sized {
 
     /// Indicates that the visited type is a `u128`.
     #[inline]
-    fn visit_u128<C>(self, cx: &mut C, _: u128) -> Result<Self::Ok, C::Error>
+    fn visit_u128<C>(self, cx: &C, _: u128) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -151,7 +151,7 @@ pub trait Visitor<'de>: Sized {
 
     /// Indicates that the visited type is a `i8`.
     #[inline]
-    fn visit_i8<C>(self, cx: &mut C, _: i8) -> Result<Self::Ok, C::Error>
+    fn visit_i8<C>(self, cx: &C, _: i8) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -163,7 +163,7 @@ pub trait Visitor<'de>: Sized {
 
     /// Indicates that the visited type is a `i16`.
     #[inline]
-    fn visit_i16<C>(self, cx: &mut C, _: i16) -> Result<Self::Ok, C::Error>
+    fn visit_i16<C>(self, cx: &C, _: i16) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -175,7 +175,7 @@ pub trait Visitor<'de>: Sized {
 
     /// Indicates that the visited type is a `i32`.
     #[inline]
-    fn visit_i32<C>(self, cx: &mut C, _: i32) -> Result<Self::Ok, C::Error>
+    fn visit_i32<C>(self, cx: &C, _: i32) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -187,7 +187,7 @@ pub trait Visitor<'de>: Sized {
 
     /// Indicates that the visited type is a `i64`.
     #[inline]
-    fn visit_i64<C>(self, cx: &mut C, _: i64) -> Result<Self::Ok, C::Error>
+    fn visit_i64<C>(self, cx: &C, _: i64) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -199,7 +199,7 @@ pub trait Visitor<'de>: Sized {
 
     /// Indicates that the visited type is a `i128`.
     #[inline]
-    fn visit_i128<C>(self, cx: &mut C, _: i128) -> Result<Self::Ok, C::Error>
+    fn visit_i128<C>(self, cx: &C, _: i128) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -211,7 +211,7 @@ pub trait Visitor<'de>: Sized {
 
     /// Indicates that the visited type is a `usize`.
     #[inline]
-    fn visit_usize<C>(self, cx: &mut C, _: usize) -> Result<Self::Ok, C::Error>
+    fn visit_usize<C>(self, cx: &C, _: usize) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -223,7 +223,7 @@ pub trait Visitor<'de>: Sized {
 
     /// Indicates that the visited type is a `isize`.
     #[inline]
-    fn visit_isize<C>(self, cx: &mut C, _: isize) -> Result<Self::Ok, C::Error>
+    fn visit_isize<C>(self, cx: &C, _: isize) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -235,7 +235,7 @@ pub trait Visitor<'de>: Sized {
 
     /// Indicates that the visited type is a `f32`.
     #[inline]
-    fn visit_f32<C>(self, cx: &mut C, _: f32) -> Result<Self::Ok, C::Error>
+    fn visit_f32<C>(self, cx: &C, _: f32) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -247,7 +247,7 @@ pub trait Visitor<'de>: Sized {
 
     /// Indicates that the visited type is a `f64`.
     #[inline]
-    fn visit_f64<C>(self, cx: &mut C, _: f64) -> Result<Self::Ok, C::Error>
+    fn visit_f64<C>(self, cx: &C, _: f64) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -259,7 +259,7 @@ pub trait Visitor<'de>: Sized {
 
     /// Indicates that the visited type is an optional type.
     #[inline]
-    fn visit_option<C, D>(self, cx: &mut C, _: Option<D>) -> Result<Self::Ok, C::Error>
+    fn visit_option<C, D>(self, cx: &C, _: Option<D>) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
         D: Decoder<'de, Error = Self::Error>,
@@ -272,7 +272,7 @@ pub trait Visitor<'de>: Sized {
 
     /// Indicates that the visited type is a sequence.
     #[inline]
-    fn visit_sequence<C, D>(self, cx: &mut C, decoder: D) -> Result<Self::Ok, C::Error>
+    fn visit_sequence<C, D>(self, cx: &C, decoder: D) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
         D: SequenceDecoder<'de, Error = Self::Error>,
@@ -285,7 +285,7 @@ pub trait Visitor<'de>: Sized {
 
     /// Indicates that the visited type is a map.
     #[inline]
-    fn visit_map<C, D>(self, cx: &mut C, decoder: D) -> Result<Self::Ok, C::Error>
+    fn visit_map<C, D>(self, cx: &C, decoder: D) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
         D: PairsDecoder<'de, Error = Self::Error>,
@@ -298,7 +298,7 @@ pub trait Visitor<'de>: Sized {
 
     /// Indicates that the visited type is `string`.
     #[inline]
-    fn visit_string<C>(self, cx: &mut C, hint: SizeHint) -> Result<Self::String<C>, C::Error>
+    fn visit_string<C>(self, cx: &C, hint: SizeHint) -> Result<Self::String<C>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -310,7 +310,7 @@ pub trait Visitor<'de>: Sized {
 
     /// Indicates that the visited type is `bytes`.
     #[inline]
-    fn visit_bytes<C>(self, cx: &mut C, hint: SizeHint) -> Result<Self::Bytes<C>, C::Error>
+    fn visit_bytes<C>(self, cx: &C, hint: SizeHint) -> Result<Self::Bytes<C>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -322,7 +322,7 @@ pub trait Visitor<'de>: Sized {
 
     /// Indicates that the visited type is a number.
     #[inline]
-    fn visit_number<C>(self, cx: &mut C, hint: NumberHint) -> Result<Self::Number<C>, C::Error>
+    fn visit_number<C>(self, cx: &C, hint: NumberHint) -> Result<Self::Number<C>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -334,7 +334,7 @@ pub trait Visitor<'de>: Sized {
 
     /// Indicates that the visited type is a variant.
     #[inline]
-    fn visit_variant<C, D>(self, cx: &mut C, _: D) -> Result<Self::Ok, C::Error>
+    fn visit_variant<C, D>(self, cx: &C, _: D) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
         D: VariantDecoder<'de, Error = Self::Error>,

--- a/crates/musli/src/derives.rs
+++ b/crates/musli/src/derives.rs
@@ -598,14 +598,14 @@
 //!
 //!     use super::Field;
 //!
-//!     pub fn encode<M, C, E>(field: &Field, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+//!     pub fn encode<M, C, E>(field: &Field, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
 //!     where
 //!         M: Mode,
 //!         C: Context<Input = E::Error>,
 //!         E: Encoder
 //! # { todo!() }
 //!
-//!     pub fn decode<'de, M, C, D>(cx: &mut C, decoder: D) -> Result<Field, C::Error>
+//!     pub fn decode<'de, M, C, D>(cx: &C, decoder: D) -> Result<Field, C::Error>
 //!     where
 //!         M: Mode,
 //!         C: Context<Input = D::Error>,
@@ -639,14 +639,14 @@
 //!
 //!     use super::Field;
 //!
-//!     pub fn encode<M, C, E, T>(field: &Field<T>, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+//!     pub fn encode<M, C, E, T>(field: &Field<T>, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
 //!     where
 //!         M: Mode,
 //!         C: Context<Input = E::Error>,
 //!         E: Encoder
 //! # { todo!() }
 //!
-//!     pub fn decode<'de, M, C, D, T>(cx: &mut C, decoder: D) -> Result<Field<T>, C::Error>
+//!     pub fn decode<'de, M, C, D, T>(cx: &C, decoder: D) -> Result<Field<T>, C::Error>
 //!     where
 //!         M: Mode,
 //!         C: Context<Input = D::Error>,
@@ -678,7 +678,7 @@
 //!
 //!     use super::CustomUuid;
 //!
-//!     pub fn encode<M, C, E>(uuid: &CustomUuid, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+//!     pub fn encode<M, C, E>(uuid: &CustomUuid, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
 //!     where
 //!         M: Mode,
 //!         C: Context<Input = E::Error>,
@@ -687,7 +687,7 @@
 //!         Encode::<M>::encode(&uuid.0, cx, encoder)
 //!     }
 //!
-//!     pub fn decode<'de, M, C, D>(cx: &mut C, decoder: D) -> Result<CustomUuid, C::Error>
+//!     pub fn decode<'de, M, C, D>(cx: &C, decoder: D) -> Result<CustomUuid, C::Error>
 //!     where
 //!         M: Mode,
 //!         C: Context<Input = D::Error>,
@@ -703,7 +703,7 @@
 //!
 //!     use musli::{Context, Mode, Decode, Decoder, Encode, Encoder};
 //!
-//!     pub fn encode<M, C, E, T>(set: &HashSet<T>, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+//!     pub fn encode<M, C, E, T>(set: &HashSet<T>, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
 //!     where
 //!         M: Mode,
 //!         C: Context<Input = E::Error>,
@@ -713,7 +713,7 @@
 //!         HashSet::<T>::encode(set, cx, encoder)
 //!     }
 //!
-//!     pub fn decode<'de, M, C, D, T>(cx: &mut C, decoder: D) -> Result<HashSet<T>, C::Error>
+//!     pub fn decode<'de, M, C, D, T>(cx: &C, decoder: D) -> Result<HashSet<T>, C::Error>
 //!     where
 //!         M: Mode,
 //!         C: Context<Input = D::Error>,

--- a/crates/musli/src/en/encode.rs
+++ b/crates/musli/src/en/encode.rs
@@ -10,7 +10,7 @@ where
     M: Mode,
 {
     /// Encode the given output.
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder;
@@ -29,7 +29,7 @@ where
     M: Mode,
 {
     /// Encode the given output.
-    fn trace_encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn trace_encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder;
@@ -41,7 +41,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -56,7 +56,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,

--- a/crates/musli/src/en/encoder.rs
+++ b/crates/musli/src/en/encoder.rs
@@ -1,6 +1,5 @@
 use core::fmt;
 
-use crate::context::Buffer;
 use crate::en::Encode;
 use crate::error::Error;
 use crate::expecting::{self, Expecting};
@@ -193,9 +192,9 @@ pub trait Encoder: Sized {
     /// Encoder returned when encoding an optional value which is present.
     type Some: Encoder<Ok = Self::Ok, Error = Self::Error>;
     /// A simple pack that packs a sequence of elements.
-    type Pack<B>: SequenceEncoder<Ok = Self::Ok, Error = Self::Error>
+    type Pack<'this, C>: SequenceEncoder<Ok = Self::Ok, Error = Self::Error>
     where
-        B: Buffer;
+        C: 'this + Context;
     /// The type of a sequence encoder.
     type Sequence: SequenceEncoder<Ok = Self::Ok, Error = Self::Error>;
     /// The type of a tuple encoder.
@@ -1006,7 +1005,7 @@ pub trait Encoder: Sized {
     /// }
     /// ```
     #[inline]
-    fn encode_pack<'a, C>(self, cx: &'a C) -> Result<Self::Pack<C::Buf<'a>>, C::Error>
+    fn encode_pack<C>(self, cx: &C) -> Result<Self::Pack<'_, C>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {

--- a/crates/musli/src/en/encoder.rs
+++ b/crates/musli/src/en/encoder.rs
@@ -21,13 +21,13 @@ pub trait SequenceEncoder {
 
     /// Prepare encoding of the next element.
     #[must_use = "Encoder must be consumed"]
-    fn next<C>(&mut self, cx: &mut C) -> Result<Self::Encoder<'_>, C::Error>
+    fn next<C>(&mut self, cx: &C) -> Result<Self::Encoder<'_>, C::Error>
     where
         C: Context<Input = Self::Error>;
 
     /// Push an element into the sequence.
     #[inline]
-    fn push<M, C, T>(&mut self, cx: &mut C, value: T) -> Result<(), C::Error>
+    fn push<M, C, T>(&mut self, cx: &C, value: T) -> Result<(), C::Error>
     where
         M: Mode,
         C: Context<Input = Self::Error>,
@@ -39,7 +39,7 @@ pub trait SequenceEncoder {
     }
 
     /// End the sequence.
-    fn end<C>(self, cx: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(self, cx: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>;
 }
@@ -59,7 +59,7 @@ pub trait PairsEncoder {
 
     /// Insert a pair immediately.
     #[inline]
-    fn insert<M, C, F, S>(&mut self, cx: &mut C, first: F, second: S) -> Result<(), C::Error>
+    fn insert<M, C, F, S>(&mut self, cx: &C, first: F, second: S) -> Result<(), C::Error>
     where
         Self: Sized,
         M: Mode,
@@ -72,12 +72,12 @@ pub trait PairsEncoder {
     }
 
     /// Encode the next pair.
-    fn next<C>(&mut self, cx: &mut C) -> Result<Self::Encoder<'_>, C::Error>
+    fn next<C>(&mut self, cx: &C) -> Result<Self::Encoder<'_>, C::Error>
     where
         C: Context<Input = Self::Error>;
 
     /// Finish encoding pairs.
-    fn end<C>(self, cx: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(self, cx: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>;
 }
@@ -101,7 +101,7 @@ pub trait PairEncoder {
 
     /// Insert the pair immediately.
     #[inline]
-    fn insert<M, C, F, S>(mut self, cx: &mut C, first: F, second: S) -> Result<Self::Ok, C::Error>
+    fn insert<M, C, F, S>(mut self, cx: &C, first: F, second: S) -> Result<Self::Ok, C::Error>
     where
         Self: Sized,
         M: Mode,
@@ -116,18 +116,18 @@ pub trait PairEncoder {
 
     /// Return the encoder for the first element in the pair.
     #[must_use = "Encoder must be consumed through Encoder::encode_* methods, otherwise incomplete encoding might occur!"]
-    fn first<C>(&mut self, cx: &mut C) -> Result<Self::First<'_>, C::Error>
+    fn first<C>(&mut self, cx: &C) -> Result<Self::First<'_>, C::Error>
     where
         C: Context<Input = Self::Error>;
 
     /// Return encoder for the second element in the pair.
     #[must_use = "Encoder must be consumed through Encoder::encode_* methods, otherwise incomplete encoding might occur!"]
-    fn second<C>(&mut self, cx: &mut C) -> Result<Self::Second<'_>, C::Error>
+    fn second<C>(&mut self, cx: &C) -> Result<Self::Second<'_>, C::Error>
     where
         C: Context<Input = Self::Error>;
 
     /// Stop encoding this pair.
-    fn end<C>(self, cx: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(self, cx: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>;
 }
@@ -151,7 +151,7 @@ pub trait VariantEncoder {
 
     /// Insert the variant immediately.
     #[inline]
-    fn insert<M, C, F, S>(mut self, cx: &mut C, first: F, second: S) -> Result<Self::Ok, C::Error>
+    fn insert<M, C, F, S>(mut self, cx: &C, first: F, second: S) -> Result<Self::Ok, C::Error>
     where
         Self: Sized,
         M: Mode,
@@ -166,18 +166,18 @@ pub trait VariantEncoder {
 
     /// Return the encoder for the first element in the variant.
     #[must_use = "Encoder must be consumed through Encoder::encode_* methods, otherwise incomplete encoding might occur!"]
-    fn tag<C>(&mut self, cx: &mut C) -> Result<Self::Tag<'_>, C::Error>
+    fn tag<C>(&mut self, cx: &C) -> Result<Self::Tag<'_>, C::Error>
     where
         C: Context<Input = Self::Error>;
 
     /// Return encoder for the second element in the variant.
     #[must_use = "Encoder must be consumed through Encoder::encode_* methods, otherwise incomplete encoding might occur!"]
-    fn variant<C>(&mut self, cx: &mut C) -> Result<Self::Variant<'_>, C::Error>
+    fn variant<C>(&mut self, cx: &C) -> Result<Self::Variant<'_>, C::Error>
     where
         C: Context<Input = Self::Error>;
 
     /// End the variant encoder.
-    fn end<C>(self, cx: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(self, cx: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>;
 }
@@ -227,7 +227,7 @@ pub trait Encoder: Sized {
     /// struct EmptyStruct;
     ///
     /// impl<M> Encode<M> for EmptyStruct where M: Mode {
-    ///     fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    ///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     ///     where
     ///         C: Context<Input = E::Error>,
     ///         E: Encoder
@@ -237,7 +237,7 @@ pub trait Encoder: Sized {
     /// }
     /// ```
     #[inline]
-    fn encode_unit<C>(self, cx: &mut C) -> Result<Self::Ok, C::Error>
+    fn encode_unit<C>(self, cx: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -259,7 +259,7 @@ pub trait Encoder: Sized {
     /// }
     ///
     /// impl<M> Encode<M> for MyType where M: Mode {
-    ///     fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    ///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     ///     where
     ///         C: Context<Input = E::Error>,
     ///         E: Encoder
@@ -269,7 +269,7 @@ pub trait Encoder: Sized {
     /// }
     /// ```
     #[inline]
-    fn encode_bool<C>(self, cx: &mut C, _: bool) -> Result<Self::Ok, C::Error>
+    fn encode_bool<C>(self, cx: &C, _: bool) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -291,7 +291,7 @@ pub trait Encoder: Sized {
     /// }
     ///
     /// impl<M> Encode<M> for MyType where M: Mode {
-    ///     fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    ///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     ///     where
     ///         C: Context<Input = E::Error>,
     ///         E: Encoder
@@ -301,7 +301,7 @@ pub trait Encoder: Sized {
     /// }
     /// ```
     #[inline]
-    fn encode_char<C>(self, cx: &mut C, _: char) -> Result<Self::Ok, C::Error>
+    fn encode_char<C>(self, cx: &C, _: char) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -323,7 +323,7 @@ pub trait Encoder: Sized {
     /// }
     ///
     /// impl<M> Encode<M> for MyType where M: Mode {
-    ///     fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    ///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     ///     where
     ///         C: Context<Input = E::Error>,
     ///         E: Encoder
@@ -333,7 +333,7 @@ pub trait Encoder: Sized {
     /// }
     /// ```
     #[inline]
-    fn encode_u8<C>(self, cx: &mut C, _: u8) -> Result<Self::Ok, C::Error>
+    fn encode_u8<C>(self, cx: &C, _: u8) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -355,7 +355,7 @@ pub trait Encoder: Sized {
     /// }
     ///
     /// impl<M> Encode<M> for MyType where M: Mode {
-    ///     fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    ///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     ///     where
     ///         C: Context<Input = E::Error>,
     ///         E: Encoder
@@ -365,7 +365,7 @@ pub trait Encoder: Sized {
     /// }
     /// ```
     #[inline]
-    fn encode_u16<C>(self, cx: &mut C, _: u16) -> Result<Self::Ok, C::Error>
+    fn encode_u16<C>(self, cx: &C, _: u16) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -387,7 +387,7 @@ pub trait Encoder: Sized {
     /// }
     ///
     /// impl<M> Encode<M> for MyType where M: Mode {
-    ///     fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    ///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     ///     where
     ///         C: Context<Input = E::Error>,
     ///         E: Encoder
@@ -397,7 +397,7 @@ pub trait Encoder: Sized {
     /// }
     /// ```
     #[inline]
-    fn encode_u32<C>(self, cx: &mut C, _: u32) -> Result<Self::Ok, C::Error>
+    fn encode_u32<C>(self, cx: &C, _: u32) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -419,7 +419,7 @@ pub trait Encoder: Sized {
     /// }
     ///
     /// impl<M> Encode<M> for MyType where M: Mode {
-    ///     fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    ///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     ///     where
     ///         C: Context<Input = E::Error>,
     ///         E: Encoder
@@ -429,7 +429,7 @@ pub trait Encoder: Sized {
     /// }
     /// ```
     #[inline]
-    fn encode_u64<C>(self, cx: &mut C, _: u64) -> Result<Self::Ok, C::Error>
+    fn encode_u64<C>(self, cx: &C, _: u64) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -451,7 +451,7 @@ pub trait Encoder: Sized {
     /// }
     ///
     /// impl<M> Encode<M> for MyType where M: Mode {
-    ///     fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    ///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     ///     where
     ///         C: Context<Input = E::Error>,
     ///         E: Encoder
@@ -461,7 +461,7 @@ pub trait Encoder: Sized {
     /// }
     /// ```
     #[inline]
-    fn encode_u128<C>(self, cx: &mut C, _: u128) -> Result<Self::Ok, C::Error>
+    fn encode_u128<C>(self, cx: &C, _: u128) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -483,7 +483,7 @@ pub trait Encoder: Sized {
     /// }
     ///
     /// impl<M> Encode<M> for MyType where M: Mode {
-    ///     fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    ///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     ///     where
     ///         C: Context<Input = E::Error>,
     ///         E: Encoder
@@ -493,7 +493,7 @@ pub trait Encoder: Sized {
     /// }
     /// ```
     #[inline]
-    fn encode_i8<C>(self, cx: &mut C, _: i8) -> Result<Self::Ok, C::Error>
+    fn encode_i8<C>(self, cx: &C, _: i8) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -515,7 +515,7 @@ pub trait Encoder: Sized {
     /// }
     ///
     /// impl<M> Encode<M> for MyType where M: Mode {
-    ///     fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    ///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     ///     where
     ///         C: Context<Input = E::Error>,
     ///         E: Encoder
@@ -525,7 +525,7 @@ pub trait Encoder: Sized {
     /// }
     /// ```
     #[inline]
-    fn encode_i16<C>(self, cx: &mut C, _: i16) -> Result<Self::Ok, C::Error>
+    fn encode_i16<C>(self, cx: &C, _: i16) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -547,7 +547,7 @@ pub trait Encoder: Sized {
     /// }
     ///
     /// impl<M> Encode<M> for MyType where M: Mode {
-    ///     fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    ///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     ///     where
     ///         C: Context<Input = E::Error>,
     ///         E: Encoder
@@ -557,7 +557,7 @@ pub trait Encoder: Sized {
     /// }
     /// ```
     #[inline]
-    fn encode_i32<C>(self, cx: &mut C, _: i32) -> Result<Self::Ok, C::Error>
+    fn encode_i32<C>(self, cx: &C, _: i32) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -579,7 +579,7 @@ pub trait Encoder: Sized {
     /// }
     ///
     /// impl<M> Encode<M> for MyType where M: Mode {
-    ///     fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    ///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     ///     where
     ///         C: Context<Input = E::Error>,
     ///         E: Encoder
@@ -589,7 +589,7 @@ pub trait Encoder: Sized {
     /// }
     /// ```
     #[inline]
-    fn encode_i64<C>(self, cx: &mut C, _: i64) -> Result<Self::Ok, C::Error>
+    fn encode_i64<C>(self, cx: &C, _: i64) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -611,7 +611,7 @@ pub trait Encoder: Sized {
     /// }
     ///
     /// impl<M> Encode<M> for MyType where M: Mode {
-    ///     fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    ///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     ///     where
     ///         C: Context<Input = E::Error>,
     ///         E: Encoder
@@ -621,7 +621,7 @@ pub trait Encoder: Sized {
     /// }
     /// ```
     #[inline]
-    fn encode_i128<C>(self, cx: &mut C, _: i128) -> Result<Self::Ok, C::Error>
+    fn encode_i128<C>(self, cx: &C, _: i128) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -643,7 +643,7 @@ pub trait Encoder: Sized {
     /// }
     ///
     /// impl<M> Encode<M> for MyType where M: Mode {
-    ///     fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    ///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     ///     where
     ///         C: Context<Input = E::Error>,
     ///         E: Encoder
@@ -653,7 +653,7 @@ pub trait Encoder: Sized {
     /// }
     /// ```
     #[inline]
-    fn encode_usize<C>(self, cx: &mut C, _: usize) -> Result<Self::Ok, C::Error>
+    fn encode_usize<C>(self, cx: &C, _: usize) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -675,7 +675,7 @@ pub trait Encoder: Sized {
     /// }
     ///
     /// impl<M> Encode<M> for MyType where M: Mode {
-    ///     fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    ///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     ///     where
     ///         C: Context<Input = E::Error>,
     ///         E: Encoder
@@ -685,7 +685,7 @@ pub trait Encoder: Sized {
     /// }
     /// ```
     #[inline]
-    fn encode_isize<C>(self, cx: &mut C, _: isize) -> Result<Self::Ok, C::Error>
+    fn encode_isize<C>(self, cx: &C, _: isize) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -707,7 +707,7 @@ pub trait Encoder: Sized {
     /// }
     ///
     /// impl<M> Encode<M> for MyType where M: Mode {
-    ///     fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    ///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     ///     where
     ///         C: Context<Input = E::Error>,
     ///         E: Encoder
@@ -717,7 +717,7 @@ pub trait Encoder: Sized {
     /// }
     /// ```
     #[inline]
-    fn encode_f32<C>(self, cx: &mut C, _: f32) -> Result<Self::Ok, C::Error>
+    fn encode_f32<C>(self, cx: &C, _: f32) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -739,7 +739,7 @@ pub trait Encoder: Sized {
     /// }
     ///
     /// impl<M> Encode<M> for MyType where M: Mode {
-    ///     fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    ///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     ///     where
     ///         C: Context<Input = E::Error>,
     ///         E: Encoder
@@ -749,7 +749,7 @@ pub trait Encoder: Sized {
     /// }
     /// ```
     #[inline]
-    fn encode_f64<C>(self, cx: &mut C, _: f64) -> Result<Self::Ok, C::Error>
+    fn encode_f64<C>(self, cx: &C, _: f64) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -771,7 +771,7 @@ pub trait Encoder: Sized {
     /// }
     ///
     /// impl<M> Encode<M> for MyType where M: Mode {
-    ///     fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    ///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     ///     where
     ///         C: Context<Input = E::Error>,
     ///         E: Encoder
@@ -781,7 +781,7 @@ pub trait Encoder: Sized {
     /// }
     /// ```
     #[inline]
-    fn encode_array<C, const N: usize>(self, cx: &mut C, _: [u8; N]) -> Result<Self::Ok, C::Error>
+    fn encode_array<C, const N: usize>(self, cx: &C, _: [u8; N]) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -803,7 +803,7 @@ pub trait Encoder: Sized {
     /// }
     ///
     /// impl<M> Encode<M> for MyType where M: Mode {
-    ///     fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    ///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     ///     where
     ///         C: Context<Input = E::Error>,
     ///         E: Encoder
@@ -813,7 +813,7 @@ pub trait Encoder: Sized {
     /// }
     /// ```
     #[inline]
-    fn encode_bytes<C>(self, cx: &mut C, _: &[u8]) -> Result<Self::Ok, C::Error>
+    fn encode_bytes<C>(self, cx: &C, _: &[u8]) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -842,7 +842,7 @@ pub trait Encoder: Sized {
     /// }
     ///
     /// impl<M> Encode<M> for MyType where M: Mode {
-    ///     fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    ///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     ///     where
     ///         C: Context<Input = E::Error>,
     ///         E: Encoder
@@ -853,7 +853,7 @@ pub trait Encoder: Sized {
     /// }
     /// ```
     #[inline]
-    fn encode_bytes_vectored<C>(self, cx: &mut C, _: &[&[u8]]) -> Result<Self::Ok, C::Error>
+    fn encode_bytes_vectored<C>(self, cx: &C, _: &[&[u8]]) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -875,7 +875,7 @@ pub trait Encoder: Sized {
     /// }
     ///
     /// impl<M> Encode<M> for MyType where M: Mode {
-    ///     fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    ///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     ///     where
     ///         C: Context<Input = E::Error>,
     ///         E: Encoder
@@ -885,7 +885,7 @@ pub trait Encoder: Sized {
     /// }
     /// ```
     #[inline]
-    fn encode_string<C>(self, cx: &mut C, _: &str) -> Result<Self::Ok, C::Error>
+    fn encode_string<C>(self, cx: &C, _: &str) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -907,7 +907,7 @@ pub trait Encoder: Sized {
     /// }
     ///
     /// impl<M> Encode<M> for MyType where M: Mode {
-    ///     fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    ///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     ///     where
     ///         C: Context<Input = E::Error>,
     ///         E: Encoder
@@ -924,7 +924,7 @@ pub trait Encoder: Sized {
     /// }
     /// ```
     #[inline]
-    fn encode_some<C>(self, cx: &mut C) -> Result<Self::Some, C::Error>
+    fn encode_some<C>(self, cx: &C) -> Result<Self::Some, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -946,7 +946,7 @@ pub trait Encoder: Sized {
     /// }
     ///
     /// impl<M> Encode<M> for MyType where M: Mode {
-    ///     fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    ///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     ///     where
     ///         C: Context<Input = E::Error>,
     ///         E: Encoder
@@ -963,7 +963,7 @@ pub trait Encoder: Sized {
     /// }
     /// ```
     #[inline]
-    fn encode_none<C>(self, cx: &mut C) -> Result<Self::Ok, C::Error>
+    fn encode_none<C>(self, cx: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -993,7 +993,7 @@ pub trait Encoder: Sized {
     /// }
     ///
     /// impl<M> Encode<M> for PackedStruct where M: Mode {
-    ///     fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    ///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     ///     where
     ///         C: Context<Input = E::Error>,
     ///         E: Encoder
@@ -1006,7 +1006,7 @@ pub trait Encoder: Sized {
     /// }
     /// ```
     #[inline]
-    fn encode_pack<C>(self, cx: &mut C) -> Result<Self::Pack<C::Buf>, C::Error>
+    fn encode_pack<C>(self, cx: &C) -> Result<Self::Pack<C::Buf>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -1036,7 +1036,7 @@ pub trait Encoder: Sized {
     /// }
     ///
     /// impl<M> Encode<M> for MyType where M: Mode {
-    ///     fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    ///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     ///     where
     ///         C: Context<Input = E::Error>,
     ///         E: Encoder
@@ -1054,7 +1054,7 @@ pub trait Encoder: Sized {
     #[inline]
     fn encode_sequence<C>(
         self,
-        cx: &mut C,
+        cx: &C,
         #[allow(unused)] len: usize,
     ) -> Result<Self::Sequence, C::Error>
     where
@@ -1086,7 +1086,7 @@ pub trait Encoder: Sized {
     /// struct PackedTuple(u32, [u8; 364]);
     ///
     /// impl<M> Encode<M> for PackedTuple where M: Mode {
-    ///     fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    ///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     ///     where
     ///         C: Context<Input = E::Error>,
     ///         E: Encoder
@@ -1099,11 +1099,7 @@ pub trait Encoder: Sized {
     /// }
     /// ```
     #[inline]
-    fn encode_tuple<C>(
-        self,
-        cx: &mut C,
-        #[allow(unused)] len: usize,
-    ) -> Result<Self::Tuple, C::Error>
+    fn encode_tuple<C>(self, cx: &C, #[allow(unused)] len: usize) -> Result<Self::Tuple, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -1117,7 +1113,7 @@ pub trait Encoder: Sized {
     ///
     ///
     #[inline]
-    fn encode_map<C>(self, cx: &mut C, #[allow(unused)] len: usize) -> Result<Self::Map, C::Error>
+    fn encode_map<C>(self, cx: &C, #[allow(unused)] len: usize) -> Result<Self::Map, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -1142,7 +1138,7 @@ pub trait Encoder: Sized {
     /// }
     ///
     /// impl<M> Encode<M> for Struct where M: Mode {
-    ///     fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    ///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     ///     where
     ///         C: Context<Input = E::Error>,
     ///         E: Encoder
@@ -1155,7 +1151,7 @@ pub trait Encoder: Sized {
     /// }
     /// ```
     #[inline]
-    fn encode_struct<C>(self, cx: &mut C, _: usize) -> Result<Self::Struct, C::Error>
+    fn encode_struct<C>(self, cx: &C, _: usize) -> Result<Self::Struct, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -1184,7 +1180,7 @@ pub trait Encoder: Sized {
     /// }
     ///
     /// impl<M> Encode<M> for Enum where M: Mode {
-    ///     fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    ///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     ///     where
     ///         C: Context<Input = E::Error>,
     ///         E: Encoder
@@ -1213,7 +1209,7 @@ pub trait Encoder: Sized {
     /// }
     /// ```
     #[inline]
-    fn encode_variant<C>(self, cx: &mut C) -> Result<Self::Variant, C::Error>
+    fn encode_variant<C>(self, cx: &C) -> Result<Self::Variant, C::Error>
     where
         C: Context<Input = Self::Error>,
     {

--- a/crates/musli/src/en/encoder.rs
+++ b/crates/musli/src/en/encoder.rs
@@ -1006,7 +1006,7 @@ pub trait Encoder: Sized {
     /// }
     /// ```
     #[inline]
-    fn encode_pack<C>(self, cx: &C) -> Result<Self::Pack<C::Buf>, C::Error>
+    fn encode_pack<'a, C>(self, cx: &'a C) -> Result<Self::Pack<C::Buf<'a>>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {

--- a/crates/musli/src/impls.rs
+++ b/crates/musli/src/impls.rs
@@ -2,6 +2,7 @@
 mod alloc;
 #[cfg(feature = "std")]
 mod net;
+mod range;
 mod tuples;
 
 use core::ffi::CStr;

--- a/crates/musli/src/impls.rs
+++ b/crates/musli/src/impls.rs
@@ -22,7 +22,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -36,7 +36,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,
@@ -50,7 +50,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -63,7 +63,7 @@ impl<'de, M, T> Decode<'de, M> for marker::PhantomData<T>
 where
     M: Mode,
 {
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,
@@ -81,7 +81,7 @@ macro_rules! atomic_impl {
             where
                 M: Mode,
             {
-                fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+                fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
                 where
                     C: Context<Input = D::Error>,
                     D: Decoder<'de>,
@@ -106,7 +106,7 @@ macro_rules! non_zero {
             M: Mode,
         {
             #[inline]
-            fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+            fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
             where
                 C: Context<Input = E::Error>,
                 E: Encoder,
@@ -119,7 +119,7 @@ macro_rules! non_zero {
         where
             M: Mode,
         {
-            fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+            fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
             where
                 C: Context<Input = D::Error>,
                 D: Decoder<'de>,
@@ -174,7 +174,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -188,7 +188,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,
@@ -204,7 +204,7 @@ macro_rules! impl_number {
             M: Mode,
         {
             #[inline]
-            fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+            fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
             where
                 C: Context<Input = E::Error>,
                 E: Encoder,
@@ -218,7 +218,7 @@ macro_rules! impl_number {
             M: Mode,
         {
             #[inline]
-            fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+            fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
             where
                 C: Context<Input = D::Error>,
                 D: Decoder<'de>,
@@ -234,7 +234,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -248,7 +248,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,
@@ -262,7 +262,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -276,7 +276,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,
@@ -305,7 +305,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -319,7 +319,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,
@@ -338,7 +338,7 @@ where
             }
 
             #[inline]
-            fn visit_borrowed(self, _: &mut C, string: &'de str) -> Result<Self::Ok, C::Error> {
+            fn visit_borrowed(self, _: &C, string: &'de str) -> Result<Self::Ok, C::Error> {
                 Ok(string)
             }
         }
@@ -351,7 +351,7 @@ impl<M> Encode<M> for [u8]
 where
     M: Mode,
 {
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -365,7 +365,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,
@@ -384,7 +384,7 @@ where
             }
 
             #[inline]
-            fn visit_borrowed(self, _: &mut C, bytes: &'de [u8]) -> Result<Self::Ok, C::Error> {
+            fn visit_borrowed(self, _: &C, bytes: &'de [u8]) -> Result<Self::Ok, C::Error> {
                 Ok(bytes)
             }
         }
@@ -399,7 +399,7 @@ where
     T: Encode<M>,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -419,7 +419,7 @@ where
     T: Decode<'de, M>,
 {
     #[inline]
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,
@@ -439,7 +439,7 @@ where
     U: Encode<M>,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -460,7 +460,7 @@ where
     U: Decode<'de, M>,
 {
     #[inline]
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,
@@ -487,7 +487,7 @@ where
     T: Encode<M>,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -502,7 +502,7 @@ where
     T: Decode<'de, M>,
 {
     #[inline]
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,
@@ -516,7 +516,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -530,7 +530,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,

--- a/crates/musli/src/impls/alloc.rs
+++ b/crates/musli/src/impls/alloc.rs
@@ -32,7 +32,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -46,7 +46,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,
@@ -65,17 +65,17 @@ where
             }
 
             #[inline]
-            fn visit_owned(self, _: &mut C, value: String) -> Result<Self::Ok, C::Error> {
+            fn visit_owned(self, _: &C, value: String) -> Result<Self::Ok, C::Error> {
                 Ok(value)
             }
 
             #[inline]
-            fn visit_borrowed(self, cx: &mut C, string: &'de str) -> Result<Self::Ok, C::Error> {
+            fn visit_borrowed(self, cx: &C, string: &'de str) -> Result<Self::Ok, C::Error> {
                 self.visit_ref(cx, string)
             }
 
             #[inline]
-            fn visit_ref(self, _: &mut C, string: &str) -> Result<Self::Ok, C::Error> {
+            fn visit_ref(self, _: &C, string: &str) -> Result<Self::Ok, C::Error> {
                 Ok(string.to_owned())
             }
         }
@@ -89,7 +89,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -103,7 +103,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,
@@ -119,7 +119,7 @@ macro_rules! cow {
             M: Mode,
         {
             #[inline]
-            fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+            fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
             where
                 C: Context<Input = E::Error>,
                 E: Encoder,
@@ -133,7 +133,7 @@ macro_rules! cow {
             M: Mode,
         {
             #[inline]
-            fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+            fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
             where
                 C: Context<Input = D::Error>,
                 D: Decoder<'de>,
@@ -154,7 +154,7 @@ macro_rules! cow {
                     #[inline]
                     fn visit_owned(
                         self,
-                        $cx: &mut C,
+                        $cx: &C,
                         $owned: <$source as ToOwned>::Owned,
                     ) -> Result<Self::Ok, C::Error> {
                         Ok($owned_expr)
@@ -163,7 +163,7 @@ macro_rules! cow {
                     #[inline]
                     fn visit_borrowed(
                         self,
-                        $cx: &mut C,
+                        $cx: &C,
                         $borrowed: &'de $source,
                     ) -> Result<Self::Ok, C::Error> {
                         Ok($borrowed_expr)
@@ -172,7 +172,7 @@ macro_rules! cow {
                     #[inline]
                     fn visit_ref(
                         self,
-                        $cx: &mut C,
+                        $cx: &C,
                         $reference: &$source,
                     ) -> Result<Self::Ok, C::Error> {
                         Ok($reference_expr)
@@ -213,7 +213,7 @@ macro_rules! sequence {
             $($extra: $extra_bound0 $(+ $extra_bound)*),*
         {
             #[inline]
-            fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+            fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
             where
                 C: Context<Input = E::Error>,
                 E: Encoder,
@@ -241,7 +241,7 @@ macro_rules! sequence {
             $($extra: $extra_bound0 $(+ $extra_bound)*),*
         {
             #[inline]
-            fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+            fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
             where
                 C: Context<Input = D::Error>,
                 D: Decoder<'de>,
@@ -305,7 +305,7 @@ macro_rules! map {
             $($extra: $extra_bound0 $(+ $extra_bound)*),*
         {
             #[inline]
-            fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+            fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
             where
                 C: Context<Input = E::Error>,
                 E: Encoder,
@@ -333,7 +333,7 @@ macro_rules! map {
             $($extra: $extra_bound0 $(+ $extra_bound)*),*
         {
             #[inline]
-            fn trace_encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+            fn trace_encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
             where
                 C: Context<Input = E::Error>,
                 E: Encoder,
@@ -363,7 +363,7 @@ macro_rules! map {
             $($extra: $extra_bound0 $(+ $extra_bound)*),*
         {
             #[inline]
-            fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+            fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
             where
                 C: Context<Input = D::Error>,
                 D: Decoder<'de>,
@@ -390,7 +390,7 @@ macro_rules! map {
             $($extra: $extra_bound0 $(+ $extra_bound)*),*
         {
             #[inline]
-            fn trace_decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+            fn trace_decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
             where
                 C: Context<Input = D::Error>,
                 D: Decoder<'de>,
@@ -427,7 +427,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -441,7 +441,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,
@@ -460,17 +460,17 @@ where
             }
 
             #[inline]
-            fn visit_owned(self, cx: &mut C, value: Vec<u8>) -> Result<Self::Ok, C::Error> {
+            fn visit_owned(self, cx: &C, value: Vec<u8>) -> Result<Self::Ok, C::Error> {
                 CString::from_vec_with_nul(value).map_err(|error| cx.custom(error))
             }
 
             #[inline]
-            fn visit_borrowed(self, cx: &mut C, bytes: &'de [u8]) -> Result<Self::Ok, C::Error> {
+            fn visit_borrowed(self, cx: &C, bytes: &'de [u8]) -> Result<Self::Ok, C::Error> {
                 self.visit_ref(cx, bytes)
             }
 
             #[inline]
-            fn visit_ref(self, cx: &mut C, bytes: &[u8]) -> Result<Self::Ok, C::Error> {
+            fn visit_ref(self, cx: &C, bytes: &[u8]) -> Result<Self::Ok, C::Error> {
                 Ok(CStr::from_bytes_with_nul(bytes)
                     .map_err(|error| cx.custom(error))?
                     .to_owned())
@@ -489,7 +489,7 @@ macro_rules! smart_pointer {
             T: Encode<M>,
         {
             #[inline]
-            fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+            fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
             where
                 C: Context<Input = E::Error>,
                 E: Encoder,
@@ -504,7 +504,7 @@ macro_rules! smart_pointer {
             T: Decode<'de, M>,
         {
             #[inline]
-            fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+            fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
             where
                 C: Context<Input = D::Error>,
                 D: Decoder<'de>,
@@ -533,7 +533,7 @@ where
 {
     #[cfg(unix)]
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -552,7 +552,7 @@ where
 
     #[cfg(windows)]
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -574,7 +574,7 @@ where
             }
         }
 
-        let mut value = variant.variant(cx)?;
+        let value = variant.variant(cx)?;
         Encode::<M>::encode(unsafe { buf.as_slice() }, cx, value)?;
         variant.end(cx)
     }
@@ -586,7 +586,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -601,7 +601,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,
@@ -648,7 +648,7 @@ where
                     }
 
                     #[inline]
-                    fn visit_ref(self, cx: &mut C, bytes: &[u8]) -> Result<Self::Ok, C::Error> {
+                    fn visit_ref(self, cx: &C, bytes: &[u8]) -> Result<Self::Ok, C::Error> {
                         use crate::context::Buffer;
 
                         let mut buf = cx.alloc();
@@ -691,7 +691,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -706,7 +706,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -721,7 +721,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,

--- a/crates/musli/src/impls/alloc.rs
+++ b/crates/musli/src/impls/alloc.rs
@@ -575,7 +575,7 @@ where
         }
 
         let value = variant.variant(cx)?;
-        Encode::<M>::encode(unsafe { buf.as_slice() }, cx, value)?;
+        Encode::<M>::encode(buf.as_slice(), cx, value)?;
         variant.end(cx)
     }
 }

--- a/crates/musli/src/impls/alloc.rs
+++ b/crates/musli/src/impls/alloc.rs
@@ -1,7 +1,7 @@
 use core::ffi::CStr;
+use core::fmt;
 #[cfg(feature = "std")]
 use core::hash::{BuildHasher, Hash};
-use core::{fmt, slice};
 
 use alloc::borrow::{Cow, ToOwned};
 use alloc::boxed::Box;
@@ -632,6 +632,7 @@ where
             }
             #[cfg(windows)]
             Tag::Windows => {
+                use core::slice;
                 use std::os::windows::ffi::OsStringExt;
 
                 struct Visitor;

--- a/crates/musli/src/impls/alloc.rs
+++ b/crates/musli/src/impls/alloc.rs
@@ -615,9 +615,7 @@ where
 
         match tag {
             #[cfg(not(unix))]
-            Tag::Unix => {
-                return Err(cx.message("Unsupported OsString::Unix variant"));
-            }
+            Tag::Unix => Err(cx.message("Unsupported OsString::Unix variant")),
             #[cfg(unix)]
             Tag::Unix => {
                 use std::os::unix::ffi::OsStringExt;
@@ -627,9 +625,7 @@ where
                 Ok(OsString::from_vec(bytes))
             }
             #[cfg(not(windows))]
-            Tag::Windows => {
-                return Err(cx.message("Unsupported OsString::Windows variant"));
-            }
+            Tag::Windows => Err(cx.message("Unsupported OsString::Windows variant")),
             #[cfg(windows)]
             Tag::Windows => {
                 use core::slice;

--- a/crates/musli/src/impls/net.rs
+++ b/crates/musli/src/impls/net.rs
@@ -10,7 +10,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -24,7 +24,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,
@@ -38,7 +38,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -52,7 +52,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,
@@ -66,7 +66,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -85,7 +85,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,
@@ -121,7 +121,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -138,7 +138,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,
@@ -160,7 +160,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -179,7 +179,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,
@@ -207,7 +207,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         C: Context<Input = E::Error>,
         E: Encoder,
@@ -226,7 +226,7 @@ where
     M: Mode,
 {
     #[inline]
-    fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
     where
         C: Context<Input = D::Error>,
         D: Decoder<'de>,

--- a/crates/musli/src/impls/range.rs
+++ b/crates/musli/src/impls/range.rs
@@ -12,7 +12,7 @@ macro_rules! implement {
         {
             #[inline]
             #[allow(unused_mut)]
-            fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+            fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
             where
                 C: Context<Input = E::Error>,
                 E: Encoder,
@@ -32,7 +32,7 @@ macro_rules! implement {
             $($type: Decode<'de, M>,)*
         {
             #[inline]
-            fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+            fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
             where
                 C: Context<Input = D::Error>,
                 D: Decoder<'de>,
@@ -52,7 +52,7 @@ macro_rules! implement_new {
             T: Encode<M>,
         {
             #[inline]
-            fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+            fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
             where
                 C: Context<Input = E::Error>,
                 E: Encoder,
@@ -72,7 +72,7 @@ macro_rules! implement_new {
             T: Decode<'de, M>,
         {
             #[inline]
-            fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+            fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
             where
                 C: Context<Input = D::Error>,
                 D: Decoder<'de>,

--- a/crates/musli/src/impls/range.rs
+++ b/crates/musli/src/impls/range.rs
@@ -1,0 +1,92 @@
+use core::ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
+
+use crate::en::SequenceEncoder;
+use crate::{Context, Decode, Decoder, Encode, Encoder, Mode};
+
+macro_rules! implement {
+    ($ty:ident $(<$type:ident>)? { $($field:ident),* }, $count:expr) => {
+        impl<M, $($type)*> Encode<M> for $ty $(<$type>)*
+        where
+            M: Mode,
+            $($type: Encode<M>,)*
+        {
+            #[inline]
+            #[allow(unused_mut)]
+            fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+            where
+                C: Context<Input = E::Error>,
+                E: Encoder,
+            {
+                let mut tuple = encoder.encode_tuple(cx, $count)?;
+                $(
+                let $field = tuple.next(cx)?;
+                Encode::<M>::encode(&self.$field, cx, $field)?;
+                )*
+                tuple.end(cx)
+            }
+        }
+
+        impl<'de, M, $($type)*> Decode<'de, M> for $ty $(<$type>)*
+        where
+            M: Mode,
+            $($type: Decode<'de, M>,)*
+        {
+            #[inline]
+            fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+            where
+                C: Context<Input = D::Error>,
+                D: Decoder<'de>,
+            {
+                let ($($field,)*) = Decode::<'de, M>::decode(cx, decoder)?;
+                Ok($ty { $($field,)* })
+            }
+        }
+    }
+}
+
+macro_rules! implement_new {
+    ($ty:ident { $($field:ident),* }, $count:expr) => {
+        impl<M, T> Encode<M> for $ty<T>
+        where
+            M: Mode,
+            T: Encode<M>,
+        {
+            #[inline]
+            fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+            where
+                C: Context<Input = E::Error>,
+                E: Encoder,
+            {
+                let mut tuple = encoder.encode_tuple(cx, $count)?;
+                $(
+                let $field = tuple.next(cx)?;
+                Encode::<M>::encode(&self.$field(), cx, $field)?;
+                )*
+                tuple.end(cx)
+            }
+        }
+
+        impl<'de, M, T> Decode<'de, M> for $ty<T>
+        where
+            M: Mode,
+            T: Decode<'de, M>,
+        {
+            #[inline]
+            fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+            where
+                C: Context<Input = D::Error>,
+                D: Decoder<'de>,
+            {
+                let ($($field,)*) = Decode::<'de, M>::decode(cx, decoder)?;
+                Ok($ty::new($($field,)*))
+            }
+        }
+    }
+}
+
+implement!(RangeFull {}, 0);
+implement!(Range<T> { start, end }, 2);
+implement!(RangeFrom<T> { start }, 1);
+implement!(RangeTo<T> { end }, 1);
+implement!(RangeToInclusive<T> { end }, 1);
+implement_new!(RangeInclusive { start, end }, 2);

--- a/crates/musli/src/impls/tuples.rs
+++ b/crates/musli/src/impls/tuples.rs
@@ -44,7 +44,7 @@ macro_rules! declare {
     (($ty0:ident, $ident0:ident) $(, ($ty:ident, $ident:ident))* $(,)?) => {
         impl<M, $ty0 $(, $ty)*> Encode<M> for ($ty0, $($ty),*) where M: Mode, $ty0: Encode<M>, $($ty: Encode<M>),* {
             #[inline]
-            fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+            fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
             where
                 C: Context<Input = E::Error>,
                 E: Encoder,
@@ -63,7 +63,7 @@ macro_rules! declare {
 
         impl<'de, M, $ty0, $($ty,)*> Decode<'de, M> for ($ty0, $($ty),*) where M: Mode, $ty0: Decode<'de, M>, $($ty: Decode<'de, M>),* {
             #[inline]
-            fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+            fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
             where
                 C: Context<Input = D::Error>,
                 D: Decoder<'de>
@@ -78,7 +78,7 @@ macro_rules! declare {
 
         impl<M, $ty0 $(,$ty)*> Encode<M> for Packed<($ty0, $($ty),*)> where M: Mode, $ty0: Encode<M>, $($ty: Encode<M>),* {
             #[inline]
-            fn encode<C, E>(&self, cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+            fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
             where
                 C: Context<Input = E::Error>,
                 E: Encoder,
@@ -97,7 +97,7 @@ macro_rules! declare {
 
         impl<'de, M, $ty0, $($ty,)*> Decode<'de, M> for Packed<($ty0, $($ty),*)> where M: Mode, $ty0: Decode<'de, M>, $($ty: Decode<'de, M>),* {
             #[inline]
-            fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+            fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
             where
                 C: Context<Input = D::Error>,
                 D: Decoder<'de>

--- a/crates/musli/src/lib.rs
+++ b/crates/musli/src/lib.rs
@@ -129,7 +129,7 @@
 //! }
 //!
 //! impl<'de, M> Decode<'de, M> for MyType where M: Mode {
-//!     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+//!     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
 //!     where
 //!         C: Context<Input = D::Error>,
 //!         D: Decoder<'de>,
@@ -453,7 +453,7 @@ pub use self::mode::Mode;
 ///         write!(f, "32-bit unsigned integers")
 ///     }
 ///
-///     fn encode_u32<C>(self, cx: &mut C, value: u32) -> Result<(), C::Error>
+///     fn encode_u32<C>(self, cx: &C, value: u32) -> Result<(), C::Error>
 ///     where
 ///         C: Context<Input = Self::Error>
 ///     {
@@ -493,7 +493,7 @@ pub use musli_macros::encoder;
 ///         write!(f, "32-bit unsigned integers")
 ///     }
 ///
-///     fn decode_u32<C>(self, _: &mut C) -> Result<u32, C::Error>
+///     fn decode_u32<C>(self, _: &C) -> Result<u32, C::Error>
 ///     where
 ///         C: Context<Input = Self::Error>
 ///     {

--- a/crates/musli/src/never.rs
+++ b/crates/musli/src/never.rs
@@ -31,19 +31,6 @@ impl Buffer for NeverBuffer {
     }
 
     #[inline(always)]
-    fn write_at(&mut self, _: usize, _: &[u8]) -> bool {
-        false
-    }
-
-    #[inline(always)]
-    fn copy_back<B>(&mut self, _: B) -> bool
-    where
-        B: Buffer,
-    {
-        false
-    }
-
-    #[inline(always)]
     fn len(&self) -> usize {
         0
     }
@@ -315,7 +302,7 @@ where
 {
     type Ok = O;
     type Error = E;
-    type Pack<B> = Self where B: Buffer;
+    type Pack<'this, C> = Self where C: 'this + Context;
     type Some = Self;
     type Sequence = Self;
     type Tuple = Self;

--- a/crates/musli/src/never.rs
+++ b/crates/musli/src/never.rs
@@ -9,7 +9,6 @@
 
 use core::fmt;
 use core::marker;
-use core::ptr::NonNull;
 
 use crate::no_std::ToOwned;
 
@@ -49,12 +48,8 @@ impl Buffer for NeverBuffer {
         0
     }
 
-    fn raw_parts(&self) -> (NonNull<u8>, usize, usize) {
-        (NonNull::dangling(), 0, 0)
-    }
-
     #[inline(always)]
-    unsafe fn as_slice(&self) -> &[u8] {
+    fn as_slice(&self) -> &[u8] {
         &[]
     }
 }

--- a/crates/musli/src/never.rs
+++ b/crates/musli/src/never.rs
@@ -83,7 +83,7 @@ pub enum NeverMarker {}
 ///         write!(f, "32-bit unsigned integers")
 ///     }
 ///
-///     fn decode_u32<C>(self, cx: &mut C) -> Result<u32, C::Error>
+///     fn decode_u32<C>(self, cx: &C) -> Result<u32, C::Error>
 ///     where
 ///         C: Context<Input = Self::Error>
 ///     {
@@ -133,7 +133,7 @@ where
         Self: 'this;
 
     #[inline]
-    fn as_decoder<C>(&self, _: &mut C) -> Result<Self::Decoder<'_>, C::Error>
+    fn as_decoder<C>(&self, _: &C) -> Result<Self::Decoder<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -154,7 +154,7 @@ where
     type Second = Self;
 
     #[inline]
-    fn first<C>(&mut self, _: &mut C) -> Result<Self::First<'_>, C::Error>
+    fn first<C>(&mut self, _: &C) -> Result<Self::First<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -162,7 +162,7 @@ where
     }
 
     #[inline]
-    fn second<C>(self, _: &mut C) -> Result<Self::Second, C::Error>
+    fn second<C>(self, _: &C) -> Result<Self::Second, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -170,7 +170,7 @@ where
     }
 
     #[inline]
-    fn skip_second<C>(self, _: &mut C) -> Result<bool, C::Error>
+    fn skip_second<C>(self, _: &C) -> Result<bool, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -191,7 +191,7 @@ where
     type Variant<'this> = Self where Self: 'this;
 
     #[inline]
-    fn tag<C>(&mut self, _: &mut C) -> Result<Self::Tag<'_>, C::Error>
+    fn tag<C>(&mut self, _: &C) -> Result<Self::Tag<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -199,7 +199,7 @@ where
     }
 
     #[inline]
-    fn variant<C>(&mut self, _: &mut C) -> Result<Self::Variant<'_>, C::Error>
+    fn variant<C>(&mut self, _: &C) -> Result<Self::Variant<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -207,7 +207,7 @@ where
     }
 
     #[inline]
-    fn skip_variant<C>(&mut self, _: &mut C) -> Result<bool, C::Error>
+    fn skip_variant<C>(&mut self, _: &C) -> Result<bool, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -215,7 +215,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<(), C::Error>
+    fn end<C>(self, _: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -239,7 +239,7 @@ where
     }
 
     #[inline]
-    fn next<C>(&mut self, _: &mut C) -> Result<Option<Self::Decoder<'_>>, C::Error>
+    fn next<C>(&mut self, _: &C) -> Result<Option<Self::Decoder<'_>>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -247,7 +247,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<(), C::Error>
+    fn end<C>(self, _: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -271,7 +271,7 @@ where
     }
 
     #[inline]
-    fn next<C>(&mut self, _: &mut C) -> Result<Option<Self::Decoder<'_>>, C::Error>
+    fn next<C>(&mut self, _: &C) -> Result<Option<Self::Decoder<'_>>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -279,7 +279,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<(), C::Error>
+    fn end<C>(self, _: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -298,7 +298,7 @@ where
         Self: 'this;
 
     #[inline]
-    fn next<C>(&mut self, _: &mut C) -> Result<Self::Decoder<'_>, C::Error>
+    fn next<C>(&mut self, _: &C) -> Result<Self::Decoder<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -306,7 +306,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<(), C::Error>
+    fn end<C>(self, _: &C) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -370,7 +370,7 @@ where
         Self: 'this;
 
     #[inline]
-    fn next<C>(&mut self, _: &mut C) -> Result<Self::Encoder<'_>, C::Error>
+    fn next<C>(&mut self, _: &C) -> Result<Self::Encoder<'_>, C::Error>
     where
         C: Context<Input = E>,
     {
@@ -378,7 +378,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(self, _: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = E>,
     {
@@ -395,14 +395,14 @@ where
     type Encoder<'this> = Self where Self: 'this;
 
     #[inline]
-    fn next<C>(&mut self, _: &mut C) -> Result<Self::Encoder<'_>, C::Error>
+    fn next<C>(&mut self, _: &C) -> Result<Self::Encoder<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
         match self._never {}
     }
 
-    fn end<C>(self, _: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(self, _: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -422,7 +422,7 @@ where
     type Second<'this> = Self where Self: 'this;
 
     #[inline]
-    fn first<C>(&mut self, _: &mut C) -> Result<Self::First<'_>, C::Error>
+    fn first<C>(&mut self, _: &C) -> Result<Self::First<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -430,7 +430,7 @@ where
     }
 
     #[inline]
-    fn second<C>(&mut self, _: &mut C) -> Result<Self::Second<'_>, C::Error>
+    fn second<C>(&mut self, _: &C) -> Result<Self::Second<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -438,7 +438,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(self, _: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -458,7 +458,7 @@ where
     type Variant<'this> = Self where Self: 'this;
 
     #[inline]
-    fn tag<C>(&mut self, _: &mut C) -> Result<Self::Tag<'_>, C::Error>
+    fn tag<C>(&mut self, _: &C) -> Result<Self::Tag<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -466,7 +466,7 @@ where
     }
 
     #[inline]
-    fn variant<C>(&mut self, _: &mut C) -> Result<Self::Variant<'_>, C::Error>
+    fn variant<C>(&mut self, _: &C) -> Result<Self::Variant<'_>, C::Error>
     where
         C: Context<Input = Self::Error>,
     {
@@ -474,7 +474,7 @@ where
     }
 
     #[inline]
-    fn end<C>(self, _: &mut C) -> Result<Self::Ok, C::Error>
+    fn end<C>(self, _: &C) -> Result<Self::Ok, C::Error>
     where
         C: Context<Input = Self::Error>,
     {

--- a/crates/musli/src/utils/visit_owned_fn.rs
+++ b/crates/musli/src/utils/visit_owned_fn.rs
@@ -24,12 +24,12 @@ use crate::Context;
 /// where
 ///     M: Mode,
 /// {
-///     fn decode<C, D>(cx: &mut C, decoder: D) -> Result<Self, C::Error>
+///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
 ///     where
 ///         C: Context<Input = D::Error>,
 ///         D: Decoder<'de>,
 ///     {
-///         decoder.decode_string(cx, musli::utils::visit_owned_fn("A string variant for Enum", |cx: &mut C, variant: &str| {
+///         decoder.decode_string(cx, musli::utils::visit_owned_fn("A string variant for Enum", |cx: &C, variant: &str| {
 ///             match variant {
 ///                 "A" => Ok(Enum::A),
 ///                 "B" => Ok(Enum::A),
@@ -50,7 +50,7 @@ pub fn visit_owned_fn<'de, E, U, C, T, O>(
 ) -> impl ValueVisitor<'de, C, T, Ok = O>
 where
     E: fmt::Display,
-    U: FnOnce(&mut C, &T) -> Result<O, C::Error>,
+    U: FnOnce(&C, &T) -> Result<O, C::Error>,
     C: Context,
     T: ?Sized + ToOwned,
 {
@@ -65,7 +65,7 @@ struct FromFn<E, U> {
 impl<'de, W, U, C, T, O> ValueVisitor<'de, C, T> for FromFn<W, U>
 where
     W: fmt::Display,
-    U: FnOnce(&mut C, &T) -> Result<O, C::Error>,
+    U: FnOnce(&C, &T) -> Result<O, C::Error>,
     T: ?Sized + ToOwned,
     C: Context,
 {
@@ -77,7 +77,7 @@ where
     }
 
     #[inline]
-    fn visit_ref(self, cx: &mut C, string: &T) -> Result<Self::Ok, C::Error> {
+    fn visit_ref(self, cx: &C, string: &T) -> Result<Self::Ok, C::Error> {
         (self.function)(cx, string)
     }
 }

--- a/crates/no-std-examples/examples/no-std-json.rs
+++ b/crates/no-std-examples/examples/no-std-json.rs
@@ -5,7 +5,7 @@
 use core::alloc::GlobalAlloc;
 
 use musli::{Decode, Encode};
-use musli_json::allocator::NoStd;
+use musli_json::allocator::{NoStd, StackBuffer};
 use musli_json::context::NoStdContext;
 
 struct Allocator;
@@ -53,7 +53,8 @@ struct Value<'a> {
 
 #[start]
 fn main(_argc: isize, _argv: *const *const u8) -> isize {
-    let alloc = NoStd::<1024>::new();
+    let mut buf = StackBuffer::<1024>::new();
+    let alloc = NoStd::new(&mut buf);
     let cx = NoStdContext::new(&alloc);
 
     let encoding = musli_json::Encoding::new();

--- a/crates/no-std-examples/examples/no-std-json.rs
+++ b/crates/no-std-examples/examples/no-std-json.rs
@@ -54,7 +54,7 @@ struct Value<'a> {
 #[start]
 fn main(_argc: isize, _argv: *const *const u8) -> isize {
     let alloc = NoStd::<1024>::new();
-    let mut cx = NoStdContext::new(&alloc);
+    let cx = NoStdContext::new(&alloc);
 
     let encoding = musli_json::Encoding::new();
 
@@ -67,8 +67,8 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
 
     let mut w = &mut buf[..];
 
-    let Ok(..) = encoding.encode_with(&mut cx, &mut w, &value) else {
-        for _error in cx.iter() {
+    let Ok(..) = encoding.encode_with(&cx, &mut w, &value) else {
+        for _error in cx.errors() {
             // report error
         }
 
@@ -77,8 +77,8 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
 
     let written = 1024 - w.len();
 
-    let Ok(value): Result<Value, _> = encoding.from_slice_with(&mut cx, &buf[..written]) else {
-        for _error in cx.iter() {
+    let Ok(value): Result<Value, _> = encoding.from_slice_with(&cx, &buf[..written]) else {
+        for _error in cx.errors() {
             // report error
         }
 

--- a/crates/tests/tests/ui/private_fn_error.rs
+++ b/crates/tests/tests/ui/private_fn_error.rs
@@ -10,7 +10,7 @@ mod array {
     use musli::{Context, Mode, Encoder, Decoder};
 
     #[inline]
-    fn encode<M, E, C, T, const N: usize>(this: &[T; N], cx: &mut C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<M, E, C, T, const N: usize>(this: &[T; N], cx: &C, encoder: E) -> Result<E::Ok, C::Error>
     where
         M: Mode,
         C: Context<Input = E::Error>,
@@ -20,7 +20,7 @@ mod array {
     }
 
     #[inline]
-    fn decode<'de, M, C, D, T, const N: usize>(cx: &mut C, decoder: D) -> Result<[T; N], C::Error>
+    fn decode<'de, M, C, D, T, const N: usize>(cx: &C, decoder: D) -> Result<[T; N], C::Error>
     where
         M: Mode,
         C: Context<Input = D::Error>,

--- a/crates/tests/tests/ui/private_fn_error.stderr
+++ b/crates/tests/tests/ui/private_fn_error.stderr
@@ -7,7 +7,7 @@ error[E0603]: function `decode` is private
 note: the function `decode` is defined here
   --> tests/ui/private_fn_error.rs:23:5
    |
-23 | /     fn decode<'de, M, C, D, T, const N: usize>(cx: &mut C, decoder: D) -> Result<[T; N], C::Error>
+23 | /     fn decode<'de, M, C, D, T, const N: usize>(cx: &C, decoder: D) -> Result<[T; N], C::Error>
 24 | |     where
 25 | |         M: Mode,
 26 | |         C: Context<Input = D::Error>,


### PR DESCRIPTION
The no-std allocator now uses a custom implementation which is not sensitive the the order in which things are allocated.