### PR TITLE
Fix packing for descriptive

### DIFF
--- a/crates/musli-descriptive/src/de.rs
+++ b/crates/musli-descriptive/src/de.rs
@@ -103,10 +103,6 @@ where
 
                     self.reader.skip(self.cx, len)?;
                 }
-                Kind::Pack => {
-                    let len = 2usize.pow(tag.data_raw() as u32);
-                    self.reader.skip(self.cx, len)?;
-                }
                 Kind::Sequence => {
                     let len = if let Some(len) = tag.data() {
                         len as usize
@@ -189,13 +185,6 @@ where
             } else {
                 musli_common::int::decode_usize::<_, _, OPT>(self.cx, self.reader.borrow_mut())?
             }),
-            Kind::Pack => {
-                let Some(len) = 2usize.checked_pow(tag.data_raw() as u32) else {
-                    return Err(self.cx.message("Pack tag overflowed"));
-                };
-
-                Ok(len)
-            }
             _ => Err(self.cx.marked_message(start, "Expected prefix or pack")),
         }
     }

--- a/crates/musli-descriptive/src/tag.rs
+++ b/crates/musli-descriptive/src/tag.rs
@@ -90,9 +90,9 @@ pub enum Kind {
     /// A marker value.
     Mark = 0b110_00000,
     /// Reserved.
-    Pack = 0b101_00000,
+    Reserved0 = 0b101_00000,
     /// Reserved.
-    Reserved0 = 0b111_00000,
+    Reserved1 = 0b111_00000,
 }
 
 /// A type tag.

--- a/crates/musli-descriptive/src/tests.rs
+++ b/crates/musli-descriptive/src/tests.rs
@@ -61,17 +61,19 @@ fn pack_max() {
 }
 
 #[test]
