### PR TITLE
Descriptive integers

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,9 @@ types.
 `self` determines if the format is self-descriptive. Allowing the structure
 of the data to be fully reconstructed from its serialized state. These
 formats do not require models to decode and can be converted to and from
-dynamic containers such as [`musli-value`] for introspection.
+dynamic containers such as [`musli-value`] for introspection. Such formats
+also allows for type-coercions to be performed, so that a signed number can
+be correctly read as an unsigned number if it fits in the destination type.
 
 For every feature you drop, the format becomes more compact and efficient.
 [`musli-storage`] using `#[musli(packed)]` for example is roughly as compact

--- a/crates/musli-descriptive/README.md
+++ b/crates/musli-descriptive/README.md
@@ -12,14 +12,15 @@ Descriptive encoding is fully upgrade stable:
 * ✔ Can tolerate missing fields if they are annotated with
   `#[musli(default)]`.
 * ✔ Can skip over unknown fields.
+* ✔ Can be fully converted back and forth between dynamic containers such as
+  the [Value] type.
+* ✔ Can handle coercion from different types of primitive types, such as
+  signed to unsigned integers. So primitive field types can be assuming they
+  only inhabit compatible values.
 
-Furthermore, it can be fully converted back and from to the [Value] type.
-
-This means that it's suitable as a wire and general interchange format,
-since the data model can evolve independently among clients. Once some
-clients are upgraded they will start sending unknown fields which
-non-upgraded clients will be forced to skip over for the duration of the
-upgrade.
+This means that it's suitable as a wire and general interchange format. It's
+also suitable for dynamically translating to and from different wire formats
+such as JSON without having access to the data model.
 
 ```rust
 use musli::{Encode, Decode};

--- a/crates/musli-descriptive/src/integer_encoding.rs
+++ b/crates/musli-descriptive/src/integer_encoding.rs
@@ -41,7 +41,7 @@ where
 
             Ok(value)
         }
-        NumberKind::Unsigned => Ok(value),
+        NumberKind::Unsigned | NumberKind::Float => Ok(value),
         kind => Err(cx.message(format_args!(
             "Expected signed or unsigned number, got {:?}",
             kind

--- a/crates/musli-descriptive/src/lib.rs
+++ b/crates/musli-descriptive/src/lib.rs
@@ -137,6 +137,6 @@ pub use self::error::Error;
 #[cfg(feature = "test")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "test")))]
 #[doc(hidden)]
-pub use self::test::{transcode, Typed};
+pub use self::test::transcode;
 
 musli_utils::simdutf8!();

--- a/crates/musli-descriptive/src/lib.rs
+++ b/crates/musli-descriptive/src/lib.rs
@@ -9,14 +9,15 @@
 //! * ✔ Can tolerate missing fields if they are annotated with
 //!   `#[musli(default)]`.
 //! * ✔ Can skip over unknown fields.
+//! * ✔ Can be fully converted back and forth between dynamic containers such as
+//!   the [Value] type.
+//! * ✔ Can handle coercion from different types of primitive types, such as
+//!   signed to unsigned integers. So primitive field types can be assuming they
+//!   only inhabit compatible values.
 //!
-//! Furthermore, it can be fully converted back and from to the [Value] type.
-//!
-//! This means that it's suitable as a wire and general interchange format,
-//! since the data model can evolve independently among clients. Once some
-//! clients are upgraded they will start sending unknown fields which
-//! non-upgraded clients will be forced to skip over for the duration of the
-//! upgrade.
+//! This means that it's suitable as a wire and general interchange format. It's
+//! also suitable for dynamically translating to and from different wire formats
+//! such as JSON without having access to the data model.
 //!
 //! ```rust
 //! use musli::{Encode, Decode};

--- a/crates/musli-descriptive/src/test.rs
+++ b/crates/musli-descriptive/src/test.rs
@@ -2,44 +2,8 @@
 
 use core::fmt::Debug;
 
-use musli::de::PackDecoder;
 use musli::mode::DefaultMode;
