### PR TITLE
Naming improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ to support it. Luckily, the implementation is also quite good!
 The following is an example of *full upgrade stability* using
 [`musli-wire`]. `Version1` can be decoded from an instance of `Version2`
 because it understands how to skip fields which are part of `Version2`.
-We're also explicitly adding `#[musli(rename = ..)]` to the fields to ensure
+We're also explicitly adding `#[musli(name = ..)]` to the fields to ensure
 that they don't change in case they are re-ordered.
 
 ```rust
@@ -232,15 +232,15 @@ use musli::{Encode, Decode};
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 struct Version1 {
-    #[musli(rename = 0)]
+    #[musli(name = 0)]
     name: String,
 }
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 struct Version2 {
-    #[musli(rename = 0)]
+    #[musli(name = 0)]
     name: String,
-    #[musli(default, rename = 1)]
+    #[musli(default, name = 1)]
     age: Option<u32>,
 }
 

--- a/crates/musli-descriptive/src/tests.rs
+++ b/crates/musli-descriptive/src/tests.rs
@@ -4,19 +4,19 @@ use crate::tag::{Kind, Tag, MAX_INLINE_LEN};
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 struct From<const N: usize> {
-    #[musli(rename = 0)]
+    #[musli(name = 0)]
     prefix: Option<u32>,
-    #[musli(rename = 1)]
+    #[musli(name = 1)]
     field: Field<N>,
-    #[musli(rename = 2)]
+    #[musli(name = 2)]
     suffix: Option<u32>,
 }
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 struct To {
-    #[musli(rename = 0)]
+    #[musli(name = 0)]
     prefix: Option<u32>,
-    #[musli(rename = 2)]
+    #[musli(name = 2)]
     suffix: Option<u32>,
 }
 

--- a/crates/musli-macros/src/de.rs
+++ b/crates/musli-macros/src/de.rs
@@ -4,11 +4,12 @@ use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::Token;
 
-use crate::expander::{Result, TagMethod};
+use crate::expander::TagMethod;
 use crate::internals::apply;
 use crate::internals::attr::{EnumTag, EnumTagging, Packing};
 use crate::internals::build::{Body, Build, BuildData, Enum, Field, Variant};
 use crate::internals::tokens::Tokens;
+use crate::internals::Result;
 
 struct Ctxt<'a> {
     ctx_var: &'a Ident,

--- a/crates/musli-macros/src/en.rs
+++ b/crates/musli-macros/src/en.rs
@@ -3,10 +3,10 @@ use quote::quote;
 use syn::punctuated::Punctuated;
 use syn::Token;
 
-use crate::expander::Result;
 use crate::internals::attr::{EnumTag, EnumTagging, Packing};
 use crate::internals::build::{Body, Build, BuildData, Enum, Variant};
 use crate::internals::tokens::Tokens;
+use crate::internals::Result;
 
 struct Ctxt<'a> {
     ctx_var: &'a syn::Ident,

--- a/crates/musli-macros/src/internals/mod.rs
+++ b/crates/musli-macros/src/internals/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod build;
 mod ctxt;
 mod expansion;
 mod mode;
+pub(crate) mod rename;
 pub(crate) mod tokens;
 
 pub(crate) const ATTR: &str = "musli";

--- a/crates/musli-macros/src/internals/mod.rs
+++ b/crates/musli-macros/src/internals/mod.rs
@@ -12,3 +12,5 @@ pub(crate) use self::attr::Only;
 pub(crate) use self::ctxt::Ctxt;
 pub(crate) use self::expansion::Expansion;
 pub(crate) use self::mode::Mode;
+
+pub(crate) type Result<T, E = ()> = std::result::Result<T, E>;

--- a/crates/musli-macros/src/internals/rename.rs
+++ b/crates/musli-macros/src/internals/rename.rs
@@ -1,0 +1,154 @@
+use core::fmt;
+use core::mem::take;
+
+#[derive(Debug, Clone, Copy)]
+#[allow(clippy::enum_variant_names)]
+pub(crate) enum RenameAll {
+    PascalCase,
+    CamelCase,
+    SnakeCase,
+    ScreamingSnakeCase,
+    KebabCase,
+    ScreamingKebabCase,
+}
+
+impl RenameAll {
+    pub(crate) const ALL: &'static [Self] = &[
+        Self::PascalCase,
+        Self::CamelCase,
+        Self::SnakeCase,
+        Self::ScreamingSnakeCase,
+        Self::KebabCase,
+        Self::ScreamingKebabCase,
+    ];
+
+    pub(crate) fn parse(input: &str) -> Option<Self> {
+        match input {
+            "PascalCase" => Some(Self::PascalCase),
+            "camelCase" => Some(Self::CamelCase),
+            "snake_case" => Some(Self::SnakeCase),
+            "SCREAMING_SNAKE_CASE" => Some(Self::ScreamingSnakeCase),
+            "kebab-case" => Some(Self::KebabCase),
+            "SCREAMING-KEBAB-CASE" => Some(Self::ScreamingKebabCase),
+            _ => None,
+        }
+    }
+
+    /// Apply the given rename to the input string.
+    pub(crate) fn apply(&self, input: &str) -> String {
+        let prefix = match self {
+            Self::SnakeCase => Some('_'),
+            Self::ScreamingSnakeCase => Some('_'),
+            Self::KebabCase => Some('-'),
+            Self::ScreamingKebabCase => Some('-'),
+            _ => None,
+        };
+
+        let feed: fn(output: &mut String, open: bool, count: usize, c: char) = match self {
+            Self::PascalCase => |output, open, _, c| {
+                if open {
+                    output.extend(c.to_uppercase());
+                } else {
+                    output.extend(c.to_lowercase());
+                }
+            },
+            Self::CamelCase => |output, open, count, c| {
+                if open && count > 0 {
+                    output.extend(c.to_uppercase());
+                } else {
+                    output.extend(c.to_lowercase());
+                }
+            },
+            Self::SnakeCase => |output, _, _, c| {
+                output.extend(c.to_lowercase());
+            },
+            Self::ScreamingSnakeCase => |output, _, _, c| {
+                output.extend(c.to_uppercase());
+            },
+            Self::KebabCase => |output, _, _, c| {
+                output.extend(c.to_lowercase());
+            },
+            Self::ScreamingKebabCase => |output, _, _, c| {
+                output.extend(c.to_uppercase());
+            },
+        };
+
+        let mut output = String::new();
+        let mut count = 0;
+        let mut group = true;
+
+        for c in input.chars() {
+            if matches!(c, '_') {
+                if !group {
+                    count += 1;
+                }
+
+                group = true;
+                continue;
+            }
+
+            if char::is_uppercase(c) && !group {
+                group = true;
+                count += 1;
+            }
+
+            let group = take(&mut group);
+
+            if group && count > 0 {
+                output.extend(prefix);
+            }
+
+            feed(&mut output, group, count, c);
+        }
+
+        output
+    }
+}
+
+impl fmt::Display for RenameAll {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::PascalCase => write!(f, "PascalCase"),
+            Self::CamelCase => write!(f, "camelCase"),
+            Self::SnakeCase => write!(f, "snake_case"),
+            Self::ScreamingSnakeCase => write!(f, "SCREAMING_SNAKE_CASE"),
+            Self::KebabCase => write!(f, "kebab-case"),
+            Self::ScreamingKebabCase => write!(f, "SCREAMING-KEBAB-CASE"),
+        }
+    }
+}
+
+#[test]
+fn test_rename() {
+    #[track_caller]
+    fn test(input: &str, rename: &str, expected: &str) {
+        let rename = RenameAll::parse(rename).unwrap();
+        assert_eq!(rename.apply(input), expected);
+    }
+
+    test("hello_world", "PascalCase", "HelloWorld");
+    test("__hello__world__", "PascalCase", "HelloWorld");
+    test("hello_world", "camelCase", "helloWorld");
+    test("__hello__world__", "camelCase", "helloWorld");
+    test("hello_world", "snake_case", "hello_world");
+    test("__hello__world__", "snake_case", "hello_world");
+    test("hello_world", "SCREAMING_SNAKE_CASE", "HELLO_WORLD");
+    test("__hello__world__", "SCREAMING_SNAKE_CASE", "HELLO_WORLD");
+    test("hello_world", "kebab-case", "hello-world");
+    test("__hello__world__", "kebab-case", "hello-world");
+    test("hello_world", "SCREAMING-KEBAB-CASE", "HELLO-WORLD");
+    test("__hello__world__", "SCREAMING-KEBAB-CASE", "HELLO-WORLD");
+
+    test("HelloWorld", "PascalCase", "HelloWorld");
+    test("__Hello__World__", "PascalCase", "HelloWorld");
+    test("HelloWorld", "camelCase", "helloWorld");
+    test("__Hello__World__", "camelCase", "helloWorld");
+    test("HelloWorld", "snake_case", "hello_world");
+    test("__Hello__World__", "snake_case", "hello_world");
+    test("HelloWorld", "SCREAMING_SNAKE_CASE", "HELLO_WORLD");
+    test("__Hello__World__", "SCREAMING_SNAKE_CASE", "HELLO_WORLD");
+    test("HelloWorld", "kebab-case", "hello-world");
+    test("__Hello__World__", "kebab-case", "hello-world");
+    test("HelloWorld", "SCREAMING-KEBAB-CASE", "HELLO-WORLD");
+    test("__Hello__World__", "SCREAMING-KEBAB-CASE", "HELLO-WORLD");
+}

--- a/crates/musli-serde/README.md
+++ b/crates/musli-serde/README.md
@@ -14,7 +14,7 @@ traits.
 
 Note that the exact method that fields are serialized and deserialized will
 not match what Müsli does, since serde requires the use of a fundamentally
-different model and Müsli metadata such as `#[musli(rename = ..)]` is not
+different model and Müsli metadata such as `#[musli(name = ..)]` is not
 available in [`serde`].
 
 <br>

