### PR TITLE
Implement explicit defaults for fields

### DIFF
--- a/crates/musli-macros/src/internals/attr.rs
+++ b/crates/musli-macros/src/internals/attr.rs
@@ -573,7 +573,7 @@ layer! {
         /// Rename a field to the given literal.
         rename: syn::Expr,
         /// Use a default value for the field if it's not available.
-        is_default: (),
+        is_default: Option<syn::Path>,
         /// Use a default value for the field if it's not available.
         skip: FieldSkip,
         /// Use the alternate TraceDecode for the field.
@@ -696,7 +696,13 @@ pub(crate) fn field_attrs(cx: &Ctxt, attrs: &[syn::Attribute]) -> Field {
 
             // parse #[musli(default)]
             if meta.path.is_ident("default") {
-                new.is_default.push((meta.path.span(), ()));
+                if meta.input.parse::<Option<Token![=]>>()?.is_some() {
+                    new.is_default
+                        .push((meta.path.span(), Some(meta.input.parse()?)));
+                } else {
+                    new.is_default.push((meta.path.span(), None));
+                }
+
                 return Ok(());
             }
 

--- a/crates/musli-macros/src/internals/build.rs
+++ b/crates/musli-macros/src/internals/build.rs
@@ -179,7 +179,7 @@ pub(crate) struct Field<'a> {
     pub(crate) tag: syn::Expr,
     pub(crate) skip_encoding_if: Option<&'a (Span, syn::Path)>,
     /// Fill with default value, if missing.
-    pub(crate) default_attr: Option<Span>,
+    pub(crate) default_attr: Option<(Span, Option<&'a syn::Path>)>,
     /// Skip field entirely and always initialize with the specified expresion,
     /// or default value if none is specified.
     pub(crate) skip: Option<&'a FieldSkip>,
@@ -420,7 +420,10 @@ fn setup_field<'a>(
     let (tag, tag_method) = data.expand_tag(e, mode, default_field)?;
     tag_methods.insert(data.span, tag_method);
     let skip_encoding_if = data.attr.skip_encoding_if(mode);
-    let default_attr = data.attr.is_default(mode).map(|&(s, ())| s);
+    let default_attr = data
+        .attr
+        .is_default(mode)
+        .map(|(s, path)| (*s, path.as_ref()));
     let skip = data.attr.skip(mode).map(|(_, skip)| skip);
 
     let member = match data.ident {

--- a/crates/musli/src/derives.rs
+++ b/crates/musli/src/derives.rs
@@ -583,6 +583,12 @@
 //!     name: String,
 //!     #[musli(default)]
 //!     age: Option<u32>,
+//!     #[musli(default = default_height)]
+//!     height: Option<u32>,
+//! }
+//!
+//! fn default_height() -> Option<u32> {
+//!     Some(180)
 //! }
 //! ```
 //!

--- a/crates/tests/tests/default_value.rs
+++ b/crates/tests/tests/default_value.rs
@@ -16,16 +16,28 @@ struct StructWithDefault {
     country: String,
 }
 
-fn is_zero(value: &u32) -> bool {
-    *value == 0
-}
-
 #[derive(Debug, PartialEq, Encode, Decode)]
 struct StructWithOption {
     name: String,
     #[musli(default, skip_encoding_if = Option::is_none)]
     age: Option<u32>,
     country: String,
+}
+
+#[derive(Debug, PartialEq, Encode, Decode)]
+struct StructWithDefaultValue {
+    name: String,
+    #[musli(default = default_age, skip_encoding_if = is_zero)]
+    age: u32,
+    country: String,
+}
+
+fn is_zero(value: &u32) -> bool {
+    *value == 0
+}
+
+fn default_age() -> u32 {
+    180
 }
 
 // Ensure that skipped over fields ensures compatibility.
@@ -74,6 +86,36 @@ fn decode_with_default() -> Result<(), Box<dyn std::error::Error>> {
             country: String::from("Greece"),
         },
         json = r#"{"0":"Aristotle","2":"Greece"}"#,
+    );
+
+    tests::assert_decode_eq!(
+        full,
+        StructWithDefaultValue {
+            name: String::from("Aristotle"),
+            age: 0,
+            country: String::from("Greece"),
+        },
+        StructWithDefaultValue {
+            name: String::from("Aristotle"),
+            age: 180,
+            country: String::from("Greece"),
+        },
+        json = r#"{"0":"Aristotle","2":"Greece"}"#,
+    );
+
+    tests::assert_decode_eq!(
+        full,
+        StructWithDefaultValue {
+            name: String::from("Aristotle"),
+            age: 170,
+            country: String::from("Greece"),
+        },
+        StructWithDefaultValue {
+            name: String::from("Aristotle"),
+            age: 170,
+            country: String::from("Greece"),
+        },
+        json = r#"{"0":"Aristotle","1":170,"2":"Greece"}"#,
     );
 
     Ok(())


### PR DESCRIPTION
This adds support for specifying a default value with `#[musli(default = <path>)]` for a field.