-use musli::{Decode, Decoder, Encode};
-
-use crate::tag::Tag;
-
-/// A typed field, which is prefixed with a type tag.
-///
-/// This is used in combination with the storage deserializer to "inspect" type
-/// tags.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Typed<T> {
-    tag: Tag,
-    value: T,
-}
-
-impl<T> Typed<T> {
-    /// Construct a new typed field.
-    pub const fn new(tag: Tag, value: T) -> Self {
-        Self { tag, value }
-    }
-}
-
-impl<'de, M, T> Decode<'de, M> for Typed<T>
-where
-    T: Decode<'de, M>,
-{
-    fn decode<D>(_: &D::Cx, decoder: D) -> Result<Self, D::Error>
-    where
-        D: Decoder<'de, Mode = M>,
-    {
-        decoder.decode_pack(|pack| {
-            let tag = pack.decode_next()?.decode()?;
-            let value = pack.decode_next()?.decode()?;
-            Ok(Self { tag, value })
-        })
-    }
-}
+use musli::{Decode, Encode};
 
 musli_utils::test_fns!("descriptive", #[musli_value]);
 

--- a/crates/musli-wire/src/de.rs
+++ b/crates/musli-wire/src/de.rs
@@ -150,7 +150,9 @@ where
             } else {
                 musli_utils::int::decode_usize::<_, _, OPT>(self.cx, self.reader.borrow_mut())?
             }),
-            _ => Err(self.cx.marked_message(start, "Expected prefix")),
+            kind => Err(self
+                .cx
+                .marked_message(start, format_args!("Expected prefix, but got {kind:?}"))),
         }
     }
 }

--- a/crates/musli-wire/src/de.rs
+++ b/crates/musli-wire/src/de.rs
@@ -498,7 +498,7 @@ where
 
         if hint.size != decoder.remaining {
             return Err(decoder.cx.message(format_args!(
-                "Tuple length {} di not match actual: {}",
+                "Tuple length {} does not match actual: {}",
                 hint.size, decoder.remaining
             )));
         }

--- a/crates/musli-wire/src/tag.rs
+++ b/crates/musli-wire/src/tag.rs
@@ -5,7 +5,8 @@
 use core::fmt;
 use core::mem;
 
-use musli::{Decode, Decoder};
+#[cfg(feature = "test")]
+use musli::{Decode, Encode};
 
 /// Data masked into the data type.
 pub(crate) const DATA_MASK: u8 = 0b00_111111;