--- a/crates/musli-serde/src/lib.rs
+++ b/crates/musli-serde/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! Note that the exact method that fields are serialized and deserialized will
 //! not match what Müsli does, since serde requires the use of a fundamentally
-//! different model and Müsli metadata such as `#[musli(rename = ..)]` is not
+//! different model and Müsli metadata such as `#[musli(name = ..)]` is not
 //! available in [`serde`].
 //!
 //! <br>

--- a/crates/musli-wire/src/tests.rs
+++ b/crates/musli-wire/src/tests.rs
@@ -4,19 +4,19 @@ use crate::tag::{Kind, Tag, MAX_INLINE_LEN};
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 struct From<const N: usize> {
-    #[musli(rename = 0)]
+    #[musli(name = 0)]
     prefix: Option<u32>,
-    #[musli(rename = 1)]
+    #[musli(name = 1)]
     field: Field<N>,
-    #[musli(rename = 2)]
+    #[musli(name = 2)]
     suffix: Option<u32>,
 }
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 struct To {
-    #[musli(rename = 0)]
+    #[musli(name = 0)]
     prefix: Option<u32>,
-    #[musli(rename = 2)]
+    #[musli(name = 2)]
     suffix: Option<u32>,
 }
 

--- a/crates/musli/README.md
+++ b/crates/musli/README.md
@@ -224,7 +224,7 @@ to support it. Luckily, the implementation is also quite good!
 The following is an example of *full upgrade stability* using
 [`musli-wire`]. `Version1` can be decoded from an instance of `Version2`
 because it understands how to skip fields which are part of `Version2`.
