### PR TITLE
Start work on associated context and error

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,9 @@ struct MyType {
 }
 
 impl<'de, M> Decode<'de, M> for MyType {
-    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+    fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
     where
-        C: ?Sized + Context<Mode = M>,
-        D: Decoder<'de, C>,
+        D: Decoder<'de, Mode = M>,
     {
         let mut seq = decoder.decode_sequence(cx)?;
         let mut data = Vec::with_capacity(seq.size_hint(cx).or_default());

--- a/crates/musli-descriptive/src/encoding.rs
+++ b/crates/musli-descriptive/src/encoding.rs
@@ -148,7 +148,7 @@ impl<M, const F: Options> Encoding<M, F> {
         }
     }
 
-    musli_common::encoding_impls!(M, SelfEncoder::<_, F>::new, SelfDecoder::<_, F>::new);
+    musli_common::encoding_impls!(M, SelfEncoder::<_, F, _>::new, SelfDecoder::<_, F, _>::new);
     musli_common::encoding_from_slice_impls!(M, SelfDecoder::<_, F>::new);
 }
 

--- a/crates/musli-descriptive/src/tag.rs
+++ b/crates/musli-descriptive/src/tag.rs
@@ -5,7 +5,6 @@
 use core::fmt;
 use core::mem;
 
-use musli::Context;
 use musli::{Decode, Decoder};
 
 /// Variant corresponding to marks.