@@ -40,7 +41,9 @@ pub enum Kind {
 /// question. It is primarily used to smuggle extra data for the kind in
 /// question.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "test", derive(Encode, Decode))]
 #[repr(transparent)]
+#[cfg_attr(feature = "test", musli(transparent))]
 pub struct Tag {
     /// The internal representation of the tag.
     repr: u8,
@@ -139,15 +142,5 @@ impl fmt::Debug for Tag {
             .field("kind", &self.kind())
             .field("data", &self.data())
             .finish()
-    }
-}
-
-impl<'de, M> Decode<'de, M> for Tag {
-    #[inline]
-    fn decode<D>(_: &D::Cx, decoder: D) -> Result<Self, D::Error>
-    where
-        D: Decoder<'de, Mode = M>,
-    {
-        Ok(Self::from_byte(decoder.decode()?))
     }
 }

--- a/crates/musli-wire/src/test.rs
+++ b/crates/musli-wire/src/test.rs
@@ -2,9 +2,8 @@
 
 use core::fmt::Debug;
 
-use musli::de::PackDecoder;
 use musli::mode::DefaultMode;
-use musli::{Decode, Decoder, Encode};
+use musli::{Decode, Encode};
 
 use crate::tag::Tag;
 
@@ -12,32 +11,18 @@ use crate::tag::Tag;
 ///
 /// This is used in combination with the storage deserializer to "inspect" type
 /// tags.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Typed<T> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]
+#[musli(packed)]
+pub struct Typed<const N: usize> {
     tag: Tag,
-    value: T,
+    #[musli(bytes)]
+    value: [u8; N],
 }
 
-impl<T> Typed<T> {
+impl<const N: usize> Typed<N> {
     /// Construct a new typed field.
-    pub const fn new(tag: Tag, value: T) -> Self {
+    pub const fn new(tag: Tag, value: [u8; N]) -> Self {
         Self { tag, value }
-    }
-}
-
-impl<'de, M, T> Decode<'de, M> for Typed<T>
-where
-    T: Decode<'de, M>,
-{
-    fn decode<D>(_: &D::Cx, decoder: D) -> Result<Self, D::Error>
-    where
-        D: Decoder<'de, Mode = M>,
-    {
-        decoder.decode_pack(|pack| {
-            let tag = pack.decode_next()?.decode()?;
-            let value = pack.decode_next()?.decode()?;
-            Ok(Self { tag, value })
-        })
     }
 }
 

--- a/crates/musli/README.md
+++ b/crates/musli/README.md
@@ -205,7 +205,9 @@ types.
 `self` determines if the format is self-descriptive. Allowing the structure
 of the data to be fully reconstructed from its serialized state. These
 formats do not require models to decode and can be converted to and from
-dynamic containers such as [`musli-value`] for introspection.
+dynamic containers such as [`musli-value`] for introspection. Such formats
+also allows for type-coercions to be performed, so that a signed number can
+be correctly read as an unsigned number if it fits in the destination type.
 
 For every feature you drop, the format becomes more compact and efficient.
 [`musli-storage`] using `#[musli(packed)]` for example is roughly as compact

--- a/crates/musli/src/de/decoder.rs
+++ b/crates/musli/src/de/decoder.rs
@@ -1359,14 +1359,8 @@ pub trait Decoder<'de>: Sized {
         )))
     }
 
-    /// Decode a struct which has an expected `len` number of elements using a
-    /// closure.
-    ///
-    /// The `len` indicates how many fields the decoder is *expecting* depending
-    /// on how many fields are present in the underlying struct being decoded,
-    /// butit should only be considered advisory.
-    ///
-    /// The size of a struct might therefore change from one session to another.
+    /// Decode a struct with a [`StructHint`] that might contain information
+    /// about the structing being decode.
     ///
     /// # Examples
     ///
@@ -1504,14 +1498,11 @@ pub trait Decoder<'de>: Sized {
         )))
     }
 
-    /// Simplified decoding of a struct which has an expected `len` number of
-    /// elements.
+    /// Decode a struct with a [`StructHint`] that might contain information
+    /// about the structing being decode.
     ///