-We're also explicitly adding `#[musli(rename = ..)]` to the fields to ensure
+We're also explicitly adding `#[musli(name = ..)]` to the fields to ensure
 that they don't change in case they are re-ordered.
 
 ```rust
@@ -232,15 +232,15 @@ use musli::{Encode, Decode};
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 struct Version1 {
-    #[musli(rename = 0)]
+    #[musli(name = 0)]
     name: String,
 }
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 struct Version2 {
-    #[musli(rename = 0)]
+    #[musli(name = 0)]
     name: String,
-    #[musli(default, rename = 1)]
+    #[musli(default, name = 1)]
     age: Option<u32>,
 }
 

--- a/crates/musli/src/context.rs
+++ b/crates/musli/src/context.rs
@@ -271,7 +271,7 @@ pub trait Context {
     ///
     /// #[derive(Decode, Encode)]
     /// struct Struct {
-    ///     #[musli(rename = "string")]
+    ///     #[musli(name = "string")]
     ///     field: String,
     /// }
     /// ```
@@ -299,7 +299,7 @@ pub trait Context {
     /// use musli::{Decode, Encode};
     ///
     /// #[derive(Decode, Encode)]
-    /// struct Struct(#[musli(rename = "string")] String);
+    /// struct Struct(#[musli(name = "string")] String);
     /// ```
     ///
     /// [`leave_field`]: Context::leave_field
@@ -339,7 +339,7 @@ pub trait Context {
     ///
     /// #[derive(Decode, Encode)]
     /// struct Struct {
-    ///     #[musli(rename = "string")]
+    ///     #[musli(name = "string")]
     ///     field: String,
     /// }
     /// ```

--- a/crates/musli/src/derives.rs
+++ b/crates/musli/src/derives.rs
@@ -153,7 +153,7 @@
 //! #[musli(default_field = "name")]
 //! struct Name<'a> {
 //!     sur_name: &'a str,
-//!     #[musli(decode_only, rename = "last")]
+//!     #[musli(decode_only, name = "last")]
 //!     last_name: &'a str,
 //! }
 //! ```
@@ -301,7 +301,7 @@
 //!
 //! #### `#[musli(name_type = ..)]`
 //!
-//! This indicates which type any contained `#[musli(rename = ..)]` attributes
+//! This indicates which type any contained `#[musli(name = ..)]` attributes
 //! should have. Tags can usually be inferred, but specifying this field ensures
 //! that all tags have a single well-defined type.
 //!
@@ -323,14 +323,14 @@
 //! #[derive(Encode, Decode)]
 //! #[musli(name_type = CustomTag)]
 //! struct Struct {
-//!     #[musli(rename = CustomTag(b"name in bytes"))]
+//!     #[musli(name = CustomTag(b"name in bytes"))]
 //!     name: String,
 //! }
 //!
 //! #[derive(Encode, Decode)]
 //! #[musli(name_type = CustomTag)]
 //! enum EnumWithCustomTag {
-//!     #[musli(rename = CustomTag(b"variant one"))]
+//!     #[musli(name = CustomTag(b"variant one"))]
 //!     Variant1 {
 //!         /* .. */
 //!     },
@@ -391,7 +391,7 @@
 //! ## Variant attributes
 //!
 //! *Variant attributes* are attributes which apply to each individual variant
-//! in an `enum`. Like the use of `#[musli(rename = ..)]` here:
+//! in an `enum`. Like the use of `#[musli(name = ..)]` here:
 //!
 //! ```
 //! use musli::{Encode, Decode};
@@ -399,7 +399,7 @@
 //! #[derive(Encode, Decode)]
 //! #[musli(default_variant = "name")]
 //! enum Enum {
-//!     #[musli(rename = "Other")]
+//!     #[musli(name = "Other")]
 //!     Something {
 //!         /* variant body */
 //!     }
@@ -408,16 +408,16 @@
 //!
 //! <br>
 //!
-//! #### `#[musli(rename = ..)]`
+//! #### `#[musli(name = ..)]`
 //!
 //! This allows for renaming a variant from its default value. It can take any
 //! value (including complex ones) that can be serialized with the current
 //! encoding, such as:
 //!
-//! * `#[musli(rename = 1)]`
-//! * `#[musli(rename = "Hello World")]`
-//! * `#[musli(rename = b"box\0")]`
-//! * `#[musli(rename = SomeStruct { field: 42 })]` (if `SomeStruct` implements
+//! * `#[musli(name = 1)]`
+//! * `#[musli(name = "Hello World")]`
+//! * `#[musli(name = b"box\0")]`
+//! * `#[musli(name = SomeStruct { field: 42 })]` (if `SomeStruct` implements
 //!   [`Encode`] and [`Decode`] as appropriate).
 //!
 //! If the type of the tag is ambiguous it can be explicitly specified through
@@ -454,7 +454,7 @@
 //! enum Enum {
 //!     #[musli(name_type = CustomTag)]
 //!     Variant {
-//!         #[musli(rename = CustomTag(b"name in bytes"))]
+//!         #[musli(name = CustomTag(b"name in bytes"))]
 //!         name: String,
 //!     }
 //! }
@@ -508,9 +508,9 @@
 //!
 //! #[derive(Debug, PartialEq, Eq, Encode, Decode)]
 //! enum Animal {
-//!     #[musli(rename = "cat")]
+//!     #[musli(name = "cat")]
 //!     Cat,
-//!     #[musli(rename = "dog")]
+//!     #[musli(name = "dog")]
 //!     Dog,
 //!     #[musli(default)]
 //!     Unknown,
@@ -531,7 +531,7 @@
 //! #[derive(Encode, Decode)]
 //! #[musli(default_field = "name")]
 //! struct Struct {
-//!     #[musli(rename = "other")]
+//!     #[musli(name = "other")]
 //!     something: String,
 //!     #[musli(skip, default = default_field)]
 //!     skipped_field: u32,
@@ -545,7 +545,7 @@
 //! #[musli(default_field = "name")]
 //! enum Enum {
 //!     Variant {
-//!         #[musli(rename = "other")]
+//!         #[musli(name = "other")]
 //!         something: String,
 //!     }
 //! }
@@ -614,16 +614,16 @@
 //!
 //! <br>
 //!
-//! #### `#[musli(rename = ..)]`
+//! #### `#[musli(name = ..)]`
 //!
 //! This allows for renaming a field from its default value. It can take any
 //! value (including complex ones) that can be serialized with the current
 //! encoding, such as:
 //!
-//! * `#[musli(rename = 1)]`
-//! * `#[musli(rename = "Hello World")]`
-//! * `#[musli(rename = b"box\0")]`
-//! * `#[musli(rename = SomeStruct { field: 42 })]` (if `SomeStruct` implements
+//! * `#[musli(name = 1)]`
+//! * `#[musli(name = "Hello World")]`
+//! * `#[musli(name = b"box\0")]`
+//! * `#[musli(name = SomeStruct { field: 42 })]` (if `SomeStruct` implements
 //!   [`Encode`] and [`Decode`] as appropriate).
 //!
 //! If the type of the tag is ambiguous it can be explicitly specified through

--- a/crates/musli/src/derives.rs
+++ b/crates/musli/src/derives.rs
@@ -184,6 +184,44 @@
 //!
 //! <br>
 //!
+//! #### `#[musli(rename_all = "..")]`
+//!
+//! Allos for renaming every field in the container. It can take any of the
+//! following values:
+//!
+//! * `PascalCase`
+//! * `camelCase`
+//! * `snake_case`
+//! * `SCREAMING_SNAKE_CASE`
+//! * `kebab-case`
+//! * `SCREAMING-KEBAB-CASE`
+//!
+//! ```
+//! use musli::{Encode, Decode};
+//!
+//! #[derive(Encode, Decode)]
+//! #[musli(rename_all = "PascalCase")]
+//! struct Struct {
+//!     field_name: u32,
+//! }
+//! ```
+//!
+//! If applied to an enum, it will instead rename all variants:
+//!
+//! ```
+//! use musli::{Encode, Decode};
+//!
+//! #[derive(Encode, Decode)]
+//! #[musli(rename_all = "PascalCase")]
+//! enum Enum {
+//!     VariantName {
+//!         field_name: u32,
+//!     }
+//! }
+//! ```
+//!
+//! <br>
+//!
 //! #### `#[musli(default_field = "..")]`
 //!
 //! This determines how the default tag for a field is determined. It can take
@@ -422,6 +460,30 @@
 //!
 //! If the type of the tag is ambiguous it can be explicitly specified through
 //! the `#[musli(name_type)]` attribute.
+//!
+//! #### `#[musli(rename_all = "..")]`
+//!
+//! Allos for renaming every field in the container. It can take any of the
+//! following values:
+//!
+//! * `PascalCase`
+//! * `camelCase`
+//! * `snake_case`
+//! * `SCREAMING_SNAKE_CASE`
+//! * `kebab-case`
+//! * `SCREAMING-KEBAB-CASE`
+//!
+//! ```
+//! use musli::{Encode, Decode};
+//!
+//! #[derive(Encode, Decode)]
+//! enum Enum {
+//!     #[musli(rename_all = "PascalCase")]
+//!     Variant {
+//!         field_name: u32,
+//!     }
+//! }
+//! ```
 //!
 //! <br>
 //!

--- a/crates/musli/src/lib.rs
+++ b/crates/musli/src/lib.rs
@@ -226,7 +226,7 @@
 //! The following is an example of *full upgrade stability* using
 //! [`musli-wire`]. `Version1` can be decoded from an instance of `Version2`
 //! because it understands how to skip fields which are part of `Version2`.
-//! We're also explicitly adding `#[musli(rename = ..)]` to the fields to ensure
+//! We're also explicitly adding `#[musli(name = ..)]` to the fields to ensure
 //! that they don't change in case they are re-ordered.
 //!
 //! ```ignore
@@ -234,15 +234,15 @@
 //!
 //! #[derive(Debug, PartialEq, Encode, Decode)]
 //! struct Version1 {
-//!     #[musli(rename = 0)]
+//!     #[musli(name = 0)]
 //!     name: String,
 //! }
 //!
 //! #[derive(Debug, PartialEq, Encode, Decode)]
 //! struct Version2 {
-//!     #[musli(rename = 0)]
+//!     #[musli(name = 0)]
 //!     name: String,
-//!     #[musli(default, rename = 1)]
+//!     #[musli(default, name = 1)]
 //!     age: Option<u32>,
 //! }
 //!

--- a/crates/tests/tests/complex_field.rs
+++ b/crates/tests/tests/complex_field.rs
@@ -41,9 +41,9 @@ const CUSTOM_TAG2: FieldVariantTag = FieldVariantTag { name: "field2" };
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 pub struct StructCustomFieldAsStruct {
-    #[musli(rename = CUSTOM_TAG1)]
+    #[musli(name = CUSTOM_TAG1)]
     field1: u32,
-    #[musli(rename = CUSTOM_TAG2)]
+    #[musli(name = CUSTOM_TAG2)]
     field2: u32,
 }
 
@@ -66,9 +66,9 @@ fn custom_struct_tag() {
 #[derive(Debug, PartialEq, Encode, Decode)]
 #[musli(name_type = Bytes<[u8; 4]>, name_format_with = BStr::new)]
 pub struct StructCustomTag {
-    #[musli(rename = Bytes([1, 2, 3, 4]))]
+    #[musli(name = Bytes([1, 2, 3, 4]))]
     field1: u32,
-    #[musli(rename = Bytes([2, 3, 4, 5]))]
+    #[musli(name = Bytes([2, 3, 4, 5]))]
     field2: u32,
 }
 
@@ -86,7 +86,7 @@ fn custom_tag() {
 #[derive(Debug, PartialEq, Encode, Decode)]
 #[musli(name_type = BytesTag)]
 struct StructWithBytesTag {
-    #[musli(rename = BytesTag(b"name in bytes"))]
+    #[musli(name = BytesTag(b"name in bytes"))]
     string: String,
 }
 
@@ -103,11 +103,11 @@ fn struct_with_bytes_tag() {
 #[derive(Debug, PartialEq, Encode, Decode)]
 #[musli(name_type = BytesTag)]
 enum EnumWithBytesTag {
-    #[musli(rename = BytesTag(b"a"))]
+    #[musli(name = BytesTag(b"a"))]
     Variant1 { string: String },
-    #[musli(rename = BytesTag(b"b"), name_type = BytesTag)]
+    #[musli(name = BytesTag(b"b"), name_type = BytesTag)]
     Variant2 {
-        #[musli(rename = BytesTag(b"c"))]
+        #[musli(name = BytesTag(b"c"))]
         string: String,
     },
 }

--- a/crates/tests/tests/custom_tagging.rs
+++ b/crates/tests/tests/custom_tagging.rs
@@ -7,7 +7,7 @@ pub enum InternallyTagged {
         string: String,
         number: u32,
     },
-    #[musli(rename = "variant2")]
+    #[musli(name = "variant2")]
     Variant2 {
         string: String,
     },
@@ -53,7 +53,7 @@ pub enum AdjacentlyTagged {
         string: String,
         number: u32,
     },
-    #[musli(rename = "variant2")]
+    #[musli(name = "variant2")]
     Variant2 {
         string: String,
     },

--- a/crates/tests/tests/default_variant.rs
+++ b/crates/tests/tests/default_variant.rs
@@ -12,7 +12,7 @@ pub enum SeveralVariants {
 #[derive(Debug, PartialEq, Encode, Decode)]
 pub enum OnlyFallback {
     // Renamed to something which is not provided in `SeveralVariants`.
-    #[musli(rename = 4)]
+    #[musli(name = 4)]
     Variant4,
     #[musli(default)]
     Fallback,

--- a/crates/tests/tests/field_compat.rs
+++ b/crates/tests/tests/field_compat.rs
@@ -29,7 +29,7 @@ pub struct SimpleStructFrom {
     pub interior: u32,
     pub option: Option<u32>,
     pub other: OtherStruct,
-    #[musli(rename = 4)]
+    #[musli(name = 4)]
     pub other_enum: OtherEnum,
 }
 
@@ -40,7 +40,7 @@ pub struct SimpleStructTo {
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 pub struct SimpleStructEnum {
-    #[musli(rename = 4)]
+    #[musli(name = 4)]
     pub value: OtherEnum,
 }
 

--- a/crates/tests/tests/large_enum.rs
+++ b/crates/tests/tests/large_enum.rs
@@ -37,15 +37,15 @@ pub struct E {
 
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
 pub enum LargeEnumStringVariants {
-    #[musli(transparent, rename = "a")]
+    #[musli(transparent, name = "a")]
     A(A),
-    #[musli(transparent, rename = "b")]
+    #[musli(transparent, name = "b")]
     B(B),
-    #[musli(transparent, rename = "c")]
+    #[musli(transparent, name = "c")]
     C(C),
-    #[musli(transparent, rename = "d")]
+    #[musli(transparent, name = "d")]
     D(D),
-    #[musli(transparent, rename = "e")]
+    #[musli(transparent, name = "e")]
     E(E),
 }
 

--- a/crates/tests/tests/named_fields.rs
+++ b/crates/tests/tests/named_fields.rs
@@ -1,0 +1,76 @@
+use musli::{Decode, Encode};
+
+#[derive(Debug, PartialEq, Eq, Encode, Decode)]
+#[musli(rename_all = "PascalCase")]
+struct PascalCase {
+    field_name: i32,
+}
+
+#[derive(Debug, PartialEq, Eq, Encode, Decode)]
+#[musli(rename_all = "camelCase")]
+struct CamelCase {
+    field_name: i32,
+}
+
+#[derive(Debug, PartialEq, Eq, Encode, Decode)]
+#[musli(rename_all = "snake_case")]
+struct SnakeCase {
+    field_name: i32,
+}
+
+#[derive(Debug, PartialEq, Eq, Encode, Decode)]
+#[musli(rename_all = "SCREAMING_SNAKE_CASE")]
+struct ScreamingSnakeCase {
+    field_name: i32,
+}
+
+#[derive(Debug, PartialEq, Eq, Encode, Decode)]
+#[musli(rename_all = "kebab-case")]
+struct KebabCase {
+    field_name: i32,
+}
+
+#[derive(Debug, PartialEq, Eq, Encode, Decode)]
+#[musli(rename_all = "SCREAMING-KEBAB-CASE")]
+struct ScreamingKebabCase {
+    field_name: i32,
+}
+
+#[test]
+fn test_rename_all() {
+    tests::rt!(
+        full,
+        PascalCase { field_name: 42 },
+        json = r#"{"FieldName":42}"#,
+    );
+
+    tests::rt!(
+        full,
+        CamelCase { field_name: 42 },
+        json = r#"{"fieldName":42}"#,
+    );
+
+    tests::rt!(
+        full,
+        SnakeCase { field_name: 42 },
+        json = r#"{"field_name":42}"#,
+    );
+
+    tests::rt!(
+        full,
+        ScreamingSnakeCase { field_name: 42 },
+        json = r#"{"FIELD_NAME":42}"#,
+    );
+
+    tests::rt!(
+        full,
+        KebabCase { field_name: 42 },
+        json = r#"{"field-name":42}"#,
+    );
+
+    tests::rt!(
+        full,
+        ScreamingKebabCase { field_name: 42 },
+        json = r#"{"FIELD-NAME":42}"#,
+    );
+}

--- a/crates/tests/tests/named_variants.rs
+++ b/crates/tests/tests/named_variants.rs
@@ -1,0 +1,72 @@
+use musli::{Decode, Encode};
+
+#[derive(Debug, PartialEq, Eq, Encode, Decode)]
+#[musli(rename_all = "PascalCase")]
+enum PascalCase {
+    VariantName,
+}
+
+#[derive(Debug, PartialEq, Eq, Encode, Decode)]
+#[musli(rename_all = "camelCase")]
+enum CamelCase {
+    VariantName,
+}
+
+#[derive(Debug, PartialEq, Eq, Encode, Decode)]
+#[musli(rename_all = "snake_case")]
+enum SnakeCase {
+    VariantName,
+}
+
+#[derive(Debug, PartialEq, Eq, Encode, Decode)]
+#[musli(rename_all = "SCREAMING_SNAKE_CASE")]
+enum ScreamingSnakeCase {
+    VariantName,
+}
+
+#[derive(Debug, PartialEq, Eq, Encode, Decode)]
+#[musli(rename_all = "kebab-case")]
+enum KebabCase {
+    VariantName,
+}
+
+#[derive(Debug, PartialEq, Eq, Encode, Decode)]
+#[musli(rename_all = "SCREAMING-KEBAB-CASE")]
+enum ScreamingKebabCase {
+    VariantName,
+}
+
+#[test]
+fn test_rename_all() {
+    tests::rt!(
+        full,
+        PascalCase::VariantName,
+        json = r#"{"VariantName":{}}"#,
+    );
+
+    tests::rt!(full, CamelCase::VariantName, json = r#"{"variantName":{}}"#,);
+
+    tests::rt!(
+        full,
+        SnakeCase::VariantName,
+        json = r#"{"variant_name":{}}"#,
+    );
+
+    tests::rt!(
+        full,
+        ScreamingSnakeCase::VariantName,
+        json = r#"{"VARIANT_NAME":{}}"#,
+    );
+
+    tests::rt!(
+        full,
+        KebabCase::VariantName,
+        json = r#"{"variant-name":{}}"#,
+    );
+
+    tests::rt!(
+        full,
+        ScreamingKebabCase::VariantName,
+        json = r#"{"VARIANT-NAME":{}}"#,
+    );
+}

--- a/crates/tests/tests/pack_compat.rs
+++ b/crates/tests/tests/pack_compat.rs
@@ -26,25 +26,25 @@ struct PackedCompat<const N: usize, const L: usize> {
 #[derive(Debug, PartialEq, Encode, Decode)]
 struct IgnoreLarge<const N: usize> {
     prefix: u32,
-    #[musli(rename = 1)]
+    #[musli(name = 1)]
     small: Packed<N>,
-    #[musli(rename = 3)]
+    #[musli(name = 3)]
     suffix: u32,
 }
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 struct IgnoreSmall<const L: usize> {
     prefix: u32,
-    #[musli(rename = 2)]
+    #[musli(name = 2)]
     large: Packed<L>,
-    #[musli(rename = 3)]
+    #[musli(name = 3)]
     suffix: u32,
 }
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 struct IgnoreBoth {
     prefix: u32,
-    #[musli(rename = 3)]
+    #[musli(name = 3)]
     suffix: u32,
 }
 

--- a/crates/tests/tests/tagged_fields.rs
+++ b/crates/tests/tests/tagged_fields.rs
@@ -10,9 +10,9 @@ pub struct StructFrom {
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 pub struct StructTo {
-    #[musli(rename = 1)]
+    #[musli(name = 1)]
     number: u32,
-    #[musli(rename = 0)]
+    #[musli(name = 0)]
     string: String,
 }
 

--- a/crates/tests/tests/ui/unsupported_rename_all_error.rs
+++ b/crates/tests/tests/ui/unsupported_rename_all_error.rs
@@ -1,0 +1,11 @@
+use musli::{Encode, Decode};
+
+#[derive(Encode, Decode)]
+#[musli(rename_all = "WHAT_IS_THIS")]
+struct Struct {
+    field: u32,
+}
+
+fn main() {
+}
+

--- a/crates/tests/tests/ui/unsupported_rename_all_error.stderr
+++ b/crates/tests/tests/ui/unsupported_rename_all_error.stderr
@@ -1,0 +1,5 @@
+error: #[musli(rename_all = "WHAT_IS_THIS")]: Bad value, expected one of "PascalCase", "camelCase", "snake_case", "SCREAMING_SNAKE_CASE", "kebab-case", "SCREAMING-KEBAB-CASE"
+ --> tests/ui/unsupported_rename_all_error.rs:4:22
+  |
+4 | #[musli(rename_all = "WHAT_IS_THIS")]
+  |                      ^^^^^^^^^^^^^^


### PR DESCRIPTION
Renames `#[musli(rename)]` to `#[musli(name)]`.
Implement `#[musli(rename_all = "..")]`.