### PR TITLE
Use default attribute when constructing skipped values

### DIFF
--- a/crates/musli-macros/src/internals/attr.rs
+++ b/crates/musli-macros/src/internals/attr.rs
@@ -12,8 +12,6 @@ use crate::expander::TagMethod;
 use crate::internals::ATTR;
 use crate::internals::{Ctxt, Mode};
 
-use super::build::FieldSkip;
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum Only {
     Encode,
@@ -575,7 +573,7 @@ layer! {
         /// Use a default value for the field if it's not available.
         is_default: Option<syn::Path>,
         /// Use a default value for the field if it's not available.
-        skip: FieldSkip,
+        skip: (),
         /// Use the alternate TraceDecode for the field.
         trace: (),
         /// Use the alternate EncodeBytes for the field.
@@ -706,15 +704,9 @@ pub(crate) fn field_attrs(cx: &Ctxt, attrs: &[syn::Attribute]) -> Field {
                 return Ok(());
             }
 
-            // parse #[musli(skip [= <path>])]
+            // parse #[musli(skip)]
             if meta.path.is_ident("skip") {
-                let skip = if meta.input.parse::<Option<Token![=]>>()?.is_some() {
-                    FieldSkip::Expr(meta.input.parse()?)
-                } else {
-                    FieldSkip::Default(meta.path.span())
-                };
-
-                new.skip.push((meta.path.span(), skip));
+                new.skip.push((meta.path.span(), ()));
                 return Ok(());
             }
 

--- a/crates/musli/src/derives.rs
+++ b/crates/musli/src/derives.rs
@@ -533,8 +533,12 @@
 //! struct Struct {
 //!     #[musli(rename = "other")]
 //!     something: String,
-//!     #[musli(skip = 42)]
+//!     #[musli(skip, default = default_field)]
 //!     skipped_field: u32,
+//! }
+//!
+//! fn default_field() -> u32 {
+//!     42
 //! }
 //!
 //! #[derive(Encode, Decode)]
@@ -549,11 +553,11 @@
 //!
 //! <br>
 //!
-//! #### `#[musli(skip [= <expr>])]`
+//! #### `#[musli(skip)]`
 //!
 //! This attribute means that the entire field is skipped. If a field is decoded
-//! it either uses the provided `<expr>` to construct the value, or tries and
-//! initialize it with [`Default::default`].
+//! it uses [`Default::default`] to construct the value. Other defaults can be
+//! specified with [`#[musli(default = <path>)]`][#muslidefault--path].
 //!
 //! ```
 //! use musli::{Encode, Decode};
@@ -563,17 +567,27 @@
 //!     name: String,
 //!     #[musli(skip)]
 //!     age: Option<u32>,
-//!     #[musli(skip = Some(String::from("Earth")))]
+//!     #[musli(skip, default = default_country)]
 //!     country: Option<String>,
+//! }
+//!
+//! fn default_country() -> Option<String> {
+//!     Some(String::from("Earth"))
 //! }
 //! ```
 //!
 //! <br>
 //!
-//! #### `#[musli(default)]`
+//! #### `#[musli(default [= <path>])]`
 //!
-//! This constructs the field using [`Default::default`] in case it's not
-//! available. This is only used when a field is missing during decoding.
+//! When a field is absent or disabled with `#[musli(skip)]`, this attribute
+//! specifies that a default value should be used instead.
+//!
+//! If `#[musli(default)]` is specified, the default value is constructed using
+//! [`Default::default`].
+//!
+//! If `#[musli(default = <path>)]` is specified, the default value is
+//! constructed by calling the function at `<path>`.
 //!
 //! ```
 //! use musli::{Encode, Decode};
@@ -585,10 +599,16 @@
 //!     age: Option<u32>,
 //!     #[musli(default = default_height)]
 //!     height: Option<u32>,
+//!     #[musli(skip, default = default_meaning)]
+//!     meaning: u32,
 //! }
 //!
 //! fn default_height() -> Option<u32> {
 //!     Some(180)
+//! }
+//!
+//! fn default_meaning() -> u32 {
+//!     42
 //! }
 //! ```
 //!

--- a/crates/tests/tests/skip.rs
+++ b/crates/tests/tests/skip.rs
@@ -12,10 +12,18 @@ struct Inner {
 pub struct AllSkipped {
     #[musli(skip)]
     skip: u32,
-    #[musli(skip = 42)]
+    #[musli(skip, default = skip_default)]
     skip_default: u32,
-    #[musli(skip = Some(Inner { a: 1, b: 2 }))]
+    #[musli(skip, default = skip_complex_field)]
     complex_field: Option<Inner>,
+}
+
+fn skip_default() -> u32 {
+    42
+}
+
+fn skip_complex_field() -> Option<Inner> {
+    Some(Inner { a: 1, b: 2 })
 }
 
 #[test]


### PR DESCRIPTION
This changes `#[musli(skip = <expr>)]` to instead use `#[musli(skip, default = <path>)]` when constructing default values for skipped fields. Skip implies `#[musli(default)]` if an option is not specified.