### PR TITLE
More allocator work

### DIFF
--- a/crates/musli-common/src/allocator.rs
+++ b/crates/musli-common/src/allocator.rs
@@ -102,7 +102,7 @@ pub fn new(buf: &mut DefaultBuffer) -> DefaultAllocator<'_> {
 #[doc(inline)]
 pub use self::default_alloc::{DefaultAllocator, DefaultBuffer};
 
-use musli::context::Buffer;
+use musli::context::Buf;
 
 /// An allocator that can be used in combination with a context.
 ///
@@ -110,7 +110,7 @@ use musli::context::Buffer;
 ///
 /// ```
 /// use musli_common::allocator::{self, Allocator};
-/// use musli::context::Buffer;
+/// use musli::context::Buf;
 ///
 /// let mut buf = allocator::buffer();
 /// let alloc = allocator::new(&mut buf);
@@ -137,14 +137,14 @@ use musli::context::Buffer;
 /// assert_eq!(a.len(), 12);
 /// ```
 pub trait Allocator {
-    /// An allocated buffer.
-    type Buf<'this>: Buffer
+    /// The type of an allocated buffer.
+    type Buf<'this>: Buf
     where
         Self: 'this;
 
-    /// Allocate an empty, uninitialized buffer. Just calling this function
-    /// doesn't cause any allocations to occur, for that to happen the returned
-    /// allocation has to be written to.
+    /// Allocate an empty, uninitialized buffer.
+    ///
+    /// Calling this method returns `None` if the allocation failed.
     fn alloc(&self) -> Option<Self::Buf<'_>>;
 }
 

--- a/crates/musli-common/src/allocator/alloc.rs
+++ b/crates/musli-common/src/allocator/alloc.rs
@@ -4,7 +4,7 @@ use core::ptr::NonNull;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 
-use musli::context::Buffer;
+use musli::context::Buf;
 
 use crate::allocator::Allocator;
 