-fn pow2() {
+fn max_inline_length() {
     macro_rules! test {
-        ($size:literal, $pow:expr, $pad:expr) => {
+        ($size:expr, $inline:expr, $pad:expr) => {
             let value = From {
                 prefix: Some(10),
-                field: Field { value: [1; $size] },
+                field: Field {
+                    value: [1; { $size }],
+                },
                 suffix: Some(20),
             };
 
             let bytes = crate::to_vec(&value).unwrap();
-            let actual: From<$size> = crate::from_slice(&bytes).unwrap();
+            let actual: From<{ $size }> = crate::from_slice(&bytes).unwrap();
             let to: To = crate::from_slice(&bytes).unwrap();
 
             assert_eq!(actual, value);
@@ -83,13 +85,10 @@ fn pow2() {
                 }
             );
 
-            assert_eq!(Tag::from_byte(bytes[8]), Tag::new(Kind::Pack, $pow));
-            assert_eq!(bytes.len(), $size + $pad);
-            let start = $size + 9;
-            assert!(bytes[start..start + 18].iter().all(|b| *b == 0));
+            assert_eq!(Tag::from_byte(bytes[8]), Tag::new(Kind::Bytes, $inline));
         };
     }
 
-    test!(110, 7, 32);
-    test!(200, 8, 70);
+    test!(MAX_INLINE_LEN, MAX_INLINE_LEN as u8, 32);
+    test!(MAX_INLINE_LEN + 10, (MAX_INLINE_LEN + 1) as u8, 70);
 }

--- a/crates/tests/tests/pack_compat.rs
+++ b/crates/tests/tests/pack_compat.rs
@@ -2,50 +2,41 @@
 
 #![cfg(feature = "test")]
 
-use musli::mode::DefaultMode;
 use musli::{Decode, Encode};
-use tests::wire::tag::MAX_INLINE_LEN;
-use tests::wire::Encoding;
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 pub struct Inner;
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 #[musli(packed)]
-struct SmallPack {
+struct Packed<const N: usize> {
+    header: u32,
     #[musli(bytes)]
-    small: [u8; MAX_INLINE_LEN],
+    values: [u8; N],
 }
 
 #[derive(Debug, PartialEq, Encode, Decode)]
-#[musli(packed)]
-struct LargePack {
-    #[musli(bytes)]
-    large: [u8; 128],
-}
-
-#[derive(Debug, PartialEq, Encode, Decode)]
-struct SmallPackCompat {
+struct PackedCompat<const N: usize, const L: usize> {
     prefix: u32,
-    small_pack: SmallPack,
-    large_pack: LargePack,
+    small: Packed<N>,
+    large: Packed<L>,
     suffix: u32,
 }
 
 #[derive(Debug, PartialEq, Encode, Decode)]
-struct IgnoreLarge {
+struct IgnoreLarge<const N: usize> {
     prefix: u32,
     #[musli(rename = 1)]
-    small_pack: SmallPack,
+    small: Packed<N>,
     #[musli(rename = 3)]
     suffix: u32,
 }
 
 #[derive(Debug, PartialEq, Encode, Decode)]
-struct IgnoreSmall {
+struct IgnoreSmall<const L: usize> {
     prefix: u32,
     #[musli(rename = 2)]
-    large_pack: LargePack,
+    large: Packed<L>,
     #[musli(rename = 3)]
     suffix: u32,
 }
@@ -57,49 +48,76 @@ struct IgnoreBoth {
     suffix: u32,
 }
 
-#[test]
-fn packed_compat() {
-    const ENCODING: Encoding<DefaultMode> = Encoding::new();
+const fn array<const N: usize>() -> [u8; N] {
+    let mut array = [0; N];
+    let mut i = 0;
 
-    let data = ENCODING
-        .to_vec(&SmallPackCompat {
+    while i < N {
+        array[i] = i as u8;
+        i += 1;
+    }
+
+    array
+}
+
+fn test_length<const N: usize, const L: usize>() {
+    tests::rt! {
+        upgrade_stable,
+        PackedCompat {
             prefix: 42,
-            small_pack: SmallPack {
-                small: [0; MAX_INLINE_LEN],
-            },
-            large_pack: LargePack { large: [0; 128] },
+            small: Packed { header: 42, values: array::<N>() },
+            large: Packed { header: 42, values: array::<L>() },
             suffix: 84,
-        })
-        .unwrap();
+        }
+    };
 
-    let actual: IgnoreSmall = ENCODING.from_slice(data.as_slice()).unwrap();
-    assert_eq!(
-        actual,
+    tests::assert_decode_eq! {
+        upgrade_stable,
+        PackedCompat {
+            prefix: 42,
+            small: Packed { header: 42, values: array::<N>() },
+            large: Packed { header: 42, values: array::<L>() },
+            suffix: 84,
+        },
         IgnoreSmall {
             prefix: 42,
-            large_pack: LargePack { large: [0; 128] },
+            large: Packed { header: 42, values: array::<L>() },
             suffix: 84
         }
-    );
+    };
 
-    let actual: IgnoreLarge = ENCODING.from_slice(data.as_slice()).unwrap();
-    assert_eq!(
-        actual,
+    tests::assert_decode_eq! {
+        upgrade_stable,
+        PackedCompat {
+            prefix: 42,
+            small: Packed { header: 42, values: array::<N>() },
+            large: Packed { header: 42, values: array::<L>() },
+            suffix: 84,
+        },
         IgnoreLarge {
             prefix: 42,
-            small_pack: SmallPack {
-                small: [0; MAX_INLINE_LEN]
-            },
+            small: Packed { header: 42, values: array::<N>() },
             suffix: 84
         }
-    );
+    };
 
-    let actual: IgnoreBoth = ENCODING.from_slice(data.as_slice()).unwrap();
-    assert_eq!(
-        actual,
+    tests::assert_decode_eq! {
+        upgrade_stable,
+        PackedCompat {
+            prefix: 42,
+            small: Packed { header: 42, values: array::<N>() },
+            large: Packed { header: 42, values: array::<L>() },
+            suffix: 84,
+        },
         IgnoreBoth {
             prefix: 42,
             suffix: 84
         }
-    );
+    };
+}
+
+#[test]
+fn test_lengths() {
+    test_length::<{ tests::wire::tag::MAX_INLINE_LEN - 4 }, 256>();
+    test_length::<{ tests::descriptive::tag::MAX_INLINE_LEN - 4 }, 256>();
 }


### PR DESCRIPTION
Packing in descriptive now happens with a regular Bytes type, to ensure that musli-value transcoding works correctly.