-    /// The `len` indicates how many fields the decoder is *expecting* depending
-    /// on how many fields are present in the underlying struct being decoded,
-    /// butit should only be considered advisory.
-    ///
-    /// The size of a struct might therefore change from one session to another.
+    /// This variant returns a decoder that decodes the struct as a sequence of
+    /// fields.
     #[inline]
     fn decode_struct_fields(
         self,

--- a/crates/musli/src/de/mod.rs
+++ b/crates/musli/src/de/mod.rs
@@ -17,66 +17,87 @@
 //! ```
 
 mod skip;
+#[doc(inline)]
 pub use self::skip::Skip;
 
 mod as_decoder;
+#[doc(inline)]
 pub use self::as_decoder::AsDecoder;
 
 mod decode;
+#[doc(inline)]
 pub use self::decode::{Decode, TraceDecode};
 
 mod decode_unsized;
+#[doc(inline)]
 pub use self::decode_unsized::DecodeUnsized;
 
 mod decode_unsized_bytes;
+#[doc(inline)]
 pub use self::decode_unsized_bytes::DecodeUnsizedBytes;
 
 mod decode_bytes;
+#[doc(inline)]
 pub use self::decode_bytes::DecodeBytes;
 
 mod decoder;
+#[doc(inline)]
 pub use self::decoder::Decoder;
 
 mod map_decoder;
+#[doc(inline)]
 pub use self::map_decoder::MapDecoder;
 
 mod map_entries_decoder;
+#[doc(inline)]
 pub use self::map_entries_decoder::MapEntriesDecoder;
 
 mod map_entry_decoder;
+#[doc(inline)]
 pub use self::map_entry_decoder::MapEntryDecoder;
 
 mod number_visitor;
+#[doc(inline)]
 pub use self::number_visitor::NumberVisitor;
 
 mod pack_decoder;
+#[doc(inline)]
 pub use self::pack_decoder::PackDecoder;
 
 mod tuple_decoder;
+#[doc(inline)]
 pub use self::tuple_decoder::TupleDecoder;
 
 mod sequence_decoder;
+#[doc(inline)]
 pub use self::sequence_decoder::SequenceDecoder;
 
 mod struct_decoder;
+#[doc(inline)]
 pub use self::struct_decoder::StructDecoder;
 
 mod struct_field_decoder;
+#[doc(inline)]
 pub use self::struct_field_decoder::StructFieldDecoder;
 
 mod struct_fields_decoder;
+#[doc(inline)]
 pub use self::struct_fields_decoder::StructFieldsDecoder;
 
 mod size_hint;
+#[doc(inline)]
 pub use self::size_hint::SizeHint;
 
 mod value_visitor;
+#[doc(inline)]
 pub use self::value_visitor::ValueVisitor;
 
 mod variant_decoder;
+#[doc(inline)]
 pub use self::variant_decoder::VariantDecoder;
 
 mod visitor;
+#[doc(inline)]
 pub use self::visitor::Visitor;
 
 use crate::mode::DefaultMode;

--- a/crates/musli/src/de/struct_fields_decoder.rs
+++ b/crates/musli/src/de/struct_fields_decoder.rs
@@ -46,6 +46,6 @@ pub trait StructFieldsDecoder<'de> {
         &mut self,
     ) -> Result<Self::DecodeStructFieldValue<'_>, <Self::Cx as Context>::Error>;
 
-    /// End pair decoding.
+    /// End struct fields decoding.
     fn end_struct_fields(self) -> Result<(), <Self::Cx as Context>::Error>;
 }

--- a/crates/musli/src/en/mod.rs
+++ b/crates/musli/src/en/mod.rs
@@ -17,37 +17,49 @@
 //! ```
 
 mod encode;
+#[doc(inline)]
 pub use self::encode::{Encode, TraceEncode};
 
 mod encode_bytes;
+#[doc(inline)]
 pub use self::encode_bytes::EncodeBytes;
 
 mod encoder;
+#[doc(inline)]
 pub use self::encoder::Encoder;
 
 mod sequence_encoder;
+#[doc(inline)]
 pub use self::sequence_encoder::SequenceEncoder;
 
 mod tuple_encoder;
+#[doc(inline)]
 pub use self::tuple_encoder::TupleEncoder;
 
 mod pack_encoder;
+#[doc(inline)]
 pub use self::pack_encoder::PackEncoder;
 
 mod map_encoder;
+#[doc(inline)]
 pub use self::map_encoder::MapEncoder;
 
 mod map_entry_encoder;
+#[doc(inline)]
 pub use self::map_entry_encoder::MapEntryEncoder;
 
 mod map_entries_encoder;
+#[doc(inline)]
 pub use self::map_entries_encoder::MapEntriesEncoder;
 
 mod struct_encoder;
+#[doc(inline)]
 pub use self::struct_encoder::StructEncoder;
 
 mod struct_field_encoder;
+#[doc(inline)]
 pub use self::struct_field_encoder::StructFieldEncoder;
 
 mod variant_encoder;
+#[doc(inline)]
 pub use self::variant_encoder::VariantEncoder;