@@ -223,10 +222,9 @@ impl fmt::Debug for Tag {
 
 impl<'de, M> Decode<'de, M> for Tag {
     #[inline]
-    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+    fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
     where
-        C: ?Sized + Context<Mode = M>,
-        D: Decoder<'de, C>,
+        D: Decoder<'de, Mode = M>,
     {
         Ok(Self::from_byte(decoder.decode_u8(cx)?))
     }

--- a/crates/musli-descriptive/src/test.rs
+++ b/crates/musli-descriptive/src/test.rs
@@ -30,10 +30,9 @@ impl<'de, M, T> Decode<'de, M> for Typed<T>
 where
     T: Decode<'de, M>,
 {
-    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+    fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
     where
-        C: ?Sized + Context<Mode = M>,
-        D: Decoder<'de, C>,
+        D: Decoder<'de, Mode = M>,
     {
         let mut unpack = decoder.decode_pack(cx)?;
         let tag = cx.decode(unpack.decode_next(cx)?)?;

--- a/crates/musli-json/src/de/object_pair_decoder.rs
+++ b/crates/musli-json/src/de/object_pair_decoder.rs
@@ -1,3 +1,5 @@
+use core::marker::PhantomData;
+
 use musli::de::{MapEntryDecoder, StructFieldDecoder};
 use musli::Context;
 
@@ -5,26 +7,31 @@ use crate::parser::{Parser, Token};
 
 use super::{JsonDecoder, JsonKeyDecoder};
 
-pub(crate) struct JsonObjectPairDecoder<P> {
+pub(crate) struct JsonObjectPairDecoder<P, C: ?Sized> {
     parser: P,
+    _marker: PhantomData<C>,
 }
 
-impl<P> JsonObjectPairDecoder<P> {
+impl<P, C: ?Sized> JsonObjectPairDecoder<P, C> {
     #[inline]
     pub(super) fn new(parser: P) -> Self {
-        Self { parser }
+        Self {
+            parser,
+            _marker: PhantomData,
+        }
     }
 }
 
-impl<'de, C, P> MapEntryDecoder<'de, C> for JsonObjectPairDecoder<P>
+impl<'de, P, C> MapEntryDecoder<'de> for JsonObjectPairDecoder<P, C>
 where
-    C: ?Sized + Context,
     P: Parser<'de>,
+    C: ?Sized + Context,
 {
-    type DecodeMapKey<'this> = JsonKeyDecoder<P::Mut<'this>>
+    type Cx = C;
+    type DecodeMapKey<'this> = JsonKeyDecoder<P::Mut<'this>, C>
     where
         Self: 'this;
-    type DecodeMapValue = JsonDecoder<P>;
+    type DecodeMapValue = JsonDecoder<P, C>;
 
     #[inline]
     fn decode_map_key(&mut self, _: &C) -> Result<Self::DecodeMapKey<'_>, C::Error> {
@@ -57,15 +64,16 @@ where
     }
 }
 
-impl<'de, C, P> StructFieldDecoder<'de, C> for JsonObjectPairDecoder<P>
+impl<'de, P, C> StructFieldDecoder<'de> for JsonObjectPairDecoder<P, C>
 where
-    C: ?Sized + Context,
     P: Parser<'de>,
+    C: ?Sized + Context,
 {
-    type DecodeFieldName<'this> = JsonKeyDecoder<P::Mut<'this>>
+    type Cx = C;
+    type DecodeFieldName<'this> = JsonKeyDecoder<P::Mut<'this>, C>
     where
         Self: 'this;
-    type DecodeFieldValue = JsonDecoder<P>;
+    type DecodeFieldValue = JsonDecoder<P, C>;
 
     #[inline]
     fn decode_field_name(&mut self, cx: &C) -> Result<Self::DecodeFieldName<'_>, C::Error> {

--- a/crates/musli-json/src/en/object_pair_encoder.rs
+++ b/crates/musli-json/src/en/object_pair_encoder.rs
@@ -1,3 +1,5 @@
+use core::marker::PhantomData;
+
 use musli::en::{MapEntryEncoder, StructFieldEncoder};
 use musli::Context;
 
@@ -6,27 +8,34 @@ use crate::writer::Writer;
 use super::{JsonEncoder, JsonObjectKeyEncoder};
 
 /// Encoder for a JSON object pair.
-pub(crate) struct JsonObjectPairEncoder<W> {
+pub(crate) struct JsonObjectPairEncoder<W, C: ?Sized> {
     empty: bool,
     writer: W,
+    _marker: PhantomData<C>,
 }
 
-impl<W> JsonObjectPairEncoder<W> {
+impl<W, C: ?Sized> JsonObjectPairEncoder<W, C> {
     #[inline]
     pub(super) const fn new(empty: bool, writer: W) -> Self {
-        Self { empty, writer }
+        Self {
+            empty,
+            writer,
+            _marker: PhantomData,
+        }
     }
 }
 
-impl<C: ?Sized + Context, W> MapEntryEncoder<C> for JsonObjectPairEncoder<W>
+impl<W, C> MapEntryEncoder for JsonObjectPairEncoder<W, C>
 where
     W: Writer,
+    C: ?Sized + Context,
 {
+    type Cx = C;
     type Ok = ();
-    type EncodeMapKey<'this> = JsonObjectKeyEncoder<W::Mut<'this>>
+    type EncodeMapKey<'this> = JsonObjectKeyEncoder<W::Mut<'this>, C>
     where
         Self: 'this;
-    type EncodeMapValue<'this> = JsonEncoder<W::Mut<'this>> where Self: 'this;
+    type EncodeMapValue<'this> = JsonEncoder<W::Mut<'this>, C> where Self: 'this;
 
     #[inline]
     fn encode_map_key(&mut self, cx: &C) -> Result<Self::EncodeMapKey<'_>, C::Error> {
@@ -49,15 +58,17 @@ where
     }
 }
 
-impl<C: ?Sized + Context, W> StructFieldEncoder<C> for JsonObjectPairEncoder<W>
+impl<W, C> StructFieldEncoder for JsonObjectPairEncoder<W, C>
 where
     W: Writer,
+    C: ?Sized + Context,
 {
+    type Cx = C;
     type Ok = ();
-    type EncodeFieldName<'this> = JsonObjectKeyEncoder<W::Mut<'this>>
+    type EncodeFieldName<'this> = JsonObjectKeyEncoder<W::Mut<'this>, C>
     where
         Self: 'this;
-    type EncodeFieldValue<'this> = JsonEncoder<W::Mut<'this>> where Self: 'this;
+    type EncodeFieldValue<'this> = JsonEncoder<W::Mut<'this>, C> where Self: 'this;
 
     #[inline]
     fn encode_field_name(&mut self, cx: &C) -> Result<Self::EncodeFieldName<'_>, C::Error> {

--- a/crates/musli-json/src/parser/integer.rs
+++ b/crates/musli-json/src/parser/integer.rs
@@ -216,10 +216,10 @@ where
 }
 
 /// Implementation to skip over a well-formed JSON number.
-pub(crate) fn skip_number<'de, C, P>(cx: &C, mut p: P) -> Result<(), C::Error>
+pub(crate) fn skip_number<'de, P, C>(cx: &C, mut p: P) -> Result<(), C::Error>
 where
-    C: ?Sized + Context,
     P: Parser<'de>,
+    C: ?Sized + Context,
 {
     p.skip_whitespace(cx)?;
 
@@ -269,8 +269,8 @@ where
 pub(crate) fn parse_unsigned_base<'de, T, C, P>(cx: &C, mut p: P) -> Result<T, C::Error>
 where
     T: Unsigned,
-    C: ?Sized + Context,
     P: Parser<'de>,
+    C: ?Sized + Context,
 {
     p.skip_whitespace(cx)?;
 
@@ -284,8 +284,8 @@ where
 pub(crate) fn parse_unsigned_full<'de, T, C, P>(cx: &C, mut p: P) -> Result<T, C::Error>
 where
     T: Unsigned,
-    C: ?Sized + Context,
     P: Parser<'de>,
+    C: ?Sized + Context,
 {
     p.skip_whitespace(cx)?;
 
@@ -368,8 +368,8 @@ where
 pub(crate) fn parse_signed_base<'de, T, C, P>(cx: &C, mut p: P) -> Result<T, C::Error>
 where
     T: Signed,
-    C: ?Sized + Context,
     P: Parser<'de>,
+    C: ?Sized + Context,
 {
     p.skip_whitespace(cx)?;
 
@@ -387,8 +387,8 @@ where
 pub(crate) fn parse_signed_full<'de, T, C, P>(cx: &C, mut p: P) -> Result<T, C::Error>
 where
     T: Signed,
-    C: ?Sized + Context,
     P: Parser<'de>,
+    C: ?Sized + Context,
 {
     p.skip_whitespace(cx)?;
 
@@ -406,8 +406,8 @@ where
 fn decode_unsigned_base<'de, T, C, P>(cx: &C, mut p: P, start: C::Mark) -> Result<T, C::Error>
 where
     T: Unsigned,
-    C: ?Sized + Context,
     P: Parser<'de>,
+    C: ?Sized + Context,
 {
     let base = match p.read_byte(cx)? {
         b'0' => T::ZERO,
@@ -438,8 +438,8 @@ fn decode_unsigned_full<'de, T, C, P>(
 ) -> Result<Parts<T>, C::Error>
 where
     T: Unsigned,
-    C: ?Sized + Context,
     P: Parser<'de>,
+    C: ?Sized + Context,
 {
     let base = decode_unsigned_base(cx, p.borrow_mut(), start)?;
 
@@ -486,10 +486,10 @@ where
 
 /// Decode an exponent.
 #[inline(always)]
-fn decode_exponent<'de, C, P>(cx: &C, mut p: P, start: C::Mark) -> Result<i32, C::Error>
+fn decode_exponent<'de, P, C>(cx: &C, mut p: P, start: C::Mark) -> Result<i32, C::Error>
 where
-    C: ?Sized + Context,
     P: Parser<'de>,
+    C: ?Sized + Context,
 {
     let mut is_negative = false;
     let mut e = 0u32;
@@ -520,8 +520,8 @@ where
 fn digit<'de, T, C, P>(cx: &C, out: T, mut p: P, start: C::Mark) -> Result<T, C::Error>
 where
     T: Unsigned,
-    C: ?Sized + Context,
     P: Parser<'de>,
+    C: ?Sized + Context,
 {
     let Some(out) = out.checked_mul10() else {
         return Err(cx.marked_message(start, IntegerError::IntegerOverflow));
@@ -532,10 +532,10 @@ where
 
 /// Decode sequence of zeros.
 #[inline(always)]
-fn decode_zeros<'de, C, P>(cx: &C, mut p: P) -> Result<i32, C::Error>
+fn decode_zeros<'de, P, C>(cx: &C, mut p: P) -> Result<i32, C::Error>
 where
-    C: ?Sized + Context,
     P: Parser<'de>,
+    C: ?Sized + Context,
 {
     let mut count = 0i32;
 

--- a/crates/musli-json/src/parser/string.rs
+++ b/crates/musli-json/src/parser/string.rs
@@ -286,10 +286,10 @@ pub(crate) fn decode_hex_val(val: u8) -> Option<u16> {
 }
 
 /// Specialized reader implementation from a slice.
-pub(crate) fn skip_string<'de, C, P>(cx: &C, mut p: P, validate: bool) -> Result<(), C::Error>
+pub(crate) fn skip_string<'de, P, C>(cx: &C, mut p: P, validate: bool) -> Result<(), C::Error>
 where
-    C: ?Sized + Context,
     P: Parser<'de>,
+    C: ?Sized + Context,
 {
     loop {
         while let Some(b) = p.peek_byte(cx)? {
@@ -320,10 +320,10 @@ where
 
 /// Parses a JSON escape sequence and appends it into the scratch space. Assumes
 /// the previous byte read was a backslash.
-fn skip_escape<'de, C, P>(cx: &C, mut p: P, validate: bool) -> Result<(), C::Error>
+fn skip_escape<'de, P, C>(cx: &C, mut p: P, validate: bool) -> Result<(), C::Error>
 where
-    C: ?Sized + Context,
     P: Parser<'de>,
+    C: ?Sized + Context,
 {
     let start = cx.mark();
     let b = p.read_byte(cx)?;

--- a/crates/musli-macros/src/lib.rs
+++ b/crates/musli-macros/src/lib.rs
@@ -81,8 +81,9 @@ pub fn decoder(attr: TokenStream, input: TokenStream) -> TokenStream {
     match input.expand(
         "decoder",
         types::DECODER_TYPES,
-        &[],
+        None,
         "__UseMusliDecoderAttributeMacro",
+        types::Kind::SelfCx,
     ) {
         Ok(tokens) => tokens.into(),
         Err(err) => err.to_compile_error().into(),
@@ -105,8 +106,9 @@ pub fn map_decoder(attr: TokenStream, input: TokenStream) -> TokenStream {
     match input.expand(
         "map_decoder",
         types::MAP_DECODER_TYPES,
-        &[],
+        None,
         "__UseMusliMapDecoderAttributeMacro",
+        types::Kind::SelfCx,
     ) {
         Ok(tokens) => tokens.into(),
         Err(err) => err.to_compile_error().into(),
@@ -129,8 +131,9 @@ pub fn struct_decoder(attr: TokenStream, input: TokenStream) -> TokenStream {
     match input.expand(
         "struct_decoder",
         types::STRUCT_DECODER_TYPES,
-        &[],
+        None,
         "__UseMusliStructDecoderAttributeMacro",
+        types::Kind::SelfCx,
     ) {
         Ok(tokens) => tokens.into(),
         Err(err) => err.to_compile_error().into(),
@@ -153,8 +156,9 @@ pub fn encoder(attr: TokenStream, input: TokenStream) -> TokenStream {
     match input.expand(
         "encoder",
         types::ENCODER_TYPES,
-        &["Ok"],
+        Some("Ok"),
         "__UseMusliEncoderAttributeMacro",
+        types::Kind::SelfCx,
     ) {
         Ok(tokens) => tokens.into(),
         Err(err) => err.to_compile_error().into(),
@@ -177,8 +181,9 @@ pub fn visitor(attr: TokenStream, input: TokenStream) -> TokenStream {
     match input.expand(
         "visitor",
         types::VISITOR_TYPES,
-        &["Ok"],
+        Some("Ok"),
         "__UseMusliVisitorAttributeMacro",
+        types::Kind::GenericCx,
     ) {
         Ok(tokens) => tokens.into(),
         Err(err) => err.to_compile_error().into(),

--- a/crates/musli-serde/src/lib.rs
+++ b/crates/musli-serde/src/lib.rs
@@ -103,10 +103,9 @@ where
 
 /// Encode the given serde value `T` to the given [Encoder] using the serde
 /// compatibility layer.
-pub fn encode<C, E, T>(value: &T, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+pub fn encode<E, T>(value: &T, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
 where
-    C: ?Sized + Context,
-    E: Encoder<C>,
+    E: Encoder,
     T: Serialize,
 {
     let encoder = encoder.with_context(cx)?;
@@ -136,10 +135,9 @@ where
 
 /// Decode the given serde value `T` from the given [Decoder] using the serde
 /// compatibility layer.
-pub fn decode<'de, C, D, T>(cx: &C, decoder: D) -> Result<T, C::Error>
+pub fn decode<'de, D, T>(cx: &D::Cx, decoder: D) -> Result<T, D::Error>
 where
-    C: ?Sized + Context,
-    D: Decoder<'de, C>,
+    D: Decoder<'de>,
     T: Deserialize<'de>,
 {
     let decoder = decoder.with_context(cx)?;

--- a/crates/musli-storage/src/encoding.rs
+++ b/crates/musli-storage/src/encoding.rs
@@ -170,7 +170,11 @@ impl<M, const F: Options> Encoding<M, F> {
         }
     }
 
-    musli_common::encoding_impls!(M, StorageEncoder::<_, F>::new, StorageDecoder::<_, F>::new);
+    musli_common::encoding_impls!(
+        M,
+        StorageEncoder::<_, F, _>::new,
+        StorageDecoder::<_, F, _>::new
+    );
     musli_common::encoding_from_slice_impls!(M, StorageDecoder::<_, F>::new);
 }
 

--- a/crates/musli-value/src/lib.rs
+++ b/crates/musli-value/src/lib.rs
@@ -59,5 +59,5 @@ where
     let mut buf = musli_common::exports::allocator::buffer();
     let alloc = musli_common::exports::allocator::new(&mut buf);
     let cx = musli_common::exports::context::Same::<_, DefaultMode, Error>::new(&alloc);
-    T::decode(&cx, value.decoder::<DEFAULT_OPTIONS>())
+    T::decode(&cx, value.decoder::<DEFAULT_OPTIONS, _>())
 }

--- a/crates/musli-wire/src/encoding.rs
+++ b/crates/musli-wire/src/encoding.rs
@@ -172,7 +172,7 @@ impl<M, const F: Options> Encoding<M, F> {
         }
     }
 
-    musli_common::encoding_impls!(M, WireEncoder::<_, F>::new, WireDecoder::<_, F>::new);
+    musli_common::encoding_impls!(M, WireEncoder::<_, F, _>::new, WireDecoder::<_, F, _>::new);
     musli_common::encoding_from_slice_impls!(M, WireDecoder::<_, F>::new);
 }
 

--- a/crates/musli-wire/src/tag.rs
+++ b/crates/musli-wire/src/tag.rs
@@ -5,7 +5,6 @@
 use core::fmt;
 use core::mem;
 
-use musli::Context;
 use musli::{Decode, Decoder};
 
 /// Data masked into the data type.
@@ -146,10 +145,9 @@ impl fmt::Debug for Tag {
 
 impl<'de, M> Decode<'de, M> for Tag {
     #[inline]
-    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+    fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
     where
-        C: ?Sized + Context<Mode = M>,
-        D: Decoder<'de, C>,
+        D: Decoder<'de, Mode = M>,
     {
         Ok(Self::from_byte(decoder.decode_u8(cx)?))
     }

--- a/crates/musli-wire/src/test.rs
+++ b/crates/musli-wire/src/test.rs
@@ -30,10 +30,9 @@ impl<'de, M, T> Decode<'de, M> for Typed<T>
 where
     T: Decode<'de, M>,
 {
-    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+    fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
     where
-        C: ?Sized + Context<Mode = M>,
-        D: Decoder<'de, C>,
+        D: Decoder<'de, Mode = M>,
     {
         let mut unpack = decoder.decode_pack(cx)?;
         let tag = cx.decode(unpack.decode_next(cx)?)?;

--- a/crates/musli/README.md
+++ b/crates/musli/README.md
@@ -126,10 +126,9 @@ struct MyType {
 }
 
 impl<'de, M> Decode<'de, M> for MyType {
-    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+    fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
     where
-        C: ?Sized + Context<Mode = M>,
-        D: Decoder<'de, C>,
+        D: Decoder<'de, Mode = M>,
     {
         let mut seq = decoder.decode_sequence(cx)?;
         let mut data = Vec::with_capacity(seq.size_hint(cx).or_default());

--- a/crates/musli/src/compat.rs
+++ b/crates/musli/src/compat.rs
@@ -3,7 +3,6 @@
 
 use crate::de::{Decode, DecodeBytes, Decoder, SequenceDecoder};
 use crate::en::{Encode, EncodeBytes, Encoder, SequenceEncoder};
-use crate::Context;
 
 /// Ensures that the given value `T` is encoded as a sequence.
 ///
@@ -22,20 +21,18 @@ impl<T> Sequence<T> {
 
 impl<M> Encode<M> for Sequence<()> {
     #[inline]
-    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
     where
-        C: ?Sized + Context<Mode = M>,
-        E: Encoder<C>,
+        E: Encoder<Mode = M>,
     {
         encoder.encode_sequence(cx, 0)?.end(cx)
     }
 }
 
 impl<'de, M> Decode<'de, M> for Sequence<()> {
-    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+    fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
     where
-        C: ?Sized + Context,
-        D: Decoder<'de, C>,
+        D: Decoder<'de>,
     {
         let seq = decoder.decode_sequence(cx)?;
         seq.end(cx)?;
@@ -54,7 +51,7 @@ impl<'de, M> Decode<'de, M> for Sequence<()> {
 /// # Examples
 ///
 /// ```
-/// use musli::{Context, Decode, Decoder};
+/// use musli::{Decode, Decoder};
 /// use musli::compat::Bytes;
 ///
 /// struct Struct {
@@ -62,10 +59,9 @@ impl<'de, M> Decode<'de, M> for Sequence<()> {
 /// }
 ///
 /// impl<'de, M> Decode<'de, M> for Struct {
-///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+///     fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
 ///     where
-///         C: ?Sized + Context<Mode = M>,
-///         D: Decoder<'de, C>,
+///         D: Decoder<'de, Mode = M>,
 ///     {
 ///         let Bytes(field) = Decode::decode(cx, decoder)?;
 ///
@@ -107,7 +103,7 @@ where
 /// # Examples
 ///
 /// ```
-/// use musli::{Context, Decode, Decoder};
+/// use musli::{Decode, Decoder};
 /// use musli::compat::Packed;
 ///
 /// struct Struct {
@@ -116,10 +112,9 @@ where
 /// }
 ///
 /// impl<'de, M> Decode<'de, M> for Struct {
-///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+///     fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
 ///     where
-///         C: ?Sized + Context<Mode = M>,
-///         D: Decoder<'de, C>,
+///         D: Decoder<'de, Mode = M>,
 ///     {
 ///         let Packed((field, field2)) = Decode::decode(cx, decoder)?;
 ///

--- a/crates/musli/src/context.rs
+++ b/crates/musli/src/context.rs
@@ -34,7 +34,7 @@ pub trait Context {
     fn decode<'de, T, D>(&self, decoder: D) -> Result<T, Self::Error>
     where
         T: Decode<'de, Self::Mode>,
-        D: Decoder<'de, Self>,
+        D: Decoder<'de, Cx = Self, Mode = Self::Mode>,
     {
         T::decode(self, decoder)
     }
@@ -43,7 +43,7 @@ pub trait Context {
     fn decode_bytes<'de, T, D>(&self, decoder: D) -> Result<T, Self::Error>
     where
         T: DecodeBytes<'de, Self::Mode>,
-        D: Decoder<'de, Self>,
+        D: Decoder<'de, Cx = Self, Mode = Self::Mode>,
     {
         T::decode_bytes(self, decoder)
     }

--- a/crates/musli/src/de/as_decoder.rs
+++ b/crates/musli/src/de/as_decoder.rs
@@ -3,12 +3,19 @@ use crate::Context;
 use super::Decoder;
 
 /// Trait that allows a type to be repeatedly coerced into a decoder.
-pub trait AsDecoder<C: ?Sized + Context> {
+pub trait AsDecoder {
+    /// Context associated with the decoder.
+    type Cx: ?Sized + Context;
     /// The decoder we reborrow as.
-    type Decoder<'this>: Decoder<'this, C>
+    type Decoder<'this>: Decoder<
+        'this,
+        Cx = Self::Cx,
+        Error = <Self::Cx as Context>::Error,
+        Mode = <Self::Cx as Context>::Mode,
+    >
     where
         Self: 'this;
 
     /// Borrow self as a new decoder.
-    fn as_decoder(&self, cx: &C) -> Result<Self::Decoder<'_>, C::Error>;
+    fn as_decoder(&self, cx: &Self::Cx) -> Result<Self::Decoder<'_>, <Self::Cx as Context>::Error>;
 }

--- a/crates/musli/src/de/decode.rs
+++ b/crates/musli/src/de/decode.rs
@@ -26,17 +26,16 @@ pub use musli_macros::Decode;
 /// Implementing manually:
 ///
 /// ```
-/// use musli::{Context, Decode, Decoder};
+/// use musli::{Decode, Decoder};
 ///
 /// struct MyType {
 ///     data: [u8; 128],
 /// }
 ///
 /// impl<'de, M> Decode<'de, M> for MyType {
-///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+///     fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
 ///     where
-///         C: ?Sized + Context<Mode = M>,
-///         D: Decoder<'de, C>,
+///         D: Decoder<'de>,
 ///     {
 ///         Ok(Self {
 ///             data: decoder.decode_array(cx)?,
@@ -46,10 +45,9 @@ pub use musli_macros::Decode;
 /// ```
 pub trait Decode<'de, M = DefaultMode>: Sized {
     /// Decode the given input.
-    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+    fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, <D::Cx as Context>::Error>
     where
-        C: ?Sized + Context<Mode = M>,
-        D: Decoder<'de, C>;
+        D: Decoder<'de, Mode = M>;
 }
 
 /// Trait governing how types are decoded specifically for tracing.
@@ -62,8 +60,7 @@ pub trait Decode<'de, M = DefaultMode>: Sized {
 /// [`fmt::Display`]: std::fmt::Display
 pub trait TraceDecode<'de, M = DefaultMode>: Sized {
     /// Decode the given input.
-    fn trace_decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+    fn trace_decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
     where
-        C: ?Sized + Context<Mode = M>,
-        D: Decoder<'de, C>;
+        D: Decoder<'de, Mode = M>;
 }

--- a/crates/musli/src/de/decode_bytes.rs
+++ b/crates/musli/src/de/decode_bytes.rs
@@ -24,7 +24,7 @@ use crate::Context;
 /// Implementing manually:
 ///
 /// ```
-/// use musli::{Context, Decode, Decoder};
+/// use musli::{Decode, Decoder};
 /// use musli::de::DecodeBytes;
 ///
 /// struct MyType {
@@ -32,10 +32,9 @@ use crate::Context;
 /// }
 ///
 /// impl<'de, M> Decode<'de, M> for MyType {
-///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+///     fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
 ///     where
-///         C: ?Sized + Context<Mode = M>,
-///         D: Decoder<'de, C>,
+///         D: Decoder<'de>,
 ///     {
 ///         Ok(Self {
 ///             data: DecodeBytes::decode_bytes(cx, decoder)?,
@@ -45,8 +44,7 @@ use crate::Context;
 /// ```
 pub trait DecodeBytes<'de, M = DefaultMode>: Sized {
     /// Decode the given input as bytes.
-    fn decode_bytes<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+    fn decode_bytes<D>(cx: &D::Cx, decoder: D) -> Result<Self, <D::Cx as Context>::Error>
     where
-        C: ?Sized + Context<Mode = M>,
-        D: Decoder<'de, C>;
+        D: Decoder<'de, Mode = M>;
 }

--- a/crates/musli/src/de/map_decoder.rs
+++ b/crates/musli/src/de/map_decoder.rs
@@ -3,13 +3,15 @@ use crate::Context;
 use super::{Decode, Decoder, MapEntriesDecoder, MapEntryDecoder, SizeHint};
 
 /// Trait governing how to decode a sequence of pairs.
-pub trait MapDecoder<'de, C: ?Sized + Context>: Sized {
+pub trait MapDecoder<'de>: Sized {
+    /// Context associated with the decoder.
+    type Cx: ?Sized + Context;
     /// The decoder to use for a key.
-    type DecodeEntry<'this>: MapEntryDecoder<'de, C>
+    type DecodeEntry<'this>: MapEntryDecoder<'de, Cx = Self::Cx>
     where
         Self: 'this;
     /// Decoder for a sequence of map pairs.
-    type IntoMapEntries: MapEntriesDecoder<'de, C>;
+    type IntoMapEntries: MapEntriesDecoder<'de, Cx = Self::Cx>;
 
     /// This is a type argument used to hint to any future implementor that they
     /// should be using the [`#[musli::map_decoder]`][crate::map_decoder]
@@ -18,19 +20,22 @@ pub trait MapDecoder<'de, C: ?Sized + Context>: Sized {
     type __UseMusliMapDecoderAttributeMacro;
 
     /// Get a size hint of known remaining elements.
-    fn size_hint(&self, cx: &C) -> SizeHint;
+    fn size_hint(&self, cx: &Self::Cx) -> SizeHint;
 
     /// Decode the next key. This returns `Ok(None)` where there are no more
     /// elements to decode.
     #[must_use = "Decoders must be consumed"]
-    fn decode_entry(&mut self, cx: &C) -> Result<Option<Self::DecodeEntry<'_>>, C::Error>;
+    fn decode_entry(
+        &mut self,
+        cx: &Self::Cx,
+    ) -> Result<Option<Self::DecodeEntry<'_>>, <Self::Cx as Context>::Error>;
 
     /// End the pair decoder.
     ///
     /// If there are any remaining elements in the sequence of pairs, this
     /// indicates that they should be flushed.
     #[inline]
-    fn end(mut self, cx: &C) -> Result<(), C::Error> {
+    fn end(mut self, cx: &Self::Cx) -> Result<(), <Self::Cx as Context>::Error> {
         // Skip remaining elements.
         while let Some(mut item) = self.decode_entry(cx)? {
             item.decode_map_key(cx)?.skip(cx)?;
@@ -41,10 +46,10 @@ pub trait MapDecoder<'de, C: ?Sized + Context>: Sized {
     }
 
     /// Decode the next map entry as a tuple.
-    fn entry<K, V>(&mut self, cx: &C) -> Result<Option<(K, V)>, C::Error>
+    fn entry<K, V>(&mut self, cx: &Self::Cx) -> Result<Option<(K, V)>, <Self::Cx as Context>::Error>
     where
-        K: Decode<'de, C::Mode>,
-        V: Decode<'de, C::Mode>,
+        K: Decode<'de, <Self::Cx as Context>::Mode>,
+        V: Decode<'de, <Self::Cx as Context>::Mode>,
     {
         match self.decode_entry(cx)? {
             Some(mut entry) => {
@@ -61,7 +66,10 @@ pub trait MapDecoder<'de, C: ?Sized + Context>: Sized {
     /// The length of the map must somehow be determined from the underlying
     /// format.
     #[inline]
-    fn into_map_entries(self, cx: &C) -> Result<Self::IntoMapEntries, C::Error>
+    fn into_map_entries(
+        self,
+        cx: &Self::Cx,
+    ) -> Result<Self::IntoMapEntries, <Self::Cx as Context>::Error>
     where
         Self: Sized,
     {

--- a/crates/musli/src/de/map_entry_decoder.rs
+++ b/crates/musli/src/de/map_entry_decoder.rs
@@ -3,27 +3,45 @@ use crate::Context;
 use super::Decoder;
 
 /// Trait governing how to decode a map entry.
-pub trait MapEntryDecoder<'de, C: ?Sized + Context> {
+pub trait MapEntryDecoder<'de> {
+    /// Context associated with the decoder.
+    type Cx: ?Sized + Context;
     /// The decoder to use for a tuple field index.
-    type DecodeMapKey<'this>: Decoder<'de, C>
+    type DecodeMapKey<'this>: Decoder<
+        'de,
+        Cx = Self::Cx,
+        Error = <Self::Cx as Context>::Error,
+        Mode = <Self::Cx as Context>::Mode,
+    >
     where
         Self: 'this;
     /// The decoder to use for a tuple field value.
-    type DecodeMapValue: Decoder<'de, C>;
+    type DecodeMapValue: Decoder<
+        'de,
+        Cx = Self::Cx,
+        Error = <Self::Cx as Context>::Error,
+        Mode = <Self::Cx as Context>::Mode,
+    >;
 
     /// Return the decoder for the first value in the pair.
     ///
     /// If this is a map the first value would be the key of the map, if this is
     /// a struct the first value would be the field of the struct.
     #[must_use = "Decoders must be consumed"]
-    fn decode_map_key(&mut self, cx: &C) -> Result<Self::DecodeMapKey<'_>, C::Error>;
+    fn decode_map_key(
+        &mut self,
+        cx: &Self::Cx,
+    ) -> Result<Self::DecodeMapKey<'_>, <Self::Cx as Context>::Error>;
 
     /// Decode the second value in the pair..
     #[must_use = "Decoders must be consumed"]
-    fn decode_map_value(self, cx: &C) -> Result<Self::DecodeMapValue, C::Error>;
+    fn decode_map_value(
+        self,
+        cx: &Self::Cx,
+    ) -> Result<Self::DecodeMapValue, <Self::Cx as Context>::Error>;
 
     /// Indicate that the second value should be skipped.
     ///
     /// The boolean returned indicates if the value was skipped or not.
-    fn skip_map_value(self, cx: &C) -> Result<bool, C::Error>;
+    fn skip_map_value(self, cx: &Self::Cx) -> Result<bool, <Self::Cx as Context>::Error>;
 }

--- a/crates/musli/src/de/number_visitor.rs
+++ b/crates/musli/src/de/number_visitor.rs
@@ -155,7 +155,7 @@ pub trait NumberVisitor<'de, C: ?Sized + Context>: Sized {
     #[inline]
     fn visit_any<D>(self, cx: &C, _: D, hint: TypeHint) -> Result<Self::Ok, C::Error>
     where
-        D: Decoder<'de, C>,
+        D: Decoder<'de, Cx = C>,
     {
         Err(cx.message(expecting::unsupported_type(
             &hint,

--- a/crates/musli/src/de/pack_decoder.rs
+++ b/crates/musli/src/de/pack_decoder.rs
@@ -3,27 +3,37 @@ use crate::Context;
 use super::{Decode, Decoder};
 
 /// A pack that can construct decoders.
-pub trait PackDecoder<'de, C: ?Sized + Context> {
+pub trait PackDecoder<'de> {
+    /// Context associated with the decoder.
+    type Cx: ?Sized + Context;
     /// The encoder to use for the pack.
-    type DecodeNext<'this>: Decoder<'de, C>
+    type DecodeNext<'this>: Decoder<
+        'de,
+        Cx = Self::Cx,
+        Error = <Self::Cx as Context>::Error,
+        Mode = <Self::Cx as Context>::Mode,
+    >
     where
         Self: 'this;
 
     /// Return decoder to unpack the next element.
     #[must_use = "Decoders must be consumed"]
-    fn decode_next(&mut self, cx: &C) -> Result<Self::DecodeNext<'_>, C::Error>;
+    fn decode_next(
+        &mut self,
+        cx: &Self::Cx,
+    ) -> Result<Self::DecodeNext<'_>, <Self::Cx as Context>::Error>;
 
     /// Stop decoding the current pack.
     ///
     /// This is required to call after a pack has finished decoding.
-    fn end(self, cx: &C) -> Result<(), C::Error>;
+    fn end(self, cx: &Self::Cx) -> Result<(), <Self::Cx as Context>::Error>;
 
     /// Unpack a value of the given type.
     #[inline]
-    fn next<T>(&mut self, cx: &C) -> Result<T, C::Error>
+    fn next<T>(&mut self, cx: &Self::Cx) -> Result<T, <Self::Cx as Context>::Error>
     where
         Self: Sized,
-        T: Decode<'de, C::Mode>,
+        T: Decode<'de, <Self::Cx as Context>::Mode>,
     {
         T::decode(cx, self.decode_next(cx)?)
     }

--- a/crates/musli/src/de/sequence_decoder.rs
+++ b/crates/musli/src/de/sequence_decoder.rs
@@ -3,24 +3,34 @@ use crate::Context;
 use super::{Decode, Decoder, SizeHint};
 
 /// Trait governing how to decode a sequence.
-pub trait SequenceDecoder<'de, C: ?Sized + Context>: Sized {
+pub trait SequenceDecoder<'de>: Sized {
+    /// Context associated with the decoder.
+    type Cx: ?Sized + Context;
     /// The decoder for individual items.
-    type DecodeNext<'this>: Decoder<'de, C>
+    type DecodeNext<'this>: Decoder<
+        'de,
+        Cx = Self::Cx,
+        Error = <Self::Cx as Context>::Error,
+        Mode = <Self::Cx as Context>::Mode,
+    >
     where
         Self: 'this;
 
     /// Get a size hint of known remaining elements.
-    fn size_hint(&self, cx: &C) -> SizeHint;
+    fn size_hint(&self, cx: &Self::Cx) -> SizeHint;
 
     /// Decode the next element.
     #[must_use = "Decoders must be consumed"]
-    fn decode_next(&mut self, cx: &C) -> Result<Option<Self::DecodeNext<'_>>, C::Error>;
+    fn decode_next(
+        &mut self,
+        cx: &Self::Cx,
+    ) -> Result<Option<Self::DecodeNext<'_>>, <Self::Cx as Context>::Error>;
 
     /// Stop decoding the current sequence.
     ///
     /// This is required to call after a sequence has finished decoding.
     #[inline]
-    fn end(mut self, cx: &C) -> Result<(), C::Error> {
+    fn end(mut self, cx: &Self::Cx) -> Result<(), <Self::Cx as Context>::Error> {
         while let Some(item) = self.decode_next(cx)? {
             item.skip(cx)?;
         }
@@ -30,10 +40,10 @@ pub trait SequenceDecoder<'de, C: ?Sized + Context>: Sized {
 
     /// Decode the next element of the given type.
     #[inline]
-    fn next<T>(&mut self, cx: &C) -> Result<Option<T>, C::Error>
+    fn next<T>(&mut self, cx: &Self::Cx) -> Result<Option<T>, <Self::Cx as Context>::Error>
     where
         Self: Sized,
-        T: Decode<'de, C::Mode>,
+        T: Decode<'de, <Self::Cx as Context>::Mode>,
     {
         let Some(decoder) = self.decode_next(cx)? else {
             return Ok(None);

--- a/crates/musli/src/de/struct_decoder.rs
+++ b/crates/musli/src/de/struct_decoder.rs
@@ -3,13 +3,15 @@ use crate::Context;
 use super::{Decoder, SizeHint, StructFieldDecoder, StructFieldsDecoder};
 
 /// Trait governing how to decode fields in a struct.
-pub trait StructDecoder<'de, C: ?Sized + Context>: Sized {
+pub trait StructDecoder<'de>: Sized {
+    /// Context associated with the decoder.
+    type Cx: ?Sized + Context;
     /// The decoder to use for a key.
-    type DecodeField<'this>: StructFieldDecoder<'de, C>
+    type DecodeField<'this>: StructFieldDecoder<'de, Cx = Self::Cx>
     where
         Self: 'this;
     /// Decoder for a sequence of struct pairs.
-    type IntoStructFields: StructFieldsDecoder<'de, C>;
+    type IntoStructFields: StructFieldsDecoder<'de, Cx = Self::Cx>;
 
     /// This is a type argument used to hint to any future implementor that they
     /// should be using the [`#[musli::struct_decoder]`][crate::struct_decoder]
@@ -18,17 +20,20 @@ pub trait StructDecoder<'de, C: ?Sized + Context>: Sized {
     type __UseMusliStructDecoderAttributeMacro;
 
     /// Get a size hint of known remaining fields.
-    fn size_hint(&self, cx: &C) -> SizeHint;
+    fn size_hint(&self, cx: &Self::Cx) -> SizeHint;
 
     /// Decode the next field.
     #[must_use = "Decoders must be consumed"]
-    fn decode_field(&mut self, cx: &C) -> Result<Option<Self::DecodeField<'_>>, C::Error>;
+    fn decode_field(
+        &mut self,
+        cx: &Self::Cx,
+    ) -> Result<Option<Self::DecodeField<'_>>, <Self::Cx as Context>::Error>;
 
     /// End the struct decoder.
     ///
     /// If there are any remaining elements in the sequence of pairs, this
     /// indicates that they should be flushed.
-    fn end(mut self, cx: &C) -> Result<(), C::Error> {
+    fn end(mut self, cx: &Self::Cx) -> Result<(), <Self::Cx as Context>::Error> {
         while let Some(mut item) = self.decode_field(cx)? {
             item.decode_field_name(cx)?.skip(cx)?;
             item.skip_field_value(cx)?;
@@ -46,7 +51,10 @@ pub trait StructDecoder<'de, C: ?Sized + Context>: Sized {
     ///
     /// The size of a struct might therefore change from one session to another.
     #[inline]
-    fn into_struct_fields(self, cx: &C) -> Result<Self::IntoStructFields, C::Error>
+    fn into_struct_fields(
+        self,
+        cx: &Self::Cx,
+    ) -> Result<Self::IntoStructFields, <Self::Cx as Context>::Error>
     where
         Self: Sized,
     {

--- a/crates/musli/src/de/struct_field_decoder.rs
+++ b/crates/musli/src/de/struct_field_decoder.rs
@@ -3,24 +3,42 @@ use crate::Context;
 use super::Decoder;
 
 /// Trait governing how to decode a struct field.
-pub trait StructFieldDecoder<'de, C: ?Sized + Context> {
+pub trait StructFieldDecoder<'de> {
+    /// Context associated with the decoder.
+    type Cx: ?Sized + Context;
     /// The decoder to use for a tuple field index.
-    type DecodeFieldName<'this>: Decoder<'de, C>
+    type DecodeFieldName<'this>: Decoder<
+        'de,
+        Cx = Self::Cx,
+        Error = <Self::Cx as Context>::Error,
+        Mode = <Self::Cx as Context>::Mode,
+    >
     where
         Self: 'this;
     /// The decoder to use for a tuple field value.
-    type DecodeFieldValue: Decoder<'de, C>;
+    type DecodeFieldValue: Decoder<
+        'de,
+        Cx = Self::Cx,
+        Error = <Self::Cx as Context>::Error,
+        Mode = <Self::Cx as Context>::Mode,
+    >;
 
     /// Return the decoder for the field name.
     #[must_use = "Decoders must be consumed"]
-    fn decode_field_name(&mut self, cx: &C) -> Result<Self::DecodeFieldName<'_>, C::Error>;
+    fn decode_field_name(
+        &mut self,
+        cx: &Self::Cx,
+    ) -> Result<Self::DecodeFieldName<'_>, <Self::Cx as Context>::Error>;
 
     /// Decode the field value.
     #[must_use = "Decoders must be consumed"]
-    fn decode_field_value(self, cx: &C) -> Result<Self::DecodeFieldValue, C::Error>;
+    fn decode_field_value(
+        self,
+        cx: &Self::Cx,
+    ) -> Result<Self::DecodeFieldValue, <Self::Cx as Context>::Error>;
 
     /// Indicate that the field value should be skipped.
     ///
     /// The boolean returned indicates if the value was skipped or not.
-    fn skip_field_value(self, cx: &C) -> Result<bool, C::Error>;
+    fn skip_field_value(self, cx: &Self::Cx) -> Result<bool, <Self::Cx as Context>::Error>;
 }

--- a/crates/musli/src/de/struct_fields_decoder.rs
+++ b/crates/musli/src/de/struct_fields_decoder.rs
@@ -9,13 +9,25 @@ use super::Decoder;
 ///
 /// If you do not intend to implement this, then serde compatibility for your
 /// format might be degraded.
-pub trait StructFieldsDecoder<'de, C: ?Sized + Context> {
+pub trait StructFieldsDecoder<'de> {
+    /// Context associated with the decoder.
+    type Cx: ?Sized + Context;
     /// The decoder to use for a tuple field index.
-    type DecodeStructFieldName<'this>: Decoder<'de, C>
+    type DecodeStructFieldName<'this>: Decoder<
+        'de,
+        Cx = Self::Cx,
+        Error = <Self::Cx as Context>::Error,
+        Mode = <Self::Cx as Context>::Mode,
+    >
     where
         Self: 'this;
     /// The decoder to use for a tuple field value.
-    type DecodeStructFieldValue<'this>: Decoder<'de, C>
+    type DecodeStructFieldValue<'this>: Decoder<
+        'de,
+        Cx = Self::Cx,
+        Error = <Self::Cx as Context>::Error,
+        Mode = <Self::Cx as Context>::Mode,
+    >
     where
         Self: 'this;
 
@@ -26,21 +38,24 @@ pub trait StructFieldsDecoder<'de, C: ?Sized + Context> {
     #[must_use = "Decoders must be consumed"]
     fn decode_struct_field_name(
         &mut self,
-        cx: &C,
-    ) -> Result<Self::DecodeStructFieldName<'_>, C::Error>;
+        cx: &Self::Cx,
+    ) -> Result<Self::DecodeStructFieldName<'_>, <Self::Cx as Context>::Error>;
 
     /// Decode the second value in the pair..
     #[must_use = "Decoders must be consumed"]
     fn decode_struct_field_value(
         &mut self,
-        cx: &C,
-    ) -> Result<Self::DecodeStructFieldValue<'_>, C::Error>;
+        cx: &Self::Cx,
+    ) -> Result<Self::DecodeStructFieldValue<'_>, <Self::Cx as Context>::Error>;
 
     /// Indicate that the second value should be skipped.
     ///
     /// The boolean returned indicates if the value was skipped or not.
-    fn skip_struct_field_value(&mut self, cx: &C) -> Result<bool, C::Error>;
+    fn skip_struct_field_value(
+        &mut self,
+        cx: &Self::Cx,
+    ) -> Result<bool, <Self::Cx as Context>::Error>;
 
     /// End pair decoding.
-    fn end(self, cx: &C) -> Result<(), C::Error>;
+    fn end(self, cx: &Self::Cx) -> Result<(), <Self::Cx as Context>::Error>;
 }

--- a/crates/musli/src/de/value_visitor.rs
+++ b/crates/musli/src/de/value_visitor.rs
@@ -62,7 +62,7 @@ where
     #[inline]
     fn visit_any<D>(self, cx: &C, _: D, hint: TypeHint) -> Result<Self::Ok, C::Error>
     where
-        D: Decoder<'de, C>,
+        D: Decoder<'de, Cx = C>,
     {
         Err(cx.message(expecting::unsupported_type(
             &hint,

--- a/crates/musli/src/de/variant_decoder.rs
+++ b/crates/musli/src/de/variant_decoder.rs
@@ -3,13 +3,25 @@ use crate::Context;
 use super::Decoder;
 
 /// Trait governing how to decode a variant.
-pub trait VariantDecoder<'de, C: ?Sized + Context> {
+pub trait VariantDecoder<'de> {
+    /// Context associated with the decoder.
+    type Cx: ?Sized + Context;
     /// The decoder to use for the variant tag.
-    type DecodeTag<'this>: Decoder<'de, C>
+    type DecodeTag<'this>: Decoder<
+        'de,
+        Cx = Self::Cx,
+        Error = <Self::Cx as Context>::Error,
+        Mode = <Self::Cx as Context>::Mode,
+    >
     where
         Self: 'this;
     /// The decoder to use for the variant value.
-    type DecodeVariant<'this>: Decoder<'de, C>
+    type DecodeVariant<'this>: Decoder<
+        'de,
+        Cx = Self::Cx,
+        Error = <Self::Cx as Context>::Error,
+        Mode = <Self::Cx as Context>::Mode,
+    >
     where
         Self: 'this;
 
@@ -18,17 +30,23 @@ pub trait VariantDecoder<'de, C: ?Sized + Context> {
     /// If this is a map the first value would be the key of the map, if this is
     /// a struct the first value would be the field of the struct.
     #[must_use = "Decoders must be consumed"]
-    fn decode_tag(&mut self, cx: &C) -> Result<Self::DecodeTag<'_>, C::Error>;
+    fn decode_tag(
+        &mut self,
+        cx: &Self::Cx,
+    ) -> Result<Self::DecodeTag<'_>, <Self::Cx as Context>::Error>;
 
     /// Decode the second value in the pair..
     #[must_use = "Decoders must be consumed"]
-    fn decode_value(&mut self, cx: &C) -> Result<Self::DecodeVariant<'_>, C::Error>;
+    fn decode_value(
+        &mut self,
+        cx: &Self::Cx,
+    ) -> Result<Self::DecodeVariant<'_>, <Self::Cx as Context>::Error>;
 
     /// Indicate that the second value should be skipped.
     ///
     /// The boolean returned indicates if the value was skipped or not.
-    fn skip_value(&mut self, cx: &C) -> Result<bool, C::Error>;
+    fn skip_value(&mut self, cx: &Self::Cx) -> Result<bool, <Self::Cx as Context>::Error>;
 
     /// End the pair decoder.
-    fn end(self, cx: &C) -> Result<(), C::Error>;
+    fn end(self, cx: &Self::Cx) -> Result<(), <Self::Cx as Context>::Error>;
 }

--- a/crates/musli/src/de/visitor.rs
+++ b/crates/musli/src/de/visitor.rs
@@ -39,7 +39,7 @@ pub trait Visitor<'de, C: ?Sized + Context>: Sized {
     /// or the underlying format doesn't know which type to decode.
     fn visit_any<D>(self, cx: &C, _: D, hint: TypeHint) -> Result<Self::Ok, C::Error>
     where
-        D: Decoder<'de, C>,
+        D: Decoder<'de, Cx = C>,
     {
         Err(cx.message(expecting::unsupported_type(
             &hint,
@@ -204,7 +204,7 @@ pub trait Visitor<'de, C: ?Sized + Context>: Sized {
     #[inline]
     fn visit_option<D>(self, cx: &C, _: Option<D>) -> Result<Self::Ok, C::Error>
     where
-        D: Decoder<'de, C>,
+        D: Decoder<'de, Cx = C>,
     {
         Err(cx.message(expecting::unsupported_type(
             &expecting::Option,
@@ -216,7 +216,7 @@ pub trait Visitor<'de, C: ?Sized + Context>: Sized {
     #[inline]
     fn visit_sequence<D>(self, cx: &C, decoder: D) -> Result<Self::Ok, C::Error>
     where
-        D: SequenceDecoder<'de, C>,
+        D: SequenceDecoder<'de, Cx = C>,
     {
         Err(cx.message(expecting::unsupported_type(
             &expecting::SequenceWith(decoder.size_hint(cx)),
@@ -226,9 +226,9 @@ pub trait Visitor<'de, C: ?Sized + Context>: Sized {
 
     /// Indicates that the visited type is a map.
     #[inline]
-    fn visit_map<D>(self, cx: &C, decoder: D) -> Result<Self::Ok, C::Error>
+    fn visit_map<D>(self, cx: &C, decoder: D) -> Result<Self::Ok, <D::Cx as Context>::Error>
     where
-        D: MapDecoder<'de, C>,
+        D: MapDecoder<'de, Cx = C>,
     {
         Err(cx.message(expecting::unsupported_type(
             &expecting::MapWith(decoder.size_hint(cx)),
@@ -267,7 +267,7 @@ pub trait Visitor<'de, C: ?Sized + Context>: Sized {
     #[inline]
     fn visit_variant<D>(self, cx: &C, _: D) -> Result<Self::Ok, C::Error>
     where
-        D: VariantDecoder<'de, C>,
+        D: VariantDecoder<'de, Cx = C>,
     {
         Err(cx.message(expecting::unsupported_type(
             &expecting::Variant,

--- a/crates/musli/src/derives.rs
+++ b/crates/musli/src/derives.rs
@@ -613,20 +613,18 @@
 //! }
 //!
 //! mod module {
-//!     use musli::{Context, Decoder, Encoder};
+//!     use musli::{Decoder, Encoder};
 //!
 //!     use super::Field;
 //!
-//!     pub fn encode<C, E>(field: &Field, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+//!     pub fn encode<E>(field: &Field, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
 //!     where
-//!         C: ?Sized + Context,
-//!         E: Encoder<C>,
+//!         E: Encoder,
 //! # { todo!() }
 //!
-//!     pub fn decode<'de, C, D>(cx: &C, decoder: D) -> Result<Field, C::Error>
+//!     pub fn decode<'de, D>(cx: &D::Cx, decoder: D) -> Result<Field, D::Error>
 //!     where
-//!         C: ?Sized + Context,
-//!         D: Decoder<'de, C>,
+//!         D: Decoder<'de>,
 //! # { todo!() }
 //! }
 //! # }
@@ -650,20 +648,18 @@
 //! }
 //!
 //! mod module {
-//!     use musli::{Context, Decoder, Encoder};
+//!     use musli::{Decoder, Encoder};
 //!
 //!     use super::Field;
 //!
-//!     pub fn encode<C, E, T>(field: &Field<T>, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+//!     pub fn encode<E, T>(field: &Field<T>, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
 //!     where
-//!         C: ?Sized + Context,
-//!         E: Encoder<C>,
+//!         E: Encoder,
 //! # { todo!() }
 //!
-//!     pub fn decode<'de, C, D, T>(cx: &C, decoder: D) -> Result<Field<T>, C::Error>
+//!     pub fn decode<'de, D, T>(cx: &D::Cx, decoder: D) -> Result<Field<T>, D::Error>
 //!     where
-//!         C: ?Sized + Context,
-//!         D: Decoder<'de, C>,
+//!         D: Decoder<'de>,
 //! # { todo!() }
 //! }
 //! # }
@@ -691,18 +687,16 @@
 //!
 //!     use super::CustomUuid;
 //!
-//!     pub fn encode<C, E>(uuid: &CustomUuid, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+//!     pub fn encode<E>(uuid: &CustomUuid, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
 //!     where
-//!         C: ?Sized + Context,
-//!         E: Encoder<C>,
+//!         E: Encoder,
 //!     {
 //!         uuid.0.encode(cx, encoder)
 //!     }
 //!
-//!     pub fn decode<'de, C, D>(cx: &C, decoder: D) -> Result<CustomUuid, C::Error>
+//!     pub fn decode<'de, D>(cx: &D::Cx, decoder: D) -> Result<CustomUuid, D::Error>
 //!     where
-//!         C: ?Sized + Context,
-//!         D: Decoder<'de, C>,
+//!         D: Decoder<'de>,
 //!     {
 //!         Ok(CustomUuid(cx.decode(decoder)?))
 //!     }
@@ -714,20 +708,18 @@
 //!
 //!     use musli::{Context, Decode, Decoder, Encode, Encoder};
 //!
-//!     pub fn encode<C, E, T>(set: &HashSet<T>, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+//!     pub fn encode<E, T>(set: &HashSet<T>, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
 //!     where
-//!         C: ?Sized + Context,
-//!         E: Encoder<C>,
-//!         T: Encode<C::Mode> + Eq + Hash,
+//!         E: Encoder,
+//!         T: Encode<E::Mode> + Eq + Hash,
 //!     {
 //!         HashSet::<T>::encode(set, cx, encoder)
 //!     }
 //!
-//!     pub fn decode<'de, C, D, T>(cx: &C, decoder: D) -> Result<HashSet<T>, C::Error>
+//!     pub fn decode<'de, D, T>(cx: &D::Cx, decoder: D) -> Result<HashSet<T>, D::Error>
 //!     where
-//!         C: ?Sized + Context,
-//!         D: Decoder<'de, C>,
-//!         T: Decode<'de, C::Mode> + Eq + Hash,
+//!         D: Decoder<'de>,
+//!         T: Decode<'de, D::Mode> + Eq + Hash,
 //!     {
 //!         cx.decode(decoder)
 //!     }

--- a/crates/musli/src/en/encode.rs
+++ b/crates/musli/src/en/encode.rs
@@ -24,17 +24,16 @@ pub use musli_macros::Encode;
 /// Implementing manually:
 ///
 /// ```
-/// use musli::{Context, Encode, Encoder};
+/// use musli::{Encode, Encoder};
 ///
 /// struct MyType {
 ///     data: [u8; 128],
 /// }
 ///
 /// impl<M> Encode<M> for MyType {
-///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+///     fn encode<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
 ///     where
-///         C: ?Sized + Context<Mode = M>,
-///         E: Encoder<C>,
+///         E: Encoder<Mode = M>,
 ///     {
 ///         encoder.encode_array(cx, &self.data)
 ///     }
@@ -42,10 +41,9 @@ pub use musli_macros::Encode;
 /// ```
 pub trait Encode<M = DefaultMode> {
     /// Encode the given output.
-    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, <E::Cx as Context>::Error>
     where
-        C: ?Sized + Context<Mode = M>,
-        E: Encoder<C>;
+        E: Encoder<Mode = M>;
 }
 
 /// Trait governing how types are encoded specifically for tracing.
@@ -58,10 +56,9 @@ pub trait Encode<M = DefaultMode> {
 /// [`fmt::Display`]: std::fmt::Display
 pub trait TraceEncode<M = DefaultMode> {
     /// Encode the given output.
-    fn trace_encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+    fn trace_encode<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, <E::Cx as Context>::Error>
     where
-        C: ?Sized + Context<Mode = M>,
-        E: Encoder<C>;
+        E: Encoder<Mode = M>;
 }
 
 impl<T, M> Encode<M> for &T
@@ -69,10 +66,9 @@ where
     T: ?Sized + Encode<M>,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
     where
-        C: ?Sized + Context<Mode = M>,
-        E: Encoder<C>,
+        E: Encoder<Mode = M>,
     {
         (**self).encode(cx, encoder)
     }
@@ -83,10 +79,9 @@ where
     T: ?Sized + Encode<M>,
 {
     #[inline]
-    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
     where
-        C: ?Sized + Context<Mode = M>,
-        E: Encoder<C>,
+        E: Encoder<Mode = M>,
     {
         (**self).encode(cx, encoder)
     }

--- a/crates/musli/src/en/encode_bytes.rs
+++ b/crates/musli/src/en/encode_bytes.rs
@@ -1,6 +1,5 @@
 use crate::en::Encoder;
 use crate::mode::DefaultMode;
-use crate::Context;
 
 /// Trait governing how a type is encoded as bytes.
 ///
@@ -24,7 +23,7 @@ use crate::Context;
 /// Implementing manually:
 ///
 /// ```
-/// use musli::{Context, Encode, Encoder};
+/// use musli::{Encode, Encoder};
 /// use musli::en::EncodeBytes;
 ///
 /// struct MyType {
@@ -32,10 +31,9 @@ use crate::Context;
 /// }
 ///
 /// impl<M> Encode<M> for MyType {
-///     fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+///     fn encode<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
 ///     where
-///         C: ?Sized + Context<Mode = M>,
-///         E: Encoder<C>,
+///         E: Encoder,
 ///     {
 ///         self.data.encode_bytes(cx, encoder)
 ///     }
@@ -43,10 +41,9 @@ use crate::Context;
 /// ```
 pub trait EncodeBytes<M = DefaultMode> {
     /// Encode the given output as bytes.
-    fn encode_bytes<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode_bytes<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
     where
-        C: ?Sized + Context<Mode = M>,
-        E: Encoder<C>;
+        E: Encoder<Mode = M>;
 }
 
 impl<T, M> EncodeBytes<M> for &T
@@ -54,10 +51,9 @@ where
     T: ?Sized + EncodeBytes<M>,
 {
     #[inline]
-    fn encode_bytes<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode_bytes<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
     where
-        C: ?Sized + Context<Mode = M>,
-        E: Encoder<C>,
+        E: Encoder<Mode = M>,
     {
         (**self).encode_bytes(cx, encoder)
     }
@@ -68,10 +64,9 @@ where
     T: ?Sized + EncodeBytes<M>,
 {
     #[inline]
-    fn encode_bytes<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode_bytes<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
     where
-        C: ?Sized + Context<Mode = M>,
-        E: Encoder<C>,
+        E: Encoder<Mode = M>,
     {
         (**self).encode_bytes(cx, encoder)
     }

--- a/crates/musli/src/en/map_encoder.rs
+++ b/crates/musli/src/en/map_encoder.rs
@@ -3,27 +3,37 @@ use crate::Context;
 use super::{Encode, MapEntryEncoder};
 
 /// Encoder for a map.
-pub trait MapEncoder<C: ?Sized + Context> {
+pub trait MapEncoder {
+    /// Context associated with the encoder.
+    type Cx: ?Sized + Context;
     /// Result type of the encoder.
     type Ok;
     /// Encode the next pair.
-    type EncodeEntry<'this>: MapEntryEncoder<C, Ok = Self::Ok>
+    type EncodeEntry<'this>: MapEntryEncoder<Cx = Self::Cx, Ok = Self::Ok>
     where
         Self: 'this;
 
     /// Encode the next pair.
-    fn encode_entry(&mut self, cx: &C) -> Result<Self::EncodeEntry<'_>, C::Error>;
+    fn encode_entry(
+        &mut self,
+        cx: &Self::Cx,
+    ) -> Result<Self::EncodeEntry<'_>, <Self::Cx as Context>::Error>;
 
     /// Finish encoding pairs.
-    fn end(self, cx: &C) -> Result<Self::Ok, C::Error>;
+    fn end(self, cx: &Self::Cx) -> Result<Self::Ok, <Self::Cx as Context>::Error>;
 
     /// Insert a pair immediately.
     #[inline]
-    fn insert_entry<F, S>(&mut self, cx: &C, key: F, value: S) -> Result<(), C::Error>
+    fn insert_entry<F, S>(
+        &mut self,
+        cx: &Self::Cx,
+        key: F,
+        value: S,
+    ) -> Result<(), <Self::Cx as Context>::Error>
     where
         Self: Sized,
-        F: Encode<C::Mode>,
-        S: Encode<C::Mode>,
+        F: Encode<<Self::Cx as Context>::Mode>,
+        S: Encode<<Self::Cx as Context>::Mode>,
     {
         self.encode_entry(cx)?.insert_entry(cx, key, value)?;
         Ok(())

--- a/crates/musli/src/en/map_entries_encoder.rs
+++ b/crates/musli/src/en/map_entries_encoder.rs
@@ -9,36 +9,58 @@ use super::{Encode, Encoder};
 ///
 /// If you do not intend to implement this, then serde compatibility for your
 /// format might be degraded.
-pub trait MapEntriesEncoder<C: ?Sized + Context> {
+pub trait MapEntriesEncoder {
+    /// Context associated with the encoder.
+    type Cx: ?Sized + Context;
     /// Result type of the encoder.
     type Ok;
     /// The encoder returned when advancing the map encoder to encode the key.
-    type EncodeMapEntryKey<'this>: Encoder<C, Ok = Self::Ok>
+    type EncodeMapEntryKey<'this>: Encoder<
+        Cx = Self::Cx,
+        Ok = Self::Ok,
+        Error = <Self::Cx as Context>::Error,
+        Mode = <Self::Cx as Context>::Mode,
+    >
     where
         Self: 'this;
     /// The encoder returned when advancing the map encoder to encode the value.
-    type EncodeMapEntryValue<'this>: Encoder<C, Ok = Self::Ok>
+    type EncodeMapEntryValue<'this>: Encoder<
+        Cx = Self::Cx,
+        Ok = Self::Ok,
+        Error = <Self::Cx as Context>::Error,
+        Mode = <Self::Cx as Context>::Mode,
+    >
     where
         Self: 'this;
 
     /// Return the encoder for the key in the entry.
     #[must_use = "Encoders must be consumed"]
-    fn encode_map_entry_key(&mut self, cx: &C) -> Result<Self::EncodeMapEntryKey<'_>, C::Error>;
+    fn encode_map_entry_key(
+        &mut self,
+        cx: &Self::Cx,
+    ) -> Result<Self::EncodeMapEntryKey<'_>, <Self::Cx as Context>::Error>;
 
     /// Return encoder for value in the entry.
     #[must_use = "Encoders must be consumed"]
-    fn encode_map_entry_value(&mut self, cx: &C)
-        -> Result<Self::EncodeMapEntryValue<'_>, C::Error>;
+    fn encode_map_entry_value(
+        &mut self,
+        cx: &Self::Cx,
+    ) -> Result<Self::EncodeMapEntryValue<'_>, <Self::Cx as Context>::Error>;
 
     /// Stop encoding this pair.
-    fn end(self, cx: &C) -> Result<Self::Ok, C::Error>;
+    fn end(self, cx: &Self::Cx) -> Result<Self::Ok, <Self::Cx as Context>::Error>;
 
     /// Insert the pair immediately.
     #[inline]
-    fn insert_entry<K, V>(&mut self, cx: &C, key: K, value: V) -> Result<(), C::Error>
+    fn insert_entry<K, V>(
+        &mut self,
+        cx: &Self::Cx,
+        key: K,
+        value: V,
+    ) -> Result<(), <Self::Cx as Context>::Error>
     where
-        K: Encode<C::Mode>,
-        V: Encode<C::Mode>,
+        K: Encode<<Self::Cx as Context>::Mode>,
+        V: Encode<<Self::Cx as Context>::Mode>,
     {
         key.encode(cx, self.encode_map_entry_key(cx)?)?;
         value.encode(cx, self.encode_map_entry_value(cx)?)?;

--- a/crates/musli/src/en/map_entry_encoder.rs
+++ b/crates/musli/src/en/map_entry_encoder.rs
@@ -3,36 +3,59 @@ use crate::Context;
 use super::{Encode, Encoder};
 
 /// Trait governing how to encode a map entry.
-pub trait MapEntryEncoder<C: ?Sized + Context> {
+pub trait MapEntryEncoder {
+    /// Context associated with the encoder.
+    type Cx: ?Sized + Context;
     /// Result type of the encoder.
     type Ok;
     /// The encoder returned when advancing the map encoder to encode the key.
-    type EncodeMapKey<'this>: Encoder<C, Ok = Self::Ok>
+    type EncodeMapKey<'this>: Encoder<
+        Cx = Self::Cx,
+        Ok = Self::Ok,
+        Error = <Self::Cx as Context>::Error,
+        Mode = <Self::Cx as Context>::Mode,
+    >
     where
         Self: 'this;
     /// The encoder returned when advancing the map encoder to encode the value.
-    type EncodeMapValue<'this>: Encoder<C, Ok = Self::Ok>
+    type EncodeMapValue<'this>: Encoder<
+        Cx = Self::Cx,
+        Ok = Self::Ok,
+        Error = <Self::Cx as Context>::Error,
+        Mode = <Self::Cx as Context>::Mode,
+    >
     where
         Self: 'this;
 
     /// Return the encoder for the key in the entry.
     #[must_use = "Encoders must be consumed"]
-    fn encode_map_key(&mut self, cx: &C) -> Result<Self::EncodeMapKey<'_>, C::Error>;
+    fn encode_map_key(
+        &mut self,
+        cx: &Self::Cx,
+    ) -> Result<Self::EncodeMapKey<'_>, <Self::Cx as Context>::Error>;
 
     /// Return encoder for value in the entry.
     #[must_use = "Encoders must be consumed"]
-    fn encode_map_value(&mut self, cx: &C) -> Result<Self::EncodeMapValue<'_>, C::Error>;
+    fn encode_map_value(
+        &mut self,
+        cx: &Self::Cx,
+    ) -> Result<Self::EncodeMapValue<'_>, <Self::Cx as Context>::Error>;
 
     /// Stop encoding this pair.
-    fn end(self, cx: &C) -> Result<Self::Ok, C::Error>;
+    fn end(self, cx: &Self::Cx) -> Result<Self::Ok, <Self::Cx as Context>::Error>;
 
     /// Insert the pair immediately.
     #[inline]
-    fn insert_entry<K, V>(mut self, cx: &C, key: K, value: V) -> Result<Self::Ok, C::Error>
+    fn insert_entry<K, V>(
+        mut self,
+        cx: &Self::Cx,
+        key: K,
+        value: V,
+    ) -> Result<Self::Ok, <Self::Cx as Context>::Error>
     where
         Self: Sized,
-        K: Encode<C::Mode>,
-        V: Encode<C::Mode>,
+        K: Encode<<Self::Cx as Context>::Mode>,
+        V: Encode<<Self::Cx as Context>::Mode>,
     {
         key.encode(cx, self.encode_map_key(cx)?)?;
         value.encode(cx, self.encode_map_value(cx)?)?;

--- a/crates/musli/src/en/sequence_encoder.rs
+++ b/crates/musli/src/en/sequence_encoder.rs
@@ -3,26 +3,36 @@ use crate::Context;
 use super::{Encode, Encoder};
 
 /// Trait governing how to encode a sequence.
-pub trait SequenceEncoder<C: ?Sized + Context> {
+pub trait SequenceEncoder {
+    /// Context associated with the encoder.
+    type Cx: ?Sized + Context;
     /// Result type of the encoder.
     type Ok;
     /// The encoder returned when advancing the sequence encoder.
-    type EncodeNext<'this>: Encoder<C, Ok = Self::Ok>
+    type EncodeNext<'this>: Encoder<
+        Cx = Self::Cx,
+        Ok = Self::Ok,
+        Error = <Self::Cx as Context>::Error,
+        Mode = <Self::Cx as Context>::Mode,
+    >
     where
         Self: 'this;
 
     /// Return encoder for the next element.
     #[must_use = "Encoder must be consumed"]
-    fn encode_next(&mut self, cx: &C) -> Result<Self::EncodeNext<'_>, C::Error>;
+    fn encode_next(
+        &mut self,
+        cx: &Self::Cx,
+    ) -> Result<Self::EncodeNext<'_>, <Self::Cx as Context>::Error>;
 
     /// Finish encoding the sequence.
-    fn end(self, cx: &C) -> Result<Self::Ok, C::Error>;
+    fn end(self, cx: &Self::Cx) -> Result<Self::Ok, <Self::Cx as Context>::Error>;
 
     /// Push an element into the sequence.
     #[inline]
-    fn push<T>(&mut self, cx: &C, value: T) -> Result<(), C::Error>
+    fn push<T>(&mut self, cx: &Self::Cx, value: T) -> Result<(), <Self::Cx as Context>::Error>
     where
-        T: Encode<C::Mode>,
+        T: Encode<<Self::Cx as Context>::Mode>,
     {
         let encoder = self.encode_next(cx)?;
         value.encode(cx, encoder)?;

--- a/crates/musli/src/en/struct_encoder.rs
+++ b/crates/musli/src/en/struct_encoder.rs
@@ -3,25 +3,34 @@ use crate::Context;
 use super::{Encode, StructFieldEncoder};
 
 /// Encoder for a struct.
-pub trait StructEncoder<C: ?Sized + Context> {
+pub trait StructEncoder {
+    /// Context associated with the encoder.
+    type Cx: ?Sized + Context;
     /// Result type of the encoder.
     type Ok;
     /// Encoder for the next struct field.
-    type EncodeField<'this>: StructFieldEncoder<C, Ok = Self::Ok>
+    type EncodeField<'this>: StructFieldEncoder<Cx = Self::Cx, Ok = Self::Ok>
     where
         Self: 'this;
 
     /// Encode the next field.
-    fn encode_field(&mut self, cx: &C) -> Result<Self::EncodeField<'_>, C::Error>;
+    fn encode_field(
+        &mut self,
+        cx: &Self::Cx,
+    ) -> Result<Self::EncodeField<'_>, <Self::Cx as Context>::Error>;
 
     /// Finish encoding the struct.
-    fn end(self, cx: &C) -> Result<Self::Ok, C::Error>;
+    fn end(self, cx: &Self::Cx) -> Result<Self::Ok, <Self::Cx as Context>::Error>;
 
     /// Encode the next field using a closure.
     #[inline]
-    fn encode_field_fn<F, O>(&mut self, cx: &C, f: F) -> Result<O, C::Error>
+    fn encode_field_fn<F, O>(
+        &mut self,
+        cx: &Self::Cx,
+        f: F,
+    ) -> Result<O, <Self::Cx as Context>::Error>
     where
-        F: FnOnce(&mut Self::EncodeField<'_>) -> Result<O, C::Error>,
+        F: FnOnce(&mut Self::EncodeField<'_>) -> Result<O, <Self::Cx as Context>::Error>,
     {
         let mut encoder = self.encode_field(cx)?;
         let output = f(&mut encoder)?;
@@ -31,10 +40,15 @@ pub trait StructEncoder<C: ?Sized + Context> {
 
     /// Insert a field immediately.
     #[inline]
-    fn insert_field<F, V>(&mut self, cx: &C, field: F, value: V) -> Result<(), C::Error>
+    fn insert_field<F, V>(
+        &mut self,
+        cx: &Self::Cx,
+        field: F,
+        value: V,
+    ) -> Result<(), <Self::Cx as Context>::Error>
     where
-        F: Encode<C::Mode>,
-        V: Encode<C::Mode>,
+        F: Encode<<Self::Cx as Context>::Mode>,
+        V: Encode<<Self::Cx as Context>::Mode>,
     {
         self.encode_field(cx)?.insert_field(cx, field, value)?;
         Ok(())

--- a/crates/musli/src/en/struct_field_encoder.rs
+++ b/crates/musli/src/en/struct_field_encoder.rs
@@ -3,36 +3,59 @@ use crate::Context;
 use super::{Encode, Encoder};
 
 /// Trait governing how to encode a sequence of pairs.
-pub trait StructFieldEncoder<C: ?Sized + Context> {
+pub trait StructFieldEncoder {
+    /// Context associated with the encoder.
+    type Cx: ?Sized + Context;
     /// Result type of the encoder.
     type Ok;
     /// The encoder returned when advancing the map encoder to encode the key.
-    type EncodeFieldName<'this>: Encoder<C, Ok = Self::Ok>
+    type EncodeFieldName<'this>: Encoder<
+        Cx = Self::Cx,
+        Ok = Self::Ok,
+        Error = <Self::Cx as Context>::Error,
+        Mode = <Self::Cx as Context>::Mode,
+    >
     where
         Self: 'this;
     /// The encoder returned when advancing the map encoder to encode the value.
-    type EncodeFieldValue<'this>: Encoder<C, Ok = Self::Ok>
+    type EncodeFieldValue<'this>: Encoder<
+        Cx = Self::Cx,
+        Ok = Self::Ok,
+        Error = <Self::Cx as Context>::Error,
+        Mode = <Self::Cx as Context>::Mode,
+    >
     where
         Self: 'this;
 
     /// Return the encoder for the field in the struct.
     #[must_use = "Encoders must be consumed"]
-    fn encode_field_name(&mut self, cx: &C) -> Result<Self::EncodeFieldName<'_>, C::Error>;
+    fn encode_field_name(
+        &mut self,
+        cx: &Self::Cx,
+    ) -> Result<Self::EncodeFieldName<'_>, <Self::Cx as Context>::Error>;
 
     /// Return encoder for the field value in the struct.
     #[must_use = "Encoders must be consumed"]
-    fn encode_field_value(&mut self, cx: &C) -> Result<Self::EncodeFieldValue<'_>, C::Error>;
+    fn encode_field_value(
+        &mut self,
+        cx: &Self::Cx,
+    ) -> Result<Self::EncodeFieldValue<'_>, <Self::Cx as Context>::Error>;
 
     /// Stop encoding this field.
-    fn end(self, cx: &C) -> Result<Self::Ok, C::Error>;
+    fn end(self, cx: &Self::Cx) -> Result<Self::Ok, <Self::Cx as Context>::Error>;
 
     /// Insert the pair immediately.
     #[inline]
-    fn insert_field<N, V>(mut self, cx: &C, name: N, value: V) -> Result<Self::Ok, C::Error>
+    fn insert_field<N, V>(
+        mut self,
+        cx: &Self::Cx,
+        name: N,
+        value: V,
+    ) -> Result<Self::Ok, <Self::Cx as Context>::Error>
     where
         Self: Sized,
-        N: Encode<C::Mode>,
-        V: Encode<C::Mode>,
+        N: Encode<<Self::Cx as Context>::Mode>,
+        V: Encode<<Self::Cx as Context>::Mode>,
     {
         name.encode(cx, self.encode_field_name(cx)?)?;
         value.encode(cx, self.encode_field_value(cx)?)?;

--- a/crates/musli/src/en/variant_encoder.rs
+++ b/crates/musli/src/en/variant_encoder.rs
@@ -3,36 +3,59 @@ use crate::Context;
 use super::{Encode, Encoder};
 
 /// Trait governing how to encode a variant.
-pub trait VariantEncoder<C: ?Sized + Context> {
+pub trait VariantEncoder {
+    /// Context associated with the encoder.
+    type Cx: ?Sized + Context;
     /// Result type of the encoder.
     type Ok;
     /// The encoder returned when advancing the map encoder to encode the key.
-    type EncodeTag<'this>: Encoder<C, Ok = Self::Ok>
+    type EncodeTag<'this>: Encoder<
+        Cx = Self::Cx,
+        Ok = Self::Ok,
+        Error = <Self::Cx as Context>::Error,
+        Mode = <Self::Cx as Context>::Mode,
+    >
     where
         Self: 'this;
     /// The encoder returned when advancing the map encoder to encode the value.
-    type EncodeValue<'this>: Encoder<C, Ok = Self::Ok>
+    type EncodeValue<'this>: Encoder<
+        Cx = Self::Cx,
+        Ok = Self::Ok,
+        Error = <Self::Cx as Context>::Error,
+        Mode = <Self::Cx as Context>::Mode,
+    >
     where
         Self: 'this;
 
     /// Return the encoder for the first element in the variant.
     #[must_use = "Encoders must be consumed"]
-    fn encode_tag(&mut self, cx: &C) -> Result<Self::EncodeTag<'_>, C::Error>;
+    fn encode_tag(
+        &mut self,
+        cx: &Self::Cx,
+    ) -> Result<Self::EncodeTag<'_>, <Self::Cx as Context>::Error>;
 
     /// Return encoder for the second element in the variant.
     #[must_use = "Encoders must be consumed"]
-    fn encode_value(&mut self, cx: &C) -> Result<Self::EncodeValue<'_>, C::Error>;
+    fn encode_value(
+        &mut self,
+        cx: &Self::Cx,
+    ) -> Result<Self::EncodeValue<'_>, <Self::Cx as Context>::Error>;
 
     /// End the variant encoder.
-    fn end(self, cx: &C) -> Result<Self::Ok, C::Error>;
+    fn end(self, cx: &Self::Cx) -> Result<Self::Ok, <Self::Cx as Context>::Error>;
 
     /// Insert the variant immediately.
     #[inline]
-    fn insert_variant<T, V>(mut self, cx: &C, tag: T, value: V) -> Result<Self::Ok, C::Error>
+    fn insert_variant<T, V>(
+        mut self,
+        cx: &Self::Cx,
+        tag: T,
+        value: V,
+    ) -> Result<Self::Ok, <Self::Cx as Context>::Error>
     where
         Self: Sized,
-        T: Encode<C::Mode>,
-        V: Encode<C::Mode>,
+        T: Encode<<Self::Cx as Context>::Mode>,
+        V: Encode<<Self::Cx as Context>::Mode>,
     {
         tag.encode(cx, self.encode_tag(cx)?)?;
         value.encode(cx, self.encode_value(cx)?)?;

--- a/crates/musli/src/impls/alloc.rs
+++ b/crates/musli/src/impls/alloc.rs
@@ -31,10 +31,9 @@ use crate::Context;
 
 impl<M> Encode<M> for String {
     #[inline]
-    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
     where
-        C: ?Sized + Context<Mode = M>,
-        E: Encoder<C>,
+        E: Encoder<Mode = M>,
     {
         self.as_str().encode(cx, encoder)
     }
@@ -42,10 +41,9 @@ impl<M> Encode<M> for String {
 
 impl<'de, M> Decode<'de, M> for String {
     #[inline]
-    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+    fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
     where
-        C: ?Sized + Context<Mode = M>,
-        D: Decoder<'de, C>,
+        D: Decoder<'de, Mode = M>,
     {
         struct Visitor;
 
@@ -82,10 +80,9 @@ impl<'de, M> Decode<'de, M> for String {
 
 impl<'de, M> Decode<'de, M> for Box<str> {
     #[inline]
-    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+    fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
     where
-        C: ?Sized + Context<Mode = M>,
-        D: Decoder<'de, C>,
+        D: Decoder<'de, Mode = M>,
     {
         let string: String = cx.decode(decoder)?;
         Ok(string.into())
@@ -97,10 +94,9 @@ where
     T: Decode<'de, M>,
 {
     #[inline]
-    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+    fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
     where
-        C: ?Sized + Context<Mode = M>,
-        D: Decoder<'de, C>,
+        D: Decoder<'de, Mode = M>,
     {
         let vec: Vec<T> = cx.decode(decoder)?;
         Ok(Box::from(vec))
@@ -119,10 +115,9 @@ macro_rules! cow {
     ) => {
         impl<M> $encode<M> for Cow<'_, $ty> {
             #[inline]
-            fn $encode_fn<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+            fn $encode_fn<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
             where
-                C: ?Sized + Context<Mode = M>,
-                E: Encoder<C>,
+                E: Encoder<Mode = M>,
             {
                 self.as_ref().$encode_fn(cx, encoder)
             }
@@ -130,10 +125,9 @@ macro_rules! cow {
 
         impl<'de, M> $decode<'de, M> for Cow<'de, $ty> {
             #[inline]
-            fn $decode_fn<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+            fn $decode_fn<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
             where
-                C: ?Sized + Context<Mode = M>,
-                D: Decoder<'de, C>,
+                D: Decoder<'de, Mode = M>,
             {
                 struct Visitor;
 
@@ -223,10 +217,9 @@ macro_rules! sequence {
             $($extra: $extra_bound0 $(+ $extra_bound)*),*
         {
             #[inline]
-            fn encode<C, E>(&self, $cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+            fn encode<E>(&self, $cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
             where
-                C: ?Sized + Context<Mode = M>,
-                E: Encoder<C>,
+                E: Encoder<Mode = M>,
             {
                 let mut seq = encoder.encode_sequence($cx, self.len())?;
 
@@ -250,10 +243,9 @@ macro_rules! sequence {
             $($extra: $extra_bound0 $(+ $extra_bound)*),*
         {
             #[inline]
-            fn decode<C, D>($cx: &C, decoder: D) -> Result<Self, C::Error>
+            fn decode<D>($cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
             where
-                C: ?Sized + Context<Mode = M>,
-                D: Decoder<'de, C>,
+                D: Decoder<'de, Mode = M>,
             {
                 let mut $access = decoder.decode_sequence($cx)?;
                 let mut out = $factory;
@@ -318,10 +310,9 @@ macro_rules! map {
             $($extra: $extra_bound0 $(+ $extra_bound)*),*
         {
             #[inline]
-            fn encode<C, E>(&self, $cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+            fn encode<E>(&self, $cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
             where
-                C: ?Sized + Context<Mode = M>,
-                E: Encoder<C>,
+                E: Encoder<Mode = M>,
             {
                 let mut map = encoder.encode_map($cx, self.len())?;
 
@@ -343,10 +334,9 @@ macro_rules! map {
             $($extra: $extra_bound0 $(+ $extra_bound)*),*
         {
             #[inline]
-            fn trace_encode<C, E>(&self, $cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+            fn trace_encode<E>(&self, $cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
             where
-                C: ?Sized + Context<Mode = M>,
-                E: Encoder<C>,
+                E: Encoder<Mode = M>,
             {
                 let mut map = encoder.encode_map($cx, self.len())?;
 
@@ -370,10 +360,9 @@ macro_rules! map {
             $($extra: $extra_bound0 $(+ $extra_bound)*),*
         {
             #[inline]
-            fn decode<C, D>($cx: &C, decoder: D) -> Result<Self, C::Error>
+            fn decode<D>($cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
             where
-                C: ?Sized + Context<Mode = M>,
-                D: Decoder<'de, C>,
+                D: Decoder<'de, Mode = M>,
             {
                 decoder.decode_map_fn($cx, |$access| {
                     let mut out = $with_capacity;
@@ -394,10 +383,9 @@ macro_rules! map {
             $($extra: $extra_bound0 $(+ $extra_bound)*),*
         {
             #[inline]
-            fn trace_decode<C, D>($cx: &C, decoder: D) -> Result<Self, C::Error>
+            fn trace_decode<D>($cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
             where
-                C: ?Sized + Context<Mode = M>,
-                D: Decoder<'de, C>,
+                D: Decoder<'de, Mode = M>,
             {
                 decoder.decode_map_fn($cx, |$access| {
                     let mut out = $with_capacity;
@@ -430,10 +418,9 @@ map!(
 
 impl<M> Encode<M> for CString {
     #[inline]
-    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
     where
-        C: ?Sized + Context,
-        E: Encoder<C>,
+        E: Encoder,
     {
         encoder.encode_bytes(cx, self.to_bytes_with_nul())
     }
@@ -441,10 +428,9 @@ impl<M> Encode<M> for CString {
 
 impl<'de, M> Decode<'de, M> for CString {
     #[inline]
-    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+    fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
     where
-        C: ?Sized + Context,
-        D: Decoder<'de, C>,
+        D: Decoder<'de>,
     {
         struct Visitor;
 
@@ -489,10 +475,9 @@ macro_rules! smart_pointer {
                 T: ?Sized + Encode<M>,
             {
                 #[inline]
-                fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+                fn encode<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
                 where
-                    C: ?Sized + Context<Mode = M>,
-                    E: Encoder<C>,
+                    E: Encoder<Mode = M>,
                 {
                     self.as_ref().encode(cx, encoder)
                 }
@@ -503,10 +488,9 @@ macro_rules! smart_pointer {
                 T: Decode<'de, M>,
             {
                 #[inline]
-                fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+                fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
                 where
-                    C: ?Sized + Context<Mode = M>,
-                    D: Decoder<'de, C>,
+                    D: Decoder<'de, Mode = M>,
                 {
                     Ok($ty::new(cx.decode(decoder)?))
                 }
@@ -514,10 +498,9 @@ macro_rules! smart_pointer {
 
             impl<'de, M> DecodeBytes<'de, M> for $ty<[u8]> {
                 #[inline]
-                fn decode_bytes<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+                fn decode_bytes<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
                 where
-                    C: ?Sized + Context<Mode = M>,
-                    D: Decoder<'de, C>,
+                    D: Decoder<'de, Mode = M>,
                 {
                     Ok($ty::from(<Vec<u8>>::decode_bytes(cx, decoder)?))
                 }
@@ -525,10 +508,9 @@ macro_rules! smart_pointer {
 
             impl<'de, M> Decode<'de, M> for $ty<CStr> {
                 #[inline]
-                fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+                fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
                 where
-                    C: ?Sized + Context<Mode = M>,
-                    D: Decoder<'de, C>,
+                    D: Decoder<'de, Mode = M>,
                 {
                     Ok($ty::from(CString::decode(cx, decoder)?))
                 }
@@ -538,10 +520,9 @@ macro_rules! smart_pointer {
             #[cfg_attr(doc_cfg, doc(cfg(all(feature = "std", any(unix, windows)))))]
             impl<'de, M> Decode<'de, M> for $ty<Path> {
                 #[inline]
-                fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+                fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
                 where
-                    C: ?Sized + Context<Mode = M>,
-                    D: Decoder<'de, C>,
+                    D: Decoder<'de, Mode = M>,
                 {
                     Ok($ty::from(PathBuf::decode(cx, decoder)?))
                 }
@@ -551,10 +532,9 @@ macro_rules! smart_pointer {
             #[cfg_attr(doc_cfg, doc(cfg(all(feature = "std", any(unix, windows)))))]
             impl<'de, M> Decode<'de, M> for $ty<OsStr> {
                 #[inline]
-                fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+                fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
                 where
-                    C: ?Sized + Context<Mode = M>,
-                    D: Decoder<'de, C>,
+                    D: Decoder<'de, Mode = M>,
                 {
                     Ok($ty::from(OsString::decode(cx, decoder)?))
                 }
@@ -578,10 +558,9 @@ enum PlatformTag {
 impl<M> Encode<M> for OsStr {
     #[cfg(unix)]
     #[inline]
-    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
     where
-        C: ?Sized + Context,
-        E: Encoder<C>,
+        E: Encoder,
     {
         use std::os::unix::ffi::OsStrExt;
 
@@ -596,10 +575,9 @@ impl<M> Encode<M> for OsStr {
 
     #[cfg(windows)]
     #[inline]
-    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
     where
-        C: ?Sized + Context,
-        E: Encoder<C>,
+        E: Encoder,
     {
         use crate::en::VariantEncoder;
         use crate::Buf;
@@ -629,10 +607,9 @@ impl<M> Encode<M> for OsStr {
 #[cfg_attr(doc_cfg, doc(cfg(all(feature = "std", any(unix, windows)))))]
 impl<M> Encode<M> for OsString {
     #[inline]
-    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
     where
-        C: ?Sized + Context,
-        E: Encoder<C>,
+        E: Encoder,
     {
         self.as_os_str().encode(cx, encoder)
     }
@@ -642,10 +619,9 @@ impl<M> Encode<M> for OsString {
 #[cfg_attr(doc_cfg, doc(cfg(all(feature = "std", any(unix, windows)))))]
 impl<'de, M> Decode<'de, M> for OsString {
     #[inline]
-    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+    fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
     where
-        C: ?Sized + Context,
-        D: Decoder<'de, C>,
+        D: Decoder<'de>,
     {
         use crate::de::VariantDecoder;
 
@@ -713,10 +689,9 @@ impl<'de, M> Decode<'de, M> for OsString {
 #[cfg_attr(doc_cfg, doc(cfg(all(feature = "std", any(unix, windows)))))]
 impl<M> Encode<M> for Path {
     #[inline]
-    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
     where
-        C: ?Sized + Context,
-        E: Encoder<C>,
+        E: Encoder,
     {
         self.as_os_str().encode(cx, encoder)
     }
@@ -726,10 +701,9 @@ impl<M> Encode<M> for Path {
 #[cfg_attr(doc_cfg, doc(cfg(all(feature = "std", any(unix, windows)))))]
 impl<M> Encode<M> for PathBuf {
     #[inline]
-    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
     where
-        C: ?Sized + Context,
-        E: Encoder<C>,
+        E: Encoder,
     {
         self.as_path().encode(cx, encoder)
     }
@@ -739,10 +713,9 @@ impl<M> Encode<M> for PathBuf {
 #[cfg_attr(doc_cfg, doc(cfg(all(feature = "std", any(unix, windows)))))]
 impl<'de, M> Decode<'de, M> for PathBuf {
     #[inline]
-    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+    fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
     where
-        C: ?Sized + Context,
-        D: Decoder<'de, C>,
+        D: Decoder<'de>,
     {
         let string: OsString = cx.decode(decoder)?;
         Ok(PathBuf::from(string))
@@ -751,10 +724,9 @@ impl<'de, M> Decode<'de, M> for PathBuf {
 
 impl<M> EncodeBytes<M> for Vec<u8> {
     #[inline]
-    fn encode_bytes<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode_bytes<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
     where
-        C: ?Sized + Context<Mode = M>,
-        E: Encoder<C>,
+        E: Encoder<Mode = M>,
     {
         encoder.encode_bytes(cx, self.as_slice())
     }
@@ -762,10 +734,9 @@ impl<M> EncodeBytes<M> for Vec<u8> {
 
 impl<'de, M> DecodeBytes<'de, M> for Vec<u8> {
     #[inline]
-    fn decode_bytes<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+    fn decode_bytes<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
     where
-        C: ?Sized + Context<Mode = M>,
-        D: Decoder<'de, C>,
+        D: Decoder<'de, Mode = M>,
     {
         struct Visitor;
 
@@ -797,10 +768,9 @@ impl<'de, M> DecodeBytes<'de, M> for Vec<u8> {
 
 impl<M> EncodeBytes<M> for VecDeque<u8> {
     #[inline]
-    fn encode_bytes<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode_bytes<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
     where
-        C: ?Sized + Context<Mode = M>,
-        E: Encoder<C>,
+        E: Encoder<Mode = M>,
     {
         let (first, second) = self.as_slices();
         encoder.encode_bytes_vectored(cx, self.len(), &[first, second])
@@ -809,10 +779,9 @@ impl<M> EncodeBytes<M> for VecDeque<u8> {
 
 impl<'de, M> DecodeBytes<'de, M> for VecDeque<u8> {
     #[inline]
-    fn decode_bytes<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+    fn decode_bytes<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
     where
-        C: ?Sized + Context<Mode = M>,
-        D: Decoder<'de, C>,
+        D: Decoder<'de, Mode = M>,
     {
         Ok(VecDeque::from(<Vec<u8>>::decode_bytes(cx, decoder)?))
     }

--- a/crates/musli/src/impls/net.rs
+++ b/crates/musli/src/impls/net.rs
@@ -6,10 +6,9 @@ use crate::Context;
 
 impl<M> Encode<M> for Ipv4Addr {
     #[inline]
-    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
     where
-        C: ?Sized + Context,
-        E: Encoder<C>,
+        E: Encoder,
     {
         encoder.encode_array(cx, &self.octets())
     }
@@ -17,10 +16,9 @@ impl<M> Encode<M> for Ipv4Addr {
 
 impl<'de, M> Decode<'de, M> for Ipv4Addr {
     #[inline]
-    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+    fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
     where
-        C: ?Sized + Context,
-        D: Decoder<'de, C>,
+        D: Decoder<'de>,
     {
         decoder.decode_array::<4>(cx).map(Ipv4Addr::from)
     }
@@ -28,10 +26,9 @@ impl<'de, M> Decode<'de, M> for Ipv4Addr {
 
 impl<M> Encode<M> for Ipv6Addr {
     #[inline]
-    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
     where
-        C: ?Sized + Context,
-        E: Encoder<C>,
+        E: Encoder,
     {
         encoder.encode_array(cx, &self.octets())
     }
@@ -39,10 +36,9 @@ impl<M> Encode<M> for Ipv6Addr {
 
 impl<'de, M> Decode<'de, M> for Ipv6Addr {
     #[inline]
-    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+    fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
     where
-        C: ?Sized + Context,
-        D: Decoder<'de, C>,
+        D: Decoder<'de>,
     {
         decoder.decode_array::<16>(cx).map(Ipv6Addr::from)
     }
@@ -57,10 +53,9 @@ enum IpAddrTag {
 
 impl<M> Encode<M> for IpAddr {
     #[inline]
-    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
     where
-        C: ?Sized + Context,
-        E: Encoder<C>,
+        E: Encoder,
     {
         let variant = encoder.encode_variant(cx)?;
 
@@ -73,10 +68,9 @@ impl<M> Encode<M> for IpAddr {
 
 impl<'de, M> Decode<'de, M> for IpAddr {
     #[inline]
-    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+    fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
     where
-        C: ?Sized + Context,
-        D: Decoder<'de, C>,
+        D: Decoder<'de>,
     {
         let mut variant = decoder.decode_variant(cx)?;
 
@@ -94,10 +88,9 @@ impl<'de, M> Decode<'de, M> for IpAddr {
 
 impl<M> Encode<M> for SocketAddrV4 {
     #[inline]
-    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
     where
-        C: ?Sized + Context,
-        E: Encoder<C>,
+        E: Encoder,
     {
         let mut pack = encoder.encode_pack(cx)?;
         pack.push(cx, self.ip())?;
@@ -108,10 +101,9 @@ impl<M> Encode<M> for SocketAddrV4 {
 
 impl<'de, M> Decode<'de, M> for SocketAddrV4 {
     #[inline]
-    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+    fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
     where
-        C: ?Sized + Context,
-        D: Decoder<'de, C>,
+        D: Decoder<'de>,
     {
         decoder.decode_pack_fn(cx, |pack| {
             Ok(SocketAddrV4::new(pack.next(cx)?, pack.next(cx)?))
@@ -121,10 +113,9 @@ impl<'de, M> Decode<'de, M> for SocketAddrV4 {
 
 impl<M> Encode<M> for SocketAddrV6 {
     #[inline]
-    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
     where
-        C: ?Sized + Context,
-        E: Encoder<C>,
+        E: Encoder,
     {
         let mut pack = encoder.encode_pack(cx)?;
         pack.push(cx, self.ip())?;
@@ -137,10 +128,9 @@ impl<M> Encode<M> for SocketAddrV6 {
 
 impl<'de, M> Decode<'de, M> for SocketAddrV6 {
     #[inline]
-    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+    fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
     where
-        C: ?Sized + Context,
-        D: Decoder<'de, C>,
+        D: Decoder<'de>,
     {
         decoder.decode_pack_fn(cx, |pack| {
             Ok(Self::new(
@@ -162,10 +152,9 @@ enum SocketAddrTag {
 
 impl<M> Encode<M> for SocketAddr {
     #[inline]
-    fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
     where
-        C: ?Sized + Context,
-        E: Encoder<C>,
+        E: Encoder,
     {
         let variant = encoder.encode_variant(cx)?;
 
@@ -178,10 +167,9 @@ impl<M> Encode<M> for SocketAddr {
 
 impl<'de, M> Decode<'de, M> for SocketAddr {
     #[inline]
-    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+    fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
     where
-        C: ?Sized + Context,
-        D: Decoder<'de, C>,
+        D: Decoder<'de>,
     {
         let mut variant = decoder.decode_variant(cx)?;
 

--- a/crates/musli/src/impls/range.rs
+++ b/crates/musli/src/impls/range.rs
@@ -11,10 +11,9 @@ macro_rules! implement {
         {
             #[inline]
             #[allow(unused_mut)]
-            fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+            fn encode<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
             where
-                C: ?Sized + Context<Mode = M>,
-                E: Encoder<C>,
+                E: Encoder<Mode = M>,
             {
                 let mut tuple = encoder.encode_tuple(cx, $count)?;
                 $(
@@ -29,10 +28,9 @@ macro_rules! implement {
             $($type: Decode<'de, M>,)*
         {
             #[inline]
-            fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+            fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
             where
-                C: ?Sized + Context<Mode = M>,
-                D: Decoder<'de, C>,
+                D: Decoder<'de, Mode = M>,
             {
                 let ($($field,)*) = cx.decode(decoder)?;
                 Ok($ty { $($field,)* })
@@ -48,10 +46,9 @@ macro_rules! implement_new {
             T: Encode<M>,
         {
             #[inline]
-            fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+            fn encode<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
             where
-                C: ?Sized + Context<Mode = M>,
-                E: Encoder<C>,
+                E: Encoder<Mode = M>,
             {
                 let mut tuple = encoder.encode_tuple(cx, $count)?;
                 $(self.$field().encode(cx, tuple.encode_next(cx)?)?;)*
@@ -64,10 +61,9 @@ macro_rules! implement_new {
             T: Decode<'de, M>,
         {
             #[inline]
-            fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+            fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
             where
-                C: ?Sized + Context<Mode = M>,
-                D: Decoder<'de, C>,
+                D: Decoder<'de, Mode = M>,
             {
                 let ($($field,)*) = Decode::decode(cx, decoder)?;
                 Ok($ty::new($($field,)*))

--- a/crates/musli/src/impls/tuples.rs
+++ b/crates/musli/src/impls/tuples.rs
@@ -43,10 +43,9 @@ macro_rules! declare {
     (($ty0:ident, $ident0:ident) $(, ($ty:ident, $ident:ident))* $(,)?) => {
         impl<M, $ty0 $(, $ty)*> Encode<M> for ($ty0, $($ty),*) where $ty0: Encode<M>, $($ty: Encode<M>),* {
             #[inline]
-            fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+            fn encode<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
             where
-                C: ?Sized + Context<Mode = M>,
-                E: Encoder<C>,
+                E: Encoder<Mode = M>,
             {
                 let mut pack = encoder.encode_tuple(cx, count!($ident0 $($ident)*))?;
                 let ($ident0, $($ident),*) = self;
@@ -58,10 +57,9 @@ macro_rules! declare {
 
         impl<'de, M, $ty0, $($ty,)*> Decode<'de, M> for ($ty0, $($ty),*) where $ty0: Decode<'de, M>, $($ty: Decode<'de, M>),* {
             #[inline]
-            fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+            fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
             where
-                C: ?Sized + Context<Mode = M>,
-                D: Decoder<'de, C>
+                D: Decoder<'de, Mode = M>,
             {
                 let mut tuple = decoder.decode_tuple(cx, count!($ident0 $($ident)*))?;
                 let $ident0 = cx.decode(tuple.decode_next(cx)?)?;
@@ -73,10 +71,9 @@ macro_rules! declare {
 
         impl<M, $ty0 $(,$ty)*> Encode<M> for Packed<($ty0, $($ty),*)> where $ty0: Encode<M>, $($ty: Encode<M>),* {
             #[inline]
-            fn encode<C, E>(&self, cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+            fn encode<E>(&self, cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
             where
-                C: ?Sized + Context<Mode = M>,
-                E: Encoder<C>,
+                E: Encoder<Mode = M>,
             {
                 let Packed(($ident0, $($ident),*)) = self;
                 let mut pack = encoder.encode_pack(cx)?;
@@ -88,10 +85,9 @@ macro_rules! declare {
 
         impl<'de, M, $ty0, $($ty,)*> Decode<'de, M> for Packed<($ty0, $($ty),*)> where $ty0: Decode<'de, M>, $($ty: Decode<'de, M>),* {
             #[inline]
-            fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+            fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
             where
-                C: ?Sized + Context<Mode = M>,
-                D: Decoder<'de, C>
+                D: Decoder<'de, Mode = M>,
             {
                 decoder.decode_pack_fn(cx, |pack| {
                     let $ident0 = pack.next(cx)?;

--- a/crates/musli/src/never.rs
+++ b/crates/musli/src/never.rs
@@ -53,14 +53,17 @@ pub enum NeverMarker {}
 ///
 /// ```
 /// use std::fmt;
+/// use std::marker::PhantomData;
 ///
 /// use musli::Context;
 /// use musli::de::Decoder;
 ///
-/// struct MyDecoder(u32);
+/// struct MyDecoder<C: ?Sized>(u32, PhantomData<C>);
 ///
 /// #[musli::decoder]
-/// impl<C: ?Sized + Context> Decoder<'_, C> for MyDecoder where {
+/// impl<C: ?Sized + Context> Decoder<'_> for MyDecoder<C> where {
+///     type Cx = C;
+///
 ///     fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 ///         write!(f, "32-bit unsigned integers")
 ///     }
@@ -80,8 +83,11 @@ pub struct Never<A = NeverMarker, B: ?Sized = NeverMarker> {
     _marker: marker::PhantomData<(A, B)>,
 }
 
-impl<'de, C: ?Sized + Context> Decoder<'de, C> for Never {
-    type WithContext<U> = Self
+impl<'de, C: ?Sized + Context> Decoder<'de> for Never<(), C> {
+    type Cx = C;
+    type Error = C::Error;
+    type Mode = C::Mode;
+    type WithContext<U> = Never<(), U>
     where
         U: Context;
     type DecodeBuffer = Self;
@@ -108,8 +114,9 @@ impl<'de, C: ?Sized + Context> Decoder<'de, C> for Never {
     }
 }
 
-impl<C: ?Sized + Context> AsDecoder<C> for Never {
-    type Decoder<'this> = Self;
+impl<C: ?Sized + Context> AsDecoder for Never<(), C> {
+    type Cx = C;
+    type Decoder<'this> = Self where Self: 'this;
 
     #[inline]
     fn as_decoder(&self, _: &C) -> Result<Self::Decoder<'_>, C::Error> {
@@ -117,8 +124,9 @@ impl<C: ?Sized + Context> AsDecoder<C> for Never {
     }
 }
 
-impl<'de, C: ?Sized + Context> StructFieldDecoder<'de, C> for Never {
-    type DecodeFieldName<'this> = Self;
+impl<'de, C: ?Sized + Context> StructFieldDecoder<'de> for Never<(), C> {
+    type Cx = C;
+    type DecodeFieldName<'this> = Self where Self: 'this;
     type DecodeFieldValue = Self;
 
     #[inline]
@@ -137,9 +145,10 @@ impl<'de, C: ?Sized + Context> StructFieldDecoder<'de, C> for Never {
     }
 }
 
-impl<'de, C: ?Sized + Context> MapEntriesDecoder<'de, C> for Never {
-    type DecodeMapEntryKey<'this> = Self;
-    type DecodeMapEntryValue<'this> = Self;
+impl<'de, C: ?Sized + Context> MapEntriesDecoder<'de> for Never<(), C> {
+    type Cx = C;
+    type DecodeMapEntryKey<'this> = Self where Self: 'this;
+    type DecodeMapEntryValue<'this> = Self where Self: 'this;
 
     #[inline]
     fn decode_map_entry_key(
@@ -165,8 +174,9 @@ impl<'de, C: ?Sized + Context> MapEntriesDecoder<'de, C> for Never {
     }
 }
 
-impl<'de, C: ?Sized + Context> StructDecoder<'de, C> for Never {
-    type DecodeField<'this> = Self;
+impl<'de, C: ?Sized + Context> StructDecoder<'de> for Never<(), C> {
+    type Cx = C;
+    type DecodeField<'this> = Self where Self: 'this;
     type IntoStructFields = Self;
 
     type __UseMusliStructDecoderAttributeMacro = ();
@@ -192,9 +202,10 @@ impl<'de, C: ?Sized + Context> StructDecoder<'de, C> for Never {
     }
 }
 
-impl<'de, C: ?Sized + Context> StructFieldsDecoder<'de, C> for Never {
-    type DecodeStructFieldName<'this> = Self;
-    type DecodeStructFieldValue<'this> = Self;
+impl<'de, C: ?Sized + Context> StructFieldsDecoder<'de> for Never<(), C> {
+    type Cx = C;
+    type DecodeStructFieldName<'this> = Self where Self: 'this;
+    type DecodeStructFieldValue<'this> = Self where Self: 'this;
 
     #[inline]
     fn decode_struct_field_name(
@@ -223,9 +234,10 @@ impl<'de, C: ?Sized + Context> StructFieldsDecoder<'de, C> for Never {
     }
 }
 
-impl<'de, C: ?Sized + Context> VariantDecoder<'de, C> for Never {
-    type DecodeTag<'this> = Self;
-    type DecodeVariant<'this> = Self;
+impl<'de, C: ?Sized + Context> VariantDecoder<'de> for Never<(), C> {
+    type Cx = C;
+    type DecodeTag<'this> = Self where Self: 'this;
+    type DecodeVariant<'this> = Self where Self: 'this;
 
     #[inline]
     fn decode_tag(&mut self, _: &C) -> Result<Self::DecodeTag<'_>, C::Error> {
@@ -248,8 +260,9 @@ impl<'de, C: ?Sized + Context> VariantDecoder<'de, C> for Never {
     }
 }
 
-impl<'de, C: ?Sized + Context> MapDecoder<'de, C> for Never {
-    type DecodeEntry<'this> = Self;
+impl<'de, C: ?Sized + Context> MapDecoder<'de> for Never<(), C> {
+    type Cx = C;
+    type DecodeEntry<'this> = Self where Self: 'this;
     type IntoMapEntries = Self;
 
     type __UseMusliMapDecoderAttributeMacro = ();
@@ -275,8 +288,9 @@ impl<'de, C: ?Sized + Context> MapDecoder<'de, C> for Never {
     }
 }
 
-impl<'de, C: ?Sized + Context> MapEntryDecoder<'de, C> for Never {
-    type DecodeMapKey<'this> = Self;
+impl<'de, C: ?Sized + Context> MapEntryDecoder<'de> for Never<(), C> {
+    type Cx = C;
+    type DecodeMapKey<'this> = Self where Self: 'this;
     type DecodeMapValue = Self;
 
     #[inline]
@@ -295,8 +309,9 @@ impl<'de, C: ?Sized + Context> MapEntryDecoder<'de, C> for Never {
     }
 }
 
-impl<'de, C: ?Sized + Context> SequenceDecoder<'de, C> for Never {
-    type DecodeNext<'this> = Self;
+impl<'de, C: ?Sized + Context> SequenceDecoder<'de> for Never<(), C> {
+    type Cx = C;
+    type DecodeNext<'this> = Self where Self: 'this;
 
     #[inline]
     fn size_hint(&self, _: &C) -> SizeHint {
@@ -314,8 +329,9 @@ impl<'de, C: ?Sized + Context> SequenceDecoder<'de, C> for Never {
     }
 }
 
-impl<'de, C: ?Sized + Context> PackDecoder<'de, C> for Never {
-    type DecodeNext<'this> = Self;
+impl<'de, C: ?Sized + Context> PackDecoder<'de> for Never<(), C> {
+    type Cx = C;
+    type DecodeNext<'this> = Self where Self: 'this;
 
     #[inline]
     fn decode_next(&mut self, _: &C) -> Result<Self::DecodeNext<'_>, C::Error> {
@@ -328,10 +344,13 @@ impl<'de, C: ?Sized + Context> PackDecoder<'de, C> for Never {
     }
 }
 
-impl<C: ?Sized + Context, O: 'static> Encoder<C> for Never<O> {
+impl<C: ?Sized + Context, O: 'static> Encoder for Never<O, C> {
+    type Cx = C;
+    type Error = C::Error;
     type Ok = O;
-    type WithContext<U> = Self where U: Context;
-    type EncodePack<'this> = Self where C: 'this;
+    type Mode = C::Mode;
+    type WithContext<U> = Never<O, U> where U: Context;
+    type EncodePack<'this> = Self where Self::Cx: 'this;
     type EncodeSome = Self;
     type EncodeSequence = Self;
     type EncodeTuple = Self;
@@ -377,9 +396,10 @@ where
     }
 }
 
-impl<O: 'static, C: ?Sized + Context> SequenceEncoder<C> for Never<O> {
+impl<O: 'static, C: ?Sized + Context> SequenceEncoder for Never<O, C> {
+    type Cx = C;
     type Ok = O;
-    type EncodeNext<'this> = Self;
+    type EncodeNext<'this> = Self where Self: 'this;
 
     #[inline]
     fn encode_next(&mut self, _: &C) -> Result<Self::EncodeNext<'_>, C::Error> {
@@ -392,9 +412,10 @@ impl<O: 'static, C: ?Sized + Context> SequenceEncoder<C> for Never<O> {
     }
 }
 
-impl<O: 'static, C: ?Sized + Context> MapEncoder<C> for Never<O> {
+impl<O: 'static, C: ?Sized + Context> MapEncoder for Never<O, C> {
+    type Cx = C;
     type Ok = O;
-    type EncodeEntry<'this> = Self;
+    type EncodeEntry<'this> = Self where Self: 'this;
 
     #[inline]
     fn encode_entry(&mut self, _: &C) -> Result<Self::EncodeEntry<'_>, C::Error> {
@@ -406,10 +427,11 @@ impl<O: 'static, C: ?Sized + Context> MapEncoder<C> for Never<O> {
     }
 }
 
-impl<O: 'static, C: ?Sized + Context> MapEntryEncoder<C> for Never<O> {
+impl<O: 'static, C: ?Sized + Context> MapEntryEncoder for Never<O, C> {
+    type Cx = C;
     type Ok = O;
-    type EncodeMapKey<'this> = Self;
-    type EncodeMapValue<'this> = Self;
+    type EncodeMapKey<'this> = Self where Self: 'this;
+    type EncodeMapValue<'this> = Self where Self: 'this;
 
     #[inline]
     fn encode_map_key(&mut self, _: &C) -> Result<Self::EncodeMapKey<'_>, C::Error> {
@@ -427,10 +449,11 @@ impl<O: 'static, C: ?Sized + Context> MapEntryEncoder<C> for Never<O> {
     }
 }
 
-impl<O: 'static, C: ?Sized + Context> MapEntriesEncoder<C> for Never<O> {
+impl<O: 'static, C: ?Sized + Context> MapEntriesEncoder for Never<O, C> {
+    type Cx = C;
     type Ok = O;
-    type EncodeMapEntryKey<'this> = Self;
-    type EncodeMapEntryValue<'this> = Self;
+    type EncodeMapEntryKey<'this> = Self where Self: 'this;
+    type EncodeMapEntryValue<'this> = Self where Self: 'this;
 
     #[inline]
     fn encode_map_entry_key(&mut self, _: &C) -> Result<Self::EncodeMapEntryKey<'_>, C::Error> {
@@ -448,9 +471,10 @@ impl<O: 'static, C: ?Sized + Context> MapEntriesEncoder<C> for Never<O> {
     }
 }
 
-impl<O: 'static, C: ?Sized + Context> StructEncoder<C> for Never<O> {
+impl<O: 'static, C: ?Sized + Context> StructEncoder for Never<O, C> {
+    type Cx = C;
     type Ok = O;
-    type EncodeField<'this> = Self;
+    type EncodeField<'this> = Self where Self: 'this;
 
     #[inline]
     fn encode_field(&mut self, _: &C) -> Result<Self::EncodeField<'_>, C::Error> {
@@ -462,10 +486,11 @@ impl<O: 'static, C: ?Sized + Context> StructEncoder<C> for Never<O> {
     }
 }
 
-impl<O: 'static, C: ?Sized + Context> StructFieldEncoder<C> for Never<O> {
+impl<O: 'static, C: ?Sized + Context> StructFieldEncoder for Never<O, C> {
+    type Cx = C;
     type Ok = O;
-    type EncodeFieldName<'this> = Self;
-    type EncodeFieldValue<'this> = Self;
+    type EncodeFieldName<'this> = Self where Self: 'this;
+    type EncodeFieldValue<'this> = Self where Self: 'this;
 
     #[inline]
     fn encode_field_name(&mut self, _: &C) -> Result<Self::EncodeFieldName<'_>, C::Error> {
@@ -483,10 +508,11 @@ impl<O: 'static, C: ?Sized + Context> StructFieldEncoder<C> for Never<O> {
     }
 }
 
-impl<O: 'static, C: ?Sized + Context> VariantEncoder<C> for Never<O> {
+impl<O: 'static, C: ?Sized + Context> VariantEncoder for Never<O, C> {
+    type Cx = C;
     type Ok = O;
-    type EncodeTag<'this> = Self;
-    type EncodeValue<'this> = Self;
+    type EncodeTag<'this> = Self where Self: 'this;
+    type EncodeValue<'this> = Self where Self: 'this;
 
     #[inline]
     fn encode_tag(&mut self, _: &C) -> Result<Self::EncodeTag<'_>, C::Error> {

--- a/crates/musli/src/utils/visit_owned_fn.rs
+++ b/crates/musli/src/utils/visit_owned_fn.rs
@@ -21,12 +21,11 @@ use crate::Context;
 /// }
 ///
 /// impl<'de, M> Decode<'de, M> for Enum {
-///     fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+///     fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
 ///     where
-///         C: ?Sized + Context,
-///         D: Decoder<'de, C>,
+///         D: Decoder<'de>,
 ///     {
-///         decoder.decode_string(cx, musli::utils::visit_owned_fn("A string variant for Enum", |cx: &C, variant: &str| {
+///         decoder.decode_string(cx, musli::utils::visit_owned_fn("A string variant for Enum", |cx: &D::Cx, variant: &str| {
 ///             match variant {
 ///                 "A" => Ok(Enum::A),
 ///                 "B" => Ok(Enum::A),

--- a/crates/tests/tests/ui/custom_decoder_error.rs
+++ b/crates/tests/tests/ui/custom_decoder_error.rs
@@ -8,20 +8,17 @@ pub struct Container<'a> {
 
 mod bytes {
     use musli::{Decoder, Encoder};
-    use musli::Context;
 
-    pub(crate) fn encode<C, E>(this: &[u8], cx: &C, mut encoder: E) -> Result<(), C::Error>
+    pub(crate) fn encode<E>(this: &[u8], cx: &E::Cx, mut encoder: E) -> Result<(), E::Error>
     where
-        C: ?Sized + Context,
-        E: Encoder<C>,
+        E: Encoder,
     {
         todo!()
     }
 
-    pub(crate) fn decode<'de, C, D>(cx: &C, mut decoder: D) -> Result<Vec<u8>, C::Error>
+    pub(crate) fn decode<'de, D>(cx: &D::Cx, mut decoder: D) -> Result<Vec<u8>, D::Error>
     where
-        C: ?Sized + Context,
-        D: Decoder<'de, C>,
+        D: Decoder<'de>,
     {
         todo!()
     }

--- a/crates/tests/tests/ui/private_fn_error.rs
+++ b/crates/tests/tests/ui/private_fn_error.rs
@@ -7,22 +7,20 @@ struct Struct {
 }
 
 mod array {
-    use musli::{Context, Encoder, Decoder};
+    use musli::{Encoder, Decoder};
 
     #[inline]
-    fn encode<C, E, T, const N: usize>(this: &[T; N], cx: &C, encoder: E) -> Result<E::Ok, C::Error>
+    fn encode<E, T, const N: usize>(this: &[T; N], cx: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
     where
-        C: ?Sized + Context,
-        E: Encoder<C>,
+        E: Encoder,
     {
         todo!()
     }
 
     #[inline]
-    fn decode<'de, C, D, T, const N: usize>(cx: &C, decoder: D) -> Result<[T; N], C::Error>
+    fn decode<'de, D, T, const N: usize>(cx: &D::Cx, decoder: D) -> Result<[T; N], D::Error>
     where
-        C: ?Sized + Context,
-        D: Decoder<'de, C>,
+        D: Decoder<'de>,
     {
         todo!()
     }

--- a/crates/tests/tests/ui/private_fn_error.stderr
+++ b/crates/tests/tests/ui/private_fn_error.stderr
@@ -5,13 +5,12 @@ error[E0603]: function `decode` is private
    |                          ^^^^^ private function
    |
 note: the function `decode` is defined here
-  --> tests/ui/private_fn_error.rs:22:5
+  --> tests/ui/private_fn_error.rs:21:5
    |
-22 | /     fn decode<'de, C, D, T, const N: usize>(cx: &C, decoder: D) -> Result<[T; N], C::Error>
-23 | |     where
-24 | |         C: ?Sized + Context,
-25 | |         D: Decoder<'de, C>,
-26 | |     {
-27 | |         todo!()
-28 | |     }
+21 | /     fn decode<'de, D, T, const N: usize>(cx: &D::Cx, decoder: D) -> Result<[T; N], D::Error>
+22 | |     where
+23 | |         D: Decoder<'de>,
+24 | |     {
+25 | |         todo!()
+26 | |     }
    | |_____^

--- a/crates/tests/tests/visitors.rs
+++ b/crates/tests/tests/visitors.rs
@@ -10,10 +10,9 @@ pub struct BytesReference<'de> {
 
 impl<'de, M> Decode<'de, M> for BytesReference<'de> {
     #[inline]
-    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+    fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
     where
-        C: ?Sized + Context,
-        D: Decoder<'de, C>,
+        D: Decoder<'de>,
     {
         struct Visitor;
 
@@ -67,10 +66,9 @@ pub struct StringReference<'de> {
 
 impl<'de, M> Decode<'de, M> for StringReference<'de> {
     #[inline]
-    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+    fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
     where
-        C: ?Sized + Context,
-        D: Decoder<'de, C>,
+        D: Decoder<'de>,
     {
         struct Visitor;
 
@@ -122,22 +120,22 @@ pub enum OwnedFn {
 }
 
 impl<'de, M> Decode<'de, M> for OwnedFn {
-    fn decode<C, D>(cx: &C, decoder: D) -> Result<Self, C::Error>
+    fn decode<D>(cx: &D::Cx, decoder: D) -> Result<Self, D::Error>
     where
-        C: ?Sized + Context,
-        D: Decoder<'de, C>,
+        D: Decoder<'de>,
     {
         decoder.decode_string(
             cx,
-            musli::utils::visit_owned_fn("A string variant for Enum", |cx: &C, variant: &str| {
-                match variant {
+            musli::utils::visit_owned_fn(
+                "A string variant for Enum",
+                |cx: &D::Cx, variant: &str| match variant {
                     "A" => Ok(OwnedFn::A),
                     "B" => Ok(OwnedFn::A),
                     other => {
                         Err(cx.message(format_args!("Expected either 'A' or 'B' but got {other}")))
                     }
-                }
-            }),
+                },
+            ),
         )
     }
 }


### PR DESCRIPTION
This vastly simplifies how encode and decode methods are built, at the cost of making associated types in the trait declaration more complicated.

Since the user-facing API most of the time will be through implementing `Encode` / `Decode`, it is well worth it.