### PR TITLE
Add support for tagging through empty variants

### DIFF
--- a/crates/musli-macros/src/en.rs
+++ b/crates/musli-macros/src/en.rs
@@ -362,6 +362,16 @@ fn encode_variant(
     let mut encode;
 
     match en.enum_tagging {
+        EnumTagging::Empty => {
+            let static_type = en.static_type();
+            let encode_t_encode = &b.encode_t_encode;
+            let name = &v.name;
+
+            encode = quote! {{
+                static #name_static: #static_type = #name;
+                #encode_t_encode(&#name_static, #ctx_var, #encoder_var)?
+            }};
+        }
         EnumTagging::Default => {
             match v.st.packing {
                 Packing::Transparent => {

--- a/crates/musli-macros/src/expander.rs
+++ b/crates/musli-macros/src/expander.rs
@@ -71,7 +71,7 @@ pub(crate) struct VariantData<'a> {
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum StructKind {
-    Indexed,
+    Indexed(usize),
     Named,
 }
 
@@ -125,9 +125,9 @@ impl<'a> Expander<'a> {
                 name: syn::LitStr::new(&input.ident.to_string(), input.ident.span()),
                 fields: fields(&cx, &st.fields),
                 kind: match &st.fields {
+                    syn::Fields::Unit => StructKind::Indexed(0),
+                    syn::Fields::Unnamed(f) => StructKind::Indexed(f.unnamed.len()),
                     syn::Fields::Named(..) => StructKind::Named,
-                    syn::Fields::Unnamed(..) => StructKind::Indexed,
-                    syn::Fields::Unit => StructKind::Indexed,
                 },
             }),
             syn::Data::Enum(en) => {
@@ -143,9 +143,9 @@ impl<'a> Expander<'a> {
                         ident: &variant.ident,
                         fields: fields(&cx, &variant.fields),
                         kind: match &variant.fields {
+                            syn::Fields::Unit => StructKind::Indexed(0),
+                            syn::Fields::Unnamed(f) => StructKind::Indexed(f.unnamed.len()),
                             syn::Fields::Named(..) => StructKind::Named,
-                            syn::Fields::Unnamed(..) => StructKind::Indexed,
-                            syn::Fields::Unit => StructKind::Indexed,
                         },
                     });
 

--- a/crates/musli-macros/src/internals/attr.rs
+++ b/crates/musli-macros/src/internals/attr.rs
@@ -50,12 +50,13 @@ struct OneOf<T> {
     any: T,
 }
 
-#[derive(Default, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub(crate) enum EnumTagging<'a> {
     /// Use the default tagging method, as provided by the encoder-specific
     /// method.
-    #[default]
     Default,
+    /// Only the tag is encoded.
+    Empty,
     /// The type is internally tagged by the field given by the expression.
     Internal { tag: &'a syn::Expr },
     /// An enumerator is adjacently tagged.
@@ -241,15 +242,13 @@ impl TypeAttr {
     }
 
     /// Indicates the state of enum tagging.
-    pub(crate) fn enum_tagging(&self, mode: Mode<'_>) -> EnumTagging<'_> {
-        let Some((_, tag)) = self.tag(mode) else {
-            return EnumTagging::Default;
-        };
+    pub(crate) fn enum_tagging(&self, mode: Mode<'_>) -> Option<EnumTagging<'_>> {
+        let (_, tag) = self.tag(mode)?;
 
-        match self.content(mode) {
+        Some(match self.content(mode) {
             Some((_, content)) => EnumTagging::Adjacent { tag, content },
             _ => EnumTagging::Internal { tag },
-        }
+        })
     }
 
     /// Get the configured crate, or fallback to default.

--- a/tests/tests/enum_fallback.rs
+++ b/tests/tests/enum_fallback.rs
@@ -26,28 +26,28 @@ fn enum_default() {
         upgrade_stable,
         Enum::Variant1,
         EnumDefault::Fallback,
-        json = r#"{"0":{}}"#,
+        json = r#"0"#,
     );
 
     tests::assert_decode_eq!(
         upgrade_stable,
         Enum::Variant2,
         EnumDefault::Fallback,
-        json = r#"{"1":{}}"#,
+        json = r#"1"#,
     );
 
     tests::assert_decode_eq!(
         upgrade_stable,
         Enum::Variant3,
         EnumDefault::Fallback,
-        json = r#"{"2":{}}"#,
+        json = r#"2"#,
     );
 
     tests::assert_decode_eq!(
         upgrade_stable,
         Enum::Variant4,
         EnumDefault::Variant4,
-        json = r#"{"3":{}}"#,
+        json = r#"3"#,
     );
 }
 
@@ -67,27 +67,27 @@ fn enum_pattern() {
         upgrade_stable,
         Enum::Variant1,
         EnumPattern::Variant1,
-        json = r#"{"0":{}}"#,
+        json = r#"0"#,
     );
 
     tests::assert_decode_eq!(
         upgrade_stable,
         Enum::Variant2,
         EnumPattern::Fallback,
-        json = r#"{"1":{}}"#,
+        json = r#"1"#,
     );
 
     tests::assert_decode_eq!(
         upgrade_stable,
         Enum::Variant3,
         EnumPattern::Fallback,
-        json = r#"{"2":{}}"#,
+        json = r#"2"#,
     );
 
     tests::assert_decode_eq!(
         upgrade_stable,
         Enum::Variant4,
         EnumPattern::Variant4,
-        json = r#"{"3":{}}"#,
+        json = r#"3"#,
     );
 }

--- a/tests/tests/named_variants.rs
+++ b/tests/tests/named_variants.rs
@@ -38,35 +38,23 @@ enum ScreamingKebabCase {
 
 #[test]
 fn test_name_all() {
-    tests::rt!(
-        full,
-        PascalCase::VariantName,
-        json = r#"{"VariantName":{}}"#,
-    );
+    tests::rt!(full, PascalCase::VariantName, json = r#""VariantName""#,);
 
-    tests::rt!(full, CamelCase::VariantName, json = r#"{"variantName":{}}"#,);
+    tests::rt!(full, CamelCase::VariantName, json = r#""variantName""#,);
 
-    tests::rt!(
-        full,
-        SnakeCase::VariantName,
-        json = r#"{"variant_name":{}}"#,
-    );
+    tests::rt!(full, SnakeCase::VariantName, json = r#""variant_name""#,);
 
     tests::rt!(
         full,
         ScreamingSnakeCase::VariantName,
-        json = r#"{"VARIANT_NAME":{}}"#,
+        json = r#""VARIANT_NAME""#,
     );
 
-    tests::rt!(
-        full,
-        KebabCase::VariantName,
-        json = r#"{"variant-name":{}}"#,
-    );
+    tests::rt!(full, KebabCase::VariantName, json = r#""variant-name""#,);
 
     tests::rt!(
         full,
         ScreamingKebabCase::VariantName,
-        json = r#"{"VARIANT-NAME":{}}"#,
+        json = r#""VARIANT-NAME""#,
     );
 }


### PR DESCRIPTION
This adds support for enums which contains strictly empty variants. Such variants are encoded using the tag of the variant directly:

This covers enums like:

```rust
enum Enum {
    Variant1,
    Variant2(),
}
```

In text encodings, this would be encoded as `"Variant1"` or `"Variant2"` by default, for binary `0` or `1`.

But not if a struct variant is specified even if empty, this is instead taken as a hint that normal encoding should apply for future compatibility:

```rust
enum Enum {
    Variant1,
    Variant2(),
    Variant3{}
}
```