--- a/crates/musli/src/fixed.rs
+++ b/crates/musli/src/fixed.rs
@@ -1,0 +1,123 @@
+use core::fmt;
+use core::mem::{self, ManuallyDrop, MaybeUninit};
+use core::ops::{Deref, DerefMut};
+use core::ptr;
+use core::slice;
+
+/// An error raised when we are at capacity.
+#[derive(Debug)]
+#[non_exhaustive]
+pub(crate) struct CapacityError;
+
+impl fmt::Display for CapacityError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Out of capacity when constructing array")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for CapacityError {}
+
+/// A fixed capacity vector allocated on the stack.
+pub(crate) struct FixedVec<T, const N: usize> {
+    data: [MaybeUninit<T>; N],
+    len: usize,
+}
+
+impl<T, const N: usize> FixedVec<T, N> {
+    /// Construct a new empty fixed vector.
+    pub(crate) const fn new() -> FixedVec<T, N> {
+        unsafe {
+            FixedVec {
+                data: MaybeUninit::uninit().assume_init(),
+                len: 0,
+            }
+        }
+    }
+
+    #[inline]
+    pub(crate) fn as_ptr(&self) -> *const T {
+        self.data.as_ptr() as *const T
+    }
+
+    #[inline]
+    pub(crate) fn as_mut_ptr(&mut self) -> *mut T {
+        self.data.as_mut_ptr() as *mut T
+    }
+
+    #[inline]
+    pub(crate) fn as_slice(&self) -> &[T] {
+        unsafe { slice::from_raw_parts(self.as_ptr(), self.len) }
+    }
+
+    #[inline]
+    pub(crate) fn as_mut_slice(&mut self) -> &mut [T] {
+        unsafe { slice::from_raw_parts_mut(self.as_mut_ptr(), self.len) }
+    }
+
+    /// Try to push an element onto the fixed vector.
+    pub(crate) fn try_push(&mut self, element: T) -> Result<(), CapacityError> {
+        if self.len >= N {
+            return Err(CapacityError);
+        }
+
+        unsafe {
+            ptr::write(self.as_mut_ptr().wrapping_add(self.len), element);
+            self.len += 1;
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn clear(&mut self) {
+        if self.len == 0 {
+            return;
+        }
+
+        let len = mem::take(&mut self.len);
+
+        if mem::needs_drop::<T>() {
+            unsafe {
+                let tail = slice::from_raw_parts_mut(self.as_mut_ptr(), len);
+                ptr::drop_in_place(tail);
+            }
+        }
+    }
+
+    pub(crate) fn into_inner(self) -> [T; N] {
+        assert!(
+            self.len == N,
+            "into_inner: length mismatch, expected {N} but got {}",
+            self.len
+        );
+
+        // SAFETY: We've asserted that the length is initialized just above.
+        unsafe {
+            let this = ManuallyDrop::new(self);
+            ptr::read(this.data.as_ptr() as *const [T; N])
+        }
+    }
+}
+
+impl<T, const N: usize> Deref for FixedVec<T, N> {
+    type Target = [T];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl<T, const N: usize> DerefMut for FixedVec<T, N> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.as_mut_slice()
+    }
+}
+
+impl<T, const N: usize> Drop for FixedVec<T, N> {
+    #[inline]
+    fn drop(&mut self) {
+        self.clear()
+    }
+}

--- a/crates/musli/src/lib.rs
+++ b/crates/musli/src/lib.rs
@@ -422,6 +422,7 @@ pub mod de;
 pub mod derives;
 pub mod en;
 mod expecting;
+mod fixed;
 pub mod hint;
 mod impls;
 mod internal;

--- a/crates/musli/src/lib.rs
+++ b/crates/musli/src/lib.rs
@@ -207,7 +207,9 @@
 //! `self` determines if the format is self-descriptive. Allowing the structure
 //! of the data to be fully reconstructed from its serialized state. These
 //! formats do not require models to decode and can be converted to and from
-//! dynamic containers such as [`musli-value`] for introspection.
+//! dynamic containers such as [`musli-value`] for introspection. Such formats
+//! also allows for type-coercions to be performed, so that a signed number can
+//! be correctly read as an unsigned number if it fits in the destination type.
 //!
 //! For every feature you drop, the format becomes more compact and efficient.
 //! [`musli-storage`] using `#[musli(packed)]` for example is roughly as compact

--- a/tests/tests/compatible_types.rs
+++ b/tests/tests/compatible_types.rs
@@ -1,0 +1,111 @@
+//! Test which ensures that compatible types can be decoded.
+
+use musli::{Decode, Encode};
+
+#[derive(Debug, PartialEq, Encode, Decode)]
+struct SignedIntegers {
+    a: i8,
+    b: i16,
+    c: i32,
+    d: i64,
+    e: i128,
+    f: isize,
+}
+
+#[derive(Debug, PartialEq, Encode, Decode)]
+struct UnsignedIntegers {
+    a: u8,
+    b: u16,
+    c: u32,
+    d: u64,
+    e: u128,
+    f: usize,
+}
+
+#[test]
+fn signed_to_unsigned() {
+    macro_rules! test_case {
+        ($ty:ty) => {{
+            #[derive(Debug, PartialEq, Encode, Decode)]
+            struct UnsignedIntegers {
+                a: $ty,
+                b: $ty,
+                c: $ty,
+                d: $ty,
+                e: $ty,
+                f: $ty,
+            }
+
+            tests::assert_decode_eq! {
+                descriptive,
+                SignedIntegers {
+                    a: 2,
+                    b: 3,
+                    c: 4,
+                    d: 5,
+                    e: 6,
+                    f: 7,
+                },
+                UnsignedIntegers {
+                    a: 2,
+                    b: 3,
+                    c: 4,
+                    d: 5,
+                    e: 6,
+                    f: 7,
+                }
+            };
+        }};
+    }
+
+    test_case!(u8);
+    test_case!(u16);
+    test_case!(u32);
+    test_case!(u64);
+    test_case!(u128);
+    test_case!(usize);
+}
+
+#[test]
+fn unsigned_to_signed() {
+    macro_rules! test_case {
+        ($ty:ty) => {{
+            #[derive(Debug, PartialEq, Encode, Decode)]
+            struct UnsignedIntegers {
+                a: $ty,
+                b: $ty,
+                c: $ty,
+                d: $ty,
+                e: $ty,
+                f: $ty,
+            }
+
+            tests::assert_decode_eq! {
+                descriptive,
+                UnsignedIntegers {
+                    a: 2,
+                    b: 3,
+                    c: 4,
+                    d: 5,
+                    e: 6,
+                    f: 7,
+                },
+                SignedIntegers {
+                    a: 2,
+                    b: 3,
+                    c: 4,
+                    d: 5,
+                    e: 6,
+                    f: 7,
+                }
+            };
+        }};
+    }
+
+    test_case!(i8);
+    test_case!(i16);
+    test_case!(i32);
+    test_case!(i64);
+    test_case!(i128);
+    test_case!(isize);
+}

--- a/tests/tests/numbers.rs
+++ b/tests/tests/numbers.rs
@@ -21,7 +21,7 @@ struct Unpacked {
     b: (Tag, Tag),
     c: (Tag, Tag),
     d: (Tag, Tag),
-    e: (Tag, Typed<[u8; 5]>),
+    e: (Tag, Typed<5>),
 }
 
 #[test]

--- a/tests/tests/primitives.rs
+++ b/tests/tests/primitives.rs
@@ -1,13 +1,13 @@
 #![cfg(feature = "test")]
 
-use musli::compat::{Bytes, Sequence};
+use musli::compat::Sequence;
 use musli::{Decode, Encode};
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 pub struct Inner;
 
 #[derive(Debug, PartialEq, Encode, Decode)]
-pub struct Numbers {
+pub struct Primitives {
     pub bool_field: bool,
     pub char_field: char,
     pub u8_field: u8,
@@ -20,18 +20,18 @@ pub struct Numbers {
     pub i32_field: i32,
     pub i64_field: i64,
     pub i128_field: i128,
+    pub f32_field: f32,
+    pub f64_field: f64,
     pub usize_field: usize,
     pub isize_field: isize,
-    pub empty_array_field: Bytes<[u8; 0]>,
     pub empty_tuple: (),
-    pub empty_sequence: Sequence<()>,
 }
 
 #[test]
-fn primitives_max() {
+fn primitives() {
     tests::rt!(
         full,
-        Numbers {
+        Primitives {
             bool_field: true,
             char_field: char::MAX,
             u8_field: u8::MAX,
@@ -44,20 +44,17 @@ fn primitives_max() {
             i32_field: i32::MAX,
             i64_field: i64::MAX,
             i128_field: i128::MAX,
+            f32_field: f32::MAX,
+            f64_field: f64::MAX,
             usize_field: usize::MAX,
             isize_field: isize::MAX,
-            empty_array_field: Bytes([]),
             empty_tuple: (),
-            empty_sequence: Sequence(()),
         }
     );
-}
 
-#[test]
-fn primitives_min() {
     tests::rt!(
         full,
-        Numbers {
+        Primitives {
             bool_field: false,
             char_field: '\u{0000}',
             u8_field: u8::MIN,
@@ -70,10 +67,57 @@ fn primitives_min() {
             i32_field: i32::MIN,
             i64_field: i64::MIN,
             i128_field: i128::MIN,
+            f32_field: f32::MIN,
+            f64_field: f64::MIN,
             usize_field: usize::MIN,
             isize_field: isize::MIN,
-            empty_array_field: Bytes([]),
             empty_tuple: (),
+        }
+    );
+}
+
+#[derive(Debug, PartialEq, Encode, Decode)]
+pub struct Arrays {
+    pub empty_array_field: [u8; 0],
+    pub ten_array: [i32; 10],
+}
+
+#[test]
+fn arrays() {
+    tests::rt!(
+        full,
+        Arrays {
+            empty_array_field: [],
+            ten_array: [i32::MIN; 10],
+        }
+    );
+
+    tests::rt!(
+        full,
+        Arrays {
+            empty_array_field: [],
+            ten_array: [i32::MAX; 10],
+        }
+    );
+}
+
+#[derive(Debug, PartialEq, Encode, Decode)]
+pub struct Sequences {
+    pub empty_sequence: Sequence<()>,
+}
+
+#[test]
+fn sequences() {
+    tests::rt!(
+        full,
+        Sequences {
+            empty_sequence: Sequence(()),
+        }
+    );
+
+    tests::rt!(
+        full,
+        Sequences {
             empty_sequence: Sequence(()),
         }
     );

--- a/tests/tests/struct_name.rs
+++ b/tests/tests/struct_name.rs
@@ -52,9 +52,9 @@ fn named_struct_unpack() {
     #[musli(packed)]
     pub struct Unpacked {
         field_count: Tag,
-        field1_name: Typed<[u8; 6]>,
-        field1_value: Typed<[u8; 3]>,
-        field2_name: Typed<[u8; 6]>,
+        field1_name: Typed<6>,
+        field1_value: Typed<3>,
+        field2_name: Typed<6>,
         field2_value: Tag,
     }
 
@@ -122,7 +122,7 @@ fn indexed_struct_unpack() {
     pub struct Unpacked {
         field_count: Tag,
         field1_index: Tag,
-        field1_value: Typed<[u8; 3]>,
+        field1_value: Typed<3>,
         field2_index: Tag,
         field2_value: Tag,
     }


### PR DESCRIPTION
This fixes an issue where data encoded in musli-descriptive would be incorrectly decoded in case there is a type-mismatch.

For example, if a i32 is decoded as a u32, zigzag encoding (if enabled) would cause the integer to be twice as wide when continuation-decoded.

This patch ensures that the available type information is used during decoding, and coerces integers into the appropriate format.

Also fixes an encoding mismatch with `[T; N]` arrays.