@@ -41,11 +41,11 @@ impl<'a> Alloc<'a> {
 }
 
 impl<'a> Allocator for Alloc<'a> {
-    type Buf<'this> = Buf<'this> where Self: 'this;
+    type Buf<'this> = AllocBuf<'this> where Self: 'this;
 
     #[inline(always)]
     fn alloc(&self) -> Option<Self::Buf<'_>> {
-        Some(Buf {
+        Some(AllocBuf {
             region: Internal::alloc(&self.buf.internal),
             internal: &self.buf.internal,
         })
@@ -68,12 +68,12 @@ impl<'a> Drop for Alloc<'a> {
 }
 
 /// A vector-backed allocation.
-pub struct Buf<'a> {
+pub struct AllocBuf<'a> {
     region: &'a mut Region,
     internal: &'a UnsafeCell<Internal>,
 }
 
-impl<'a> Buffer for Buf<'a> {
+impl<'a> Buf for AllocBuf<'a> {
     #[inline]
     fn write(&mut self, bytes: &[u8]) -> bool {
         self.region.data.extend_from_slice(bytes);
@@ -91,7 +91,7 @@ impl<'a> Buffer for Buf<'a> {
     }
 }
 
-impl<'a> Drop for Buf<'a> {
+impl<'a> Drop for AllocBuf<'a> {
     fn drop(&mut self) {
         Internal::free(self.internal, self.region);
     }

--- a/crates/musli-common/src/allocator/disabled.rs
+++ b/crates/musli-common/src/allocator/disabled.rs
@@ -1,11 +1,11 @@
-use musli::context::Buffer;
+use musli::context::Buf;
 
 use crate::allocator::Allocator;
 
 /// An empty buffer.
 pub struct EmptyBuf;
 
-impl Buffer for EmptyBuf {
+impl Buf for EmptyBuf {
     #[inline(always)]
     fn write(&mut self, _: &[u8]) -> bool {
         false

--- a/crates/musli-common/src/allocator/no_std/tests.rs
+++ b/crates/musli-common/src/allocator/no_std/tests.rs
@@ -1,0 +1,221 @@
+use crate::allocator::{Allocator, Buf};
+
+use super::{Header, NoStd, Region, State};
+
+macro_rules! assert_linked {
+    (
+        $i:expr $(, $kind:ident [$($link:expr),* $(,)?])* $(,)?
+    ) => {{
+        $(
+            let mut free = alloc::vec::Vec::<Region>::new();
+            let mut current = $i.$kind;
+
+            while let Some(c) = current.take() {
+                free.push(c);
+                current = $i.header(c).link;
+            }
+
+            assert_eq!(free, [$($link),*], "Expected `{}`", stringify!($kind));
+        )*
+    }};
+}
+
+macro_rules! assert_list {
+    (
+        $i:expr, $($link:expr),* $(,)?
+    ) => {
+        let mut expected = [$($link),*];
+
+        {
+            let mut list = alloc::vec::Vec::<Region>::new();
+            let mut current = $i.head;
+
+            while let Some(c) = current.take() {
+                list.push(c);
+                current = $i.header(c).next;
+            }
+
+            assert_eq!(list, expected, "Expected forward list");
+        }
+
+        {
+            let mut list = alloc::vec::Vec::<Region>::new();
+            let mut current = $i.tail;
+
+            while let Some(c) = current.take() {
+                list.push(c);
+                current = $i.header(c).prev;
+            }
+
+            expected.reverse();
+            assert_eq!(list, expected, "Expected reverse list");
+        }
+    };
+}
+
+macro_rules! assert_structure {
+    (
+        $list:expr,
+        freed [$($freed:expr),* $(,)?],
+        occupied [$($occupied:expr),* $(,)?],
+        list [$($node:expr),* $(,)?],
+        $($region:expr => {
+            $start:expr,
+            $size:expr,
+            $state:expr,
+            link: $link:expr,
+            prev: $prev:expr,
+            next: $next:expr $(,)?
+        },)* $(,)?
+    ) => {{
+        let i = unsafe { &*$list.internal.get() };
+
+        $(
+            assert_eq! {
+                *i.header($region),
+                Header {
+                    start: $start,
+                    size: $size,
+                    state: $state,
+                    link: $link,
+                    prev: $prev,
+                    next: $next,
+                },
+                "Comparing region {}", stringify!($region)
+            };
+        )*
+
+        assert_linked!(i, freed[$($freed),*], occupied[$($occupied),*]);
+        assert_list!(i, $($node),*);
+    }};
+}
+
+const A: Region = unsafe { Region::new_unchecked(1) };
+const B: Region = unsafe { Region::new_unchecked(2) };
+const C: Region = unsafe { Region::new_unchecked(3) };
+
+fn grow_last(alloc: &NoStd<'_>) {
+    let a = alloc.alloc().unwrap();
+
+    let mut b = alloc.alloc().unwrap();
+    b.write(&[1, 2, 3, 4, 5, 6]);
+    b.write(&[7, 8]);
+
+    assert_structure! {
+        alloc,
+        freed[], occupied[], list[A, B],
+        A => { 0, 0, State::Used, link: None, prev: None, next: Some(B) },
+        B => { 0, 8, State::Used, link: None, prev: Some(A), next: None },
+    };
+
+    b.write(&[9, 10]);
+
+    assert_structure! {
+        alloc,
+        freed[], occupied[], list[A, B],
+        A => { 0, 0, State::Used, link: None, prev: None, next: Some(B) },
+        B => { 0, 10, State::Used, link: None, prev: Some(A), next: None },
+    };
+
+    drop(a);
+    drop(b);
+
+    assert_structure! {
+        alloc,
+        freed[A, B], occupied[], list[],
+        A => { 0, 0, State::Free, link: Some(B), prev: None, next: None },
+        B => { 0, 0, State::Free, link: None, prev: None, next: None },
+    };
+}
+
+#[test]
+fn nostd_grow_last() {
+    let mut buf = crate::allocator::StackBuffer::<4096>::new();
+    let alloc = crate::allocator::NoStd::new(&mut buf);
+    grow_last(&alloc);
+}
+
+fn realloc(alloc: &NoStd<'_>) {
+    let mut a = alloc.alloc().unwrap();
+    a.write(&[1, 2, 3, 4]);
+    assert_eq!(a.region.get(), A);
+
+    let mut b = alloc.alloc().unwrap();
+    b.write(&[1, 2, 3, 4]);
+    assert_eq!(b.region.get(), B);
+
+    let mut c = alloc.alloc().unwrap();
+    c.write(&[1, 2, 3, 4]);
+    assert_eq!(c.region.get(), C);
+
+    assert_eq!(a.region.get(), A);
+    assert_eq!(b.region.get(), B);
+    assert_eq!(c.region.get(), C);
+
+    assert_structure! {
+        alloc,
+        freed[], occupied[], list[A, B, C],
+        A => { 0, 4, State::Used, link: None, prev: None, next: Some(B) },
+        B => { 4, 4, State::Used, link: None, prev: Some(A), next: Some(C) },
+        C => { 8, 4, State::Used, link: None, prev: Some(B), next: None },
+    };
+
+    drop(a);
+
+    assert_structure! {
+        alloc,
+        freed[], occupied[A], list[A, B, C],
+        A => { 0, 4, State::Occupy, link: None, prev: None, next: Some(B) },
+        B => { 4, 4, State::Used, link: None, prev: Some(A), next: Some(C) },
+        C => { 8, 4, State::Used, link: None, prev: Some(B), next: None },
+    };
+
+    drop(b);
+
+    assert_structure! {
+        alloc,
+        freed[B], occupied[A], list[A, C],
+        A => { 0, 8, State::Occupy, link: None, prev: None, next: Some(C) },
+        B => { 0, 0, State::Free, link: None, prev: None, next: None },
+        C => { 8, 4, State::Used, link: None, prev: Some(A), next: None },
+    };
+
+    let mut d = alloc.alloc().unwrap();
+
+    assert_structure! {
+        alloc,
+        freed[B], occupied[], list[A, C],
+        A => { 0, 8, State::Used, link: None, prev: None, next: Some(C) },
+        B => { 0, 0, State::Free, link: None, prev: None, next: None },
+        C => { 8, 4, State::Used, link: None, prev: Some(A), next: None },
+    };
+
+    d.write(&[1, 2]);
+    assert_eq!(d.region.get(), A);
+
+    assert_structure! {
+        alloc,
+        freed[B], occupied[], list[A, C],
+        A => { 0, 8, State::Used, link: None, prev: None, next: Some(C) },
+        B => { 0, 0, State::Free, link: None, prev: None, next: None },
+        C => { 8, 4, State::Used, link: None, prev: Some(A), next: None },
+    };
+
+    d.write(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+    assert_eq!(d.region.get(), B);
+
+    assert_structure! {
+        alloc,
+        freed[], occupied[A], list[A, C, B],
+        A => { 0, 8, State::Occupy, link: None, prev: None, next: Some(C) },
+        B => { 12, 18, State::Used, link: None, prev: Some(C), next: None },
+        C => { 8, 4, State::Used, link: None, prev: Some(A), next: Some(B) },
+    };
+}
+
+#[test]
+fn nostd_realloc() {
+    let mut buf = crate::allocator::StackBuffer::<4096>::new();
+    let alloc = crate::allocator::NoStd::new(&mut buf);
+    realloc(&alloc);
+}

--- a/crates/musli-common/src/allocator/tests.rs
+++ b/crates/musli-common/src/allocator/tests.rs
@@ -1,5 +1,5 @@
 use crate::allocator::Allocator;
-use musli::context::Buffer;
+use musli::context::Buf;
 
 fn basic_allocations<A: Allocator>(alloc: &A) {
     let mut a = alloc.alloc().unwrap();

--- a/crates/musli-common/src/buffered_writer.rs
+++ b/crates/musli-common/src/buffered_writer.rs
@@ -1,7 +1,7 @@
 //! A writer which buffers the writes before it outputs it into the backing
 //! storage.
 
-use musli::context::Buffer;
+use musli::context::Buf;
 use musli::Context;
 
 use crate::fixed_bytes::{FixedBytes, FixedBytesOverflow};
@@ -58,7 +58,7 @@ where
     fn write_buffer<C, B>(&mut self, cx: &C, buffer: B) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
-        B: Buffer,
+        B: Buf,
     {
         // SAFETY: the buffer never outlives this function call.
         self.write_bytes(cx, buffer.as_slice())

--- a/crates/musli-common/src/fixed_bytes.rs
+++ b/crates/musli-common/src/fixed_bytes.rs
@@ -5,7 +5,7 @@ use core::fmt;
 use core::mem::MaybeUninit;
 use core::ptr;
 
-use musli::context::Buffer;
+use musli::context::Buf;
 use musli::Context;
 
 use crate::writer::Writer;
@@ -192,7 +192,7 @@ impl<const N: usize> Writer for FixedBytes<N> {
     fn write_buffer<C, B>(&mut self, cx: &C, buffer: B) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
-        B: Buffer,
+        B: Buf,
     {
         // SAFETY: the buffer never outlives this function call.
         self.write_bytes(cx, buffer.as_slice())

--- a/crates/musli-common/src/wrap.rs
+++ b/crates/musli-common/src/wrap.rs
@@ -5,7 +5,7 @@
 //! an adapter around an I/O type to work with musli.
 
 #[cfg(feature = "std")]
-use musli::context::Buffer;
+use musli::context::Buf;
 #[cfg(feature = "std")]
 use musli::Context;
 
@@ -40,7 +40,7 @@ where
     fn write_buffer<C, B>(&mut self, cx: &C, buffer: B) -> Result<(), C::Error>
     where
         C: Context<Input = Self::Error>,
-        B: Buffer,
+        B: Buf,
     {
         // SAFETY: the buffer never outlives this function call.
         self.write_bytes(cx, buffer.as_slice())

--- a/crates/musli-descriptive/src/en.rs
+++ b/crates/musli-descriptive/src/en.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use musli::context::Buffer;
+use musli::context::Buf;
 use musli::en::{Encoder, PairEncoder, PairsEncoder, SequenceEncoder, VariantEncoder};
 use musli::Context;
 use musli_storage::en::StorageEncoder;
@@ -13,7 +13,7 @@ use crate::tag::{
     Kind, Mark, Tag, F32, F64, I128, I16, I32, I64, I8, ISIZE, MAX_INLINE_LEN, U128, U16, U32, U64,
     U8, USIZE,
 };
-use crate::writer::{BufferWriter, Writer};
+use crate::writer::{BufWriter, Writer};
 
 /// A very simple encoder.
 pub struct SelfEncoder<W, const F: Options> {
@@ -33,7 +33,7 @@ where
     W: Writer,
 {
     writer: W,
-    buffer: BufferWriter<B, W::Error>,
+    buffer: BufWriter<B, W::Error>,
 }
 
 impl<W, B, const F: Options> SelfPackEncoder<W, B, F>
@@ -46,7 +46,7 @@ where
     pub(crate) fn new(writer: W, buffer: B) -> Self {
         Self {
             writer,
-            buffer: BufferWriter::new(buffer),
+            buffer: BufWriter::new(buffer),
         }
     }
 }
@@ -343,11 +343,11 @@ impl<W, B, const F: Options> SequenceEncoder for SelfPackEncoder<W, B, F>
 where
     W: Writer,
     Error: From<W::Error>,
-    B: Buffer,
+    B: Buf,
 {
     type Ok = ();
     type Error = Error;
-    type Encoder<'this> = StorageEncoder<&'this mut BufferWriter<B, W::Error>, F, Error> where Self: 'this;
+    type Encoder<'this> = StorageEncoder<&'this mut BufWriter<B, W::Error>, F, Error> where Self: 'this;
 
     #[inline]
     fn next<C>(&mut self, _: &C) -> Result<Self::Encoder<'_>, C::Error>

--- a/crates/musli-json/src/reader/parser.rs
+++ b/crates/musli-json/src/reader/parser.rs
@@ -1,4 +1,4 @@
-use musli::context::Buffer;
+use musli::context::Buf;
 use musli::de::NumberVisitor;
 use musli::Context;
 
@@ -41,7 +41,7 @@ pub trait Parser<'de>: private::Sealed {
     ) -> Result<StringReference<'de, 'scratch>, C::Error>
     where
         C: Context<Input = Error>,
-        S: ?Sized + Buffer;
+        S: ?Sized + Buf;
 
     #[doc(hidden)]
     fn read_byte<C>(&mut self, cx: &C) -> Result<u8, C::Error>
@@ -255,7 +255,7 @@ where
     ) -> Result<StringReference<'de, 'scratch>, C::Error>
     where
         C: Context<Input = Error>,
-        S: ?Sized + Buffer,
+        S: ?Sized + Buf,
     {
         (**self).parse_string(cx, validate, scratch)
     }

--- a/crates/musli-json/src/reader/slice_parser.rs
+++ b/crates/musli-json/src/reader/slice_parser.rs
@@ -1,4 +1,4 @@
-use musli::context::Buffer;
+use musli::context::Buf;
 use musli::Context;
 
 use crate::error::{Error, ErrorKind};
@@ -39,7 +39,7 @@ impl<'de> Parser<'de> for SliceParser<'de> {
     ) -> Result<StringReference<'de, 'scratch>, C::Error>
     where
         C: Context<Input = Error>,
-        S: ?Sized + Buffer,
+        S: ?Sized + Buf,
     {
         let start = cx.mark();
         let actual = self.peek(cx)?;

--- a/crates/musli-json/src/reader/string.rs
+++ b/crates/musli-json/src/reader/string.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::zero_prefixed_literal)]
 
-use musli::context::Buffer;
+use musli::context::Buf;
 use musli::Context;
 
 use crate::error::{Error, ErrorKind};
@@ -56,7 +56,7 @@ pub(crate) fn parse_string_slice_reader<'de, 'scratch, C, S>(
 ) -> Result<StringReference<'de, 'scratch>, C::Error>
 where
     C: Context<Input = Error>,
-    S: ?Sized + Buffer,
+    S: ?Sized + Buf,
 {
     // Index of the first byte not yet copied into the scratch space.
     let mut open_mark = cx.mark();
@@ -155,7 +155,7 @@ fn parse_escape<C, B>(
 ) -> Result<bool, C::Error>
 where
     C: Context<Input = Error>,
-    B: ?Sized + Buffer,
+    B: ?Sized + Buf,
 {
     let start = cx.mark();
     let b = parser.read_byte(cx)?;
@@ -172,7 +172,7 @@ where
         b'u' => {
             fn encode_surrogate<B>(scratch: &mut B, n: u16) -> bool
             where
-                B: ?Sized + Buffer,
+                B: ?Sized + Buf,
             {
                 scratch.write(&[
                     (n >> 12 & 0b0000_1111) as u8 | 0b1110_0000,

--- a/crates/musli-macros/src/de.rs
+++ b/crates/musli-macros/src/de.rs
@@ -109,7 +109,7 @@ fn decode_enum(
     }
 
     let as_decoder_t = &e.tokens.as_decoder_t;
-    let buffer_t = &e.tokens.buffer_t;
+    let buf_t = &e.tokens.buf_t;
     let context_t = &e.tokens.context_t;
     let decoder_t = &e.tokens.decoder_t;
     let fmt = &e.tokens.fmt;
@@ -190,7 +190,7 @@ fn decode_enum(
                     #result_ok(match string {
                         #(#arms,)*
                         string => {
-                            if !#buffer_t::write(&mut #variant_alloc_var, str::as_bytes(string)) {
+                            if !#buf_t::write(&mut #variant_alloc_var, str::as_bytes(string)) {
                                 return #result_err(#context_t::alloc_failed(#ctx_var));
                             }
 
@@ -383,7 +383,7 @@ fn decode_enum(
                             #result_ok(match string {
                                 #field_tag => Outcome::Tag,
                                 string => {
-                                    if !#buffer_t::write(&mut #field_alloc_var, str::as_bytes(string)) {
+                                    if !#buf_t::write(&mut #field_alloc_var, str::as_bytes(string)) {
                                         Outcome::AllocErr
                                     } else {
                                         Outcome::Err
@@ -540,7 +540,7 @@ fn decode_enum(
                                 #tag => Outcome::Tag,
                                 #content => Outcome::Content,
                                 string => {
-                                    if !#buffer_t::write(&mut #field_alloc_var, str::as_bytes(string)) {
+                                    if !#buf_t::write(&mut #field_alloc_var, str::as_bytes(string)) {
                                         Outcome::AllocErr
                                     } else {
                                         Outcome::Err
@@ -691,7 +691,7 @@ fn decode_tagged(
     let field_alloc_var = e.cx.ident("field_alloc");
 
     let context_t = &e.tokens.context_t;
-    let buffer_t = &e.tokens.buffer_t;
+    let buf_t = &e.tokens.buf_t;
     let decoder_t = &e.tokens.decoder_t;
     let default_function = &e.tokens.default_function;
     let fmt = &e.tokens.fmt;
@@ -801,7 +801,7 @@ fn decode_tagged(
                     #result_ok(match string {
                         #(#patterns,)*
                         string => {
-                            if !#buffer_t::write(&mut #field_alloc_var, str::as_bytes(string)) {
+                            if !#buf_t::write(&mut #field_alloc_var, str::as_bytes(string)) {
                                 return #result_err(#context_t::alloc_failed(#ctx_var));
                             }
 

--- a/crates/musli-macros/src/internals/tokens.rs
+++ b/crates/musli-macros/src/internals/tokens.rs
@@ -3,7 +3,7 @@ use syn::Token;
 
 pub(crate) struct Tokens {
     pub(crate) as_decoder_t: syn::Path,
-    pub(crate) buffer_t: syn::Path,
+    pub(crate) buf_t: syn::Path,
     pub(crate) context_t: syn::Path,
     pub(crate) core_result: syn::Path,
     pub(crate) decode_t: syn::Path,
@@ -36,7 +36,7 @@ impl Tokens {
     pub(crate) fn new(span: Span, prefix: &syn::Path) -> Self {
         Self {
             as_decoder_t: path(span, prefix, ["de", "AsDecoder"]),
-            buffer_t: path(span, prefix, ["context", "Buffer"]),
+            buf_t: path(span, prefix, ["context", "Buf"]),
             context_t: path(span, prefix, ["Context"]),
             core_result: core(span, ["result", "Result"]),
             decode_t: path(span, prefix, ["de", "Decode"]),

--- a/crates/musli-wire/src/en.rs
+++ b/crates/musli-wire/src/en.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use musli::context::Buffer;
+use musli::context::Buf;
 use musli::en::{Encoder, PairEncoder, PairsEncoder, SequenceEncoder, VariantEncoder};
 use musli::Context;
 use musli_storage::en::StorageEncoder;
@@ -8,7 +8,7 @@ use musli_storage::en::StorageEncoder;
 use crate::error::Error;
 use crate::options::Options;
 use crate::tag::{Kind, Tag, MAX_INLINE_LEN};
-use crate::writer::{BufferWriter, Writer};
+use crate::writer::{BufWriter, Writer};
 
 /// A very simple encoder.
 pub struct WireEncoder<W, const F: Options> {
@@ -29,7 +29,7 @@ where
     Error: From<W::Error>,
 {
     writer: W,
-    buffer: BufferWriter<B, W::Error>,
+    buffer: BufWriter<B, W::Error>,
 }
 
 impl<W, B, const F: Options> WirePackEncoder<W, B, F>
@@ -42,7 +42,7 @@ where
     pub(crate) fn new(writer: W, buffer: B) -> Self {
         Self {
             writer,
-            buffer: BufferWriter::new(buffer),
+            buffer: BufWriter::new(buffer),
         }
     }
 }
@@ -365,12 +365,12 @@ where
 impl<W, B, const F: Options> SequenceEncoder for WirePackEncoder<W, B, F>
 where
     W: Writer,
-    B: Buffer,
+    B: Buf,
     Error: From<W::Error>,
 {
     type Ok = ();
     type Error = Error;
-    type Encoder<'this> = StorageEncoder<&'this mut BufferWriter<B, W::Error>, F, Error> where Self: 'this, B: Buffer;
+    type Encoder<'this> = StorageEncoder<&'this mut BufWriter<B, W::Error>, F, Error> where Self: 'this, B: Buf;
 
     #[inline]
     fn next<C>(&mut self, _: &C) -> Result<Self::Encoder<'_>, C::Error>

--- a/crates/musli/src/context.rs
+++ b/crates/musli/src/context.rs
@@ -11,7 +11,7 @@ pub use self::error::Error;
 /// A buffer allocated from a context.
 ///
 /// Buffers are allocated from a context through [`Context::alloc`].
-pub trait Buffer {
+pub trait Buf {
     /// Write the given number of bytes.
     ///
     /// Returns `true` if the bytes could be successfully written. A `false`
@@ -39,7 +39,7 @@ pub trait Buffer {
     fn as_slice(&self) -> &[u8];
 }
 
-impl Buffer for [u8] {
+impl Buf for [u8] {
     #[inline(always)]
     fn write(&mut self, _: &[u8]) -> bool {
         false
@@ -67,7 +67,7 @@ pub trait Context {
     /// A mark during processing.
     type Mark: Copy + Default;
     /// A growable buffer.
-    type Buf<'this>: Buffer
+    type Buf<'this>: Buf
     where
         Self: 'this;
 

--- a/crates/musli/src/context.rs
+++ b/crates/musli/src/context.rs
@@ -18,6 +18,17 @@ pub trait Buf {
     /// value indicates that we are out of buffer capacity.
     fn write(&mut self, bytes: &[u8]) -> bool;
 
+    /// Write a buffer of the same type onto the current buffer.
+    ///
+    /// This allows allocators to provide more efficient means of extending the
+    /// current buffer with one provided from the same allocator.
+    fn write_buffer(&mut self, other: Self) -> bool
+    where
+        Self: Sized,
+    {
+        self.write(other.as_slice())
+    }
+
     /// Write a single byte.
     ///
     /// Returns `true` if the bytes could be successfully written. A `false`

--- a/crates/musli/src/impls/alloc.rs
+++ b/crates/musli/src/impls/alloc.rs
@@ -557,7 +557,7 @@ where
         C: Context<Input = E::Error>,
         E: Encoder,
     {
-        use crate::context::Buffer;
+        use crate::context::Buf;
         use crate::en::VariantEncoder;
         use std::os::windows::ffi::OsStrExt;
 

--- a/crates/musli/src/never.rs
+++ b/crates/musli/src/never.rs
@@ -12,7 +12,7 @@ use core::marker;
 
 use crate::no_std::ToOwned;
 
-use crate::context::Buffer;
+use crate::context::Buf;
 use crate::de::{
     AsDecoder, Decoder, NumberVisitor, PackDecoder, PairDecoder, PairsDecoder, SequenceDecoder,
     SizeHint, ValueVisitor, VariantDecoder,
@@ -24,7 +24,7 @@ use crate::Context;
 /// An empty buffer.
 pub enum NeverBuffer {}
 
-impl Buffer for NeverBuffer {
+impl Buf for NeverBuffer {
     #[inline(always)]
     fn write(&mut self, _: &[u8]) -> bool {
         false


### PR DESCRIPTION
Renames the `Buffer` trait to `Buf`.

Extends the `NoStd` allocator with `write_buffer` specialization and add more structural tests.