### PR TITLE
Simplify field naming

### DIFF
--- a/crates/musli-macros/src/internals/attr.rs
+++ b/crates/musli-macros/src/internals/attr.rs
@@ -7,7 +7,6 @@ use syn::parse::Parse;
 use syn::spanned::Spanned;
 use syn::Token;
 
-use crate::expander::{self, TagMethod};
 use crate::internals::name::NameAll;
 use crate::internals::ATTR;
 use crate::internals::{Ctxt, Mode};
@@ -29,7 +28,6 @@ struct OneOf<T> {
 #[derive(Clone, Copy)]
 pub(crate) struct EnumTag<'a> {
     pub(crate) value: &'a syn::Expr,
-    pub(crate) method: TagMethod,
 }
 
 #[derive(Clone, Copy)]
@@ -214,10 +212,7 @@ impl TypeAttr {
     pub(crate) fn enum_tagging(&self, mode: Mode<'_>) -> Option<EnumTagging<'_>> {
         let (_, tag) = self.tag(mode)?;
 
-        let tag = EnumTag {
-            value: tag,
-            method: expander::determine_tag_method(tag),
-        };
+        let tag = EnumTag { value: tag };
 
         match self.content(mode) {
             Some((_, content)) => Some(EnumTagging::Adjacent { tag, content }),

--- a/crates/musli-macros/src/internals/name.rs
+++ b/crates/musli-macros/src/internals/name.rs
@@ -1,6 +1,8 @@
 use core::fmt;
 use core::mem::take;
 
+use crate::expander::NameMethod;
+
 #[derive(Default, Debug, Clone, Copy)]
 #[allow(clippy::enum_variant_names)]
 pub(crate) enum NameAll {
@@ -28,6 +30,20 @@ impl NameAll {
         Self::KebabCase,
         Self::ScreamingKebabCase,
     ];
+
+    pub(crate) fn ty(&self) -> syn::Type {
+        match self {
+            NameAll::Index => syn::parse_quote! { usize },
+            _ => syn::parse_quote! { str },
+        }
+    }
+
+    pub(crate) fn name_method(&self) -> NameMethod {
+        match self {
+            NameAll::Index => NameMethod::Value,
+            _ => NameMethod::Visit,
+        }
+    }
 
     pub(crate) fn parse(input: &str) -> Option<Self> {
         match input {

--- a/crates/musli/src/context.rs
+++ b/crates/musli/src/context.rs
@@ -282,6 +282,7 @@ pub trait Context {
     /// use musli::{Decode, Encode};
     ///
     /// #[derive(Decode, Encode)]
+    /// #[musli(name_all = "name")]
     /// struct Struct {
     ///     #[musli(name = "string")]
     ///     field: String,
@@ -305,19 +306,20 @@ pub trait Context {
     ///
     /// This will be matched with a corresponding call to [`leave_field`].
     ///
-    /// Here `index` is `0` and `tag` is `"string"`.
+    /// Here `index` is `0` and `name` is `"string"`.
     ///
     /// ```rust
     /// use musli::{Decode, Encode};
     ///
     /// #[derive(Decode, Encode)]
+    /// #[musli(name_all = "name")]
     /// struct Struct(#[musli(name = "string")] String);
     /// ```
     ///
     /// [`leave_field`]: Context::leave_field
     #[allow(unused_variables)]
     #[inline(always)]
-    fn enter_unnamed_field<T>(&self, index: u32, tag: &T)
+    fn enter_unnamed_field<T>(&self, index: u32, name: &T)
     where
         T: ?Sized + fmt::Display,
     {
@@ -350,6 +352,7 @@ pub trait Context {
     /// use musli::{Decode, Encode};
     ///
     /// #[derive(Decode, Encode)]
+    /// #[musli(name_all = "name")]
     /// struct Struct {
     ///     #[musli(name = "string")]
     ///     field: String,

--- a/crates/musli/src/derives.rs
+++ b/crates/musli/src/derives.rs
@@ -302,6 +302,9 @@
 //! should have. Tags can usually be inferred, but specifying this field ensures
 //! that all tags have a single well-defined type.
 //!
+//! The following values are treated specially:
+//! * `str` applies `#[musli(name_all = "name")]` by default.
+//!
 //! ```
 //! use core::fmt;
 //!
@@ -470,8 +473,8 @@
 //! should have. Tags can usually be inferred, but specifying this field ensures
 //! that all tags have a well-defined type.
 //!
-//! This attribute takes priority over the one with the same name on the
-//! container.
+//! The following values are treated specially:
+//! * `str` applies `#[musli(name_all = "name")]` by default.
 //!
 //! ```
 //! use core::fmt;
@@ -498,7 +501,7 @@
 //!         #[musli(name = CustomTag(b"field2"))]
 //!         field2: u32,
 //!     },
-//!     #[musli(name = 1usize)]
+//!     #[musli(name = 1usize, name_all = "name")]
 //!     Variant2 {
 //!         #[musli(name = "field1")]
 //!         field1: u32,

--- a/tests/tests/large_enum.rs
+++ b/tests/tests/large_enum.rs
@@ -36,6 +36,7 @@ pub struct E {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+#[musli(name_all = "name")]
 pub enum LargeEnumStringVariants {
     #[musli(transparent, name = "a")]
     A(A),

--- a/tests/tests/struct_name.rs
+++ b/tests/tests/struct_name.rs
@@ -12,6 +12,13 @@ pub struct Named {
 }
 
 #[derive(Debug, PartialEq, Encode, Decode)]
+#[musli(name_type = str)]
+pub struct NamedByType {
+    string: String,
+    number: u32,
+}
+
+#[derive(Debug, PartialEq, Encode, Decode)]
 #[musli(name_all = "index")]
 pub struct Indexed {
     string: String,
@@ -19,7 +26,7 @@ pub struct Indexed {
 }
 
 #[test]
-fn struct_named_fields() {
+fn named_struct() {
     tests::rt!(
         full,
         Named {
@@ -28,6 +35,28 @@ fn struct_named_fields() {
         },
         json = r#"{"string":"foo","number":42}"#,
     );
+
+    tests::rt!(
+        full,
+        NamedByType {
+            string: String::from("foo"),
+            number: 42,
+        },
+        json = r#"{"string":"foo","number":42}"#,
+    );
+}
+
+#[test]
+fn named_struct_unpack() {
+    #[derive(Debug, PartialEq, Decode)]
+    #[musli(packed)]
+    pub struct Unpacked {
+        field_count: Tag,
+        field1_name: Typed<[u8; 6]>,
+        field1_value: Typed<[u8; 3]>,
+        field2_name: Typed<[u8; 6]>,
+        field2_value: Tag,
+    }
 
     let out = tests::wire::to_vec(&Named {
         string: String::from("foo"),
@@ -53,20 +82,10 @@ fn struct_named_fields() {
             field2_value: Tag::new(Kind::Continuation, 42),
         }
     );
-
-    #[derive(Debug, PartialEq, Decode)]
-    #[musli(packed)]
-    pub struct Unpacked {
-        field_count: Tag,
-        field1_name: Typed<[u8; 6]>,
-        field1_value: Typed<[u8; 3]>,
-        field2_name: Typed<[u8; 6]>,
-        field2_value: Tag,
-    }
 }
 
 #[test]
-fn struct_indexed_fields() {
+fn indexed_struct() {
     tests::rt!(
         full,
         Indexed {
@@ -75,7 +94,10 @@ fn struct_indexed_fields() {
         },
         json = r#"{"0":"foo","1":42}"#,
     );
+}
 
+#[test]
+fn indexed_struct_unpack() {
     let out = tests::wire::to_vec(&Indexed {
         string: String::from("foo"),
         number: 42,


### PR DESCRIPTION
This change means that in order to change the type of a field or variant name from its default `usize`, one of the following attributes has to be specified:
* `#[musli(name_all = "..")]` which is not `"index"`.
* `#[musli(name_type = <type>)]` which explicitly specified the name type. Here `str` also implies `#[musli(name_all = "name")]` unless another value is specified.