### PR TITLE
Introduce musli-ws

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,30 @@ jobs:
     - run: cargo check -p musli --no-default-features --features ${{matrix.base}},simdutf8
     - run: cargo check -p musli --no-default-features --features ${{matrix.base}},parse-full
 
+  crate_features:
+    needs: [rustfmt, clippy]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        crate:
+        - musli-ws
+        features:
+        - ""
+        - json
+        - api
+        - yew
+        - axum
+        - axum,ws
+    env:
+      RUSTFLAGS: -D warnings
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+    - run: cargo build -p ${{matrix.crate}} --no-default-features --features ${{matrix.features}}
+    - run: cargo build -p ${{matrix.crate}} --no-default-features --features ${{matrix.features}},alloc
+    - run: cargo build -p ${{matrix.crate}} --no-default-features --features ${{matrix.features}},std
+
   recursive:
     runs-on: ubuntu-latest
     steps:

--- a/crates/musli-ws/Cargo.toml
+++ b/crates/musli-ws/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "musli-ws"
+version = "0.0.131"
+authors = ["John-John Tedro <udoprog@tedro.se>"]
+edition = "2021"
+description = """
+Types for integrating Müsli with websocket frameworks.
+"""
+documentation = "https://docs.rs/musli"
+readme = "README.md"
+homepage = "https://github.com/udoprog/musli"
+repository = "https://github.com/udoprog/musli"
+license = "MIT OR Apache-2.0"
+keywords = ["framework", "http", "web"]
+categories = ["asynchronous", "network-programming", "web-programming::http-server"]
+
+[features]
+default = ["alloc", "std"]
+alloc = ["musli?/alloc"]
+std = ["musli?/std"]
+api = ["alloc", "dep:musli"]
+json = ["musli/json", "dep:bytes", "dep:mime", "dep:axum-core", "dep:http"]
+ws = ["musli/storage", "std", "api", "dep:bytes", "dep:rand", "tokio/time", "dep:tokio-stream", "dep:axum-core", "axum/ws"]
+yew = ["musli/storage", "std", "api", "dep:log", "dep:slab", "dep:wasm-bindgen", "dep:web-sys", "dep:yew", "dep:gloo"]
+
+[dependencies]
+musli = { path = "../musli", version = "0.0.131", default-features = false, optional = true }
+axum-core = { version = "0.5.2", default-features = false, optional = true }
+http = { version = "1.3.1", default-features = false, optional = true }
+axum = { version = "0.8.0", default-features = false, optional = true }
+bytes = { version = "1.10.0", optional = true }
+mime = { version = "0.3.17", default-features = false, optional = true }
+rand = { version = "0.9.1", default-features = false, optional = true, features = ["small_rng"] }
+tracing = { version = "0.1.40", default-features = false }
+tokio = { version = "1.37.0", default-features = false, features = ["time"], optional = true }
+tokio-stream = { version = "0.1.15", default-features = false, optional = true }
+
+log = { version = "0.4.21", default-features = false, optional = true }
+slab = { version = "0.4.9", default-features = false, optional = true }
+wasm-bindgen = { version = "0.2.92", default-features = false, optional = true }
+web-sys = { version = "0.3.69", default-features = false, features = ["WebSocket", "MessageEvent", "Performance"], optional = true }
+yew = { version = "0.21.0", default-features = false, optional = true }
+gloo = { version = "0.11.0", default-features = false, features = ["timers"], optional = true }

--- a/crates/musli-ws/README.md
+++ b/crates/musli-ws/README.md
@@ -1,0 +1,11 @@
+# musli-ws
+
+[<img alt="github" src="https://img.shields.io/badge/github-udoprog/musli-8da0cb?style=for-the-badge&logo=github" height="20">](https://github.com/udoprog/musli)
+[<img alt="crates.io" src="https://img.shields.io/crates/v/musli-ws.svg?style=for-the-badge&color=fc8d62&logo=rust" height="20">](https://crates.io/crates/musli-ws)
+[<img alt="docs.rs" src="https://img.shields.io/badge/docs.rs-musli--ws-66c2a5?style=for-the-badge&logoColor=white&logo=data:image/svg+xml;base64,PHN2ZyByb2xlPSJpbWciIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDUxMiA1MTIiPjxwYXRoIGZpbGw9IiNmNWY1ZjUiIGQ9Ik00ODguNiAyNTAuMkwzOTIgMjE0VjEwNS41YzAtMTUtOS4zLTI4LjQtMjMuNC0zMy43bC0xMDAtMzcuNWMtOC4xLTMuMS0xNy4xLTMuMS0yNS4zIDBsLTEwMCAzNy41Yy0xNC4xIDUuMy0yMy40IDE4LjctMjMuNCAzMy43VjIxNGwtOTYuNiAzNi4yQzkuMyAyNTUuNSAwIDI2OC45IDAgMjgzLjlWMzk0YzAgMTMuNiA3LjcgMjYuMSAxOS45IDMyLjJsMTAwIDUwYzEwLjEgNS4xIDIyLjEgNS4xIDMyLjIgMGwxMDMuOS01MiAxMDMuOSA1MmMxMC4xIDUuMSAyMi4xIDUuMSAzMi4yIDBsMTAwLTUwYzEyLjItNi4xIDE5LjktMTguNiAxOS45LTMyLjJWMjgzLjljMC0xNS05LjMtMjguNC0yMy40LTMzLjd6TTM1OCAyMTQuOGwtODUgMzEuOXYtNjguMmw4NS0zN3Y3My4zek0xNTQgMTA0LjFsMTAyLTM4LjIgMTAyIDM4LjJ2LjZsLTEwMiA0MS40LTEwMi00MS40di0uNnptODQgMjkxLjFsLTg1IDQyLjV2LTc5LjFsODUtMzguOHY3NS40em0wLTExMmwtMTAyIDQxLjQtMTAyLTQxLjR2LS42bDEwMi0zOC4yIDEwMiAzOC4ydi42em0yNDAgMTEybC04NSA0Mi41di03OS4xbDg1LTM4Ljh2NzUuNHptMC0xMTJsLTEwMiA0MS40LTEwMi00MS40di0uNmwxMDItMzguMiAxMDIgMzguMnYuNnoiPjwvcGF0aD48L3N2Zz4K" height="20">](https://docs.rs/musli-ws)
+[<img alt="build status" src="https://img.shields.io/github/actions/workflow/status/udoprog/musli/ci.yml?branch=main&style=for-the-badge" height="20">](https://github.com/udoprog/musli/actions?query=branch%3Amain)
+
+This crate provides a set of utilities for working with [Axum] and [Müsli].
+
+[Axum]: https://github.com/tokio-rs/axum
+[Müsli]: https://github.com/udoprog/musli

--- a/crates/musli-ws/src/api.rs
+++ b/crates/musli-ws/src/api.rs
@@ -1,0 +1,46 @@
+//! Shared traits for defining API types.
+
+use musli::alloc::System;
+use musli::mode::Binary;
+use musli::{Decode, Encode};
+
+/// A marker indicating a decodable type.
+pub trait Marker: 'static {
+    /// The type that can be decoded.
+    type Type<'de>: Decode<'de, Binary, System>;
+}
+
+/// Trait governing requests.
+pub trait Request: Encode<Binary> {
+    /// The kind of the request.
+    const KIND: &'static str;
+
+    /// Type acting as a token for the response.
+    type Marker: Marker;
+}
+
+/// A broadcast type marker.
+pub trait Broadcast: Marker {
+    /// The kind of the broadcast being subscribed to.
+    const KIND: &'static str;
+}
+
+#[derive(Debug, Clone, Copy, Encode, Decode)]
+pub struct RequestHeader<'a> {
+    pub index: u32,
+    pub serial: u32,
+    /// The kind of the request.
+    pub kind: &'a str,
+}
+
+#[derive(Debug, Clone, Encode, Decode)]
+pub struct ResponseHeader<'de> {
+    pub index: u32,
+    pub serial: u32,
+    /// The response is a broadcast.
+    #[musli(default, skip_encoding_if = Option::is_none)]
+    pub broadcast: Option<&'de str>,
+    /// An error message in the response.
+    #[musli(default, skip_encoding_if = Option::is_none)]
+    pub error: Option<&'de str>,
+}

--- a/crates/musli-ws/src/json.rs
+++ b/crates/musli-ws/src/json.rs
@@ -1,0 +1,155 @@
+use alloc::string::{String, ToString};
+
+use axum_core::extract::rejection::BytesRejection;
+use axum_core::extract::{FromRequest, Request};
+use axum_core::response::{IntoResponse, Response};
+use bytes::{BufMut, Bytes, BytesMut};
+use http::header::{self, HeaderValue};
+use http::{HeaderMap, StatusCode};
+use musli::alloc::System;
+use musli::context::ErrorMarker;
+use musli::de::DecodeOwned;
+use musli::json::Encoding;
+use musli::mode::Text;
+use musli::Encode;
+
+const ENCODING: Encoding = Encoding::new();
+
+/// A rejection from the JSON extractor.
+pub enum JsonRejection {
+    ContentType,
+    Report(String),
+    BytesRejection(BytesRejection),
+}
+
+impl From<BytesRejection> for JsonRejection {
+    #[inline]
+    fn from(rejection: BytesRejection) -> Self {
+        JsonRejection::BytesRejection(rejection)
+    }
+}
+
+impl IntoResponse for JsonRejection {
+    fn into_response(self) -> Response {
+        let status;
+        let body;
+
+        match self {
+            JsonRejection::ContentType => {
+                status = StatusCode::UNSUPPORTED_MEDIA_TYPE;
+                body = String::from("Expected request with `Content-Type: application/json`");
+            }
+            JsonRejection::Report(report) => {
+                status = StatusCode::BAD_REQUEST;
+                body = report;
+            }
+            JsonRejection::BytesRejection(rejection) => {
+                return rejection.into_response();
+            }
+        }
+
+        (
+            status,
+            [(
+                header::CONTENT_TYPE,
+                HeaderValue::from_static(mime::TEXT_PLAIN_UTF_8.as_ref()),
+            )],
+            body,
+        )
+            .into_response()
+    }
+}
+
+/// Encode the given value as JSON.
+pub struct Json<T>(pub T);
+
+impl<T, S> FromRequest<S> for Json<T>
+where
+    T: DecodeOwned<Text, System>,
+    S: Send + Sync,
+{
+    type Rejection = JsonRejection;
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        if !json_content_type(req.headers()) {
+            return Err(JsonRejection::ContentType);
+        }
+
+        let bytes = Bytes::from_request(req, state).await?;
+        Self::from_bytes(&bytes)
+    }
+}
+
+fn json_content_type(headers: &HeaderMap) -> bool {
+    let content_type = if let Some(content_type) = headers.get(header::CONTENT_TYPE) {
+        content_type
+    } else {
+        return false;
+    };
+
+    let content_type = if let Ok(content_type) = content_type.to_str() {
+        content_type
+    } else {
+        return false;
+    };
+
+    let mime = if let Ok(mime) = content_type.parse::<mime::Mime>() {
+        mime
+    } else {
+        return false;
+    };
+
+    mime.type_() == "application"
+        && (mime.subtype() == "json" || mime.suffix().is_some_and(|name| name == "json"))
+}
+
+impl<T> IntoResponse for Json<T>
+where
+    T: Encode<Text>,
+{
+    fn into_response(self) -> Response {
+        let cx = musli::context::new().with_trace();
+
+        // Use a small initial capacity of 128 bytes like serde_json::to_vec
+        // https://docs.rs/serde_json/1.0.82/src/serde_json/ser.rs.html#2189
+        let mut buf = BytesMut::with_capacity(128).writer();
+
+        match ENCODING.to_writer_with(&cx, &mut buf, &self.0) {
+            Ok(()) => {
+                let content_type = [(
+                    header::CONTENT_TYPE,
+                    HeaderValue::from_static(mime::APPLICATION_JSON.as_ref()),
+                )];
+                let report = buf.into_inner().freeze();
+                (content_type, report).into_response()
+            }
+            Err(ErrorMarker { .. }) => {
+                let status = StatusCode::INTERNAL_SERVER_ERROR;
+                let content_type = [(
+                    header::CONTENT_TYPE,
+                    HeaderValue::from_static(mime::TEXT_PLAIN_UTF_8.as_ref()),
+                )];
+                let report = cx.report().to_string();
+                (status, content_type, report).into_response()
+            }
+        }
+    }
+}
+
+impl<T> Json<T>
+where
+    T: DecodeOwned<Text, System>,
+{
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Result<Self, JsonRejection> {
+        let cx = musli::context::new().with_trace();
+
+        if let Ok(value) = ENCODING.from_slice_with(&cx, bytes) {
+            return Ok(Json(value));
+        }
+
+        let report = cx.report();
+        let report = report.to_string();
+        Err(JsonRejection::Report(report))
+    }
+}

--- a/crates/musli-ws/src/lib.rs
+++ b/crates/musli-ws/src/lib.rs
@@ -1,0 +1,30 @@
+//! [<img alt="github" src="https://img.shields.io/badge/github-udoprog/musli-8da0cb?style=for-the-badge&logo=github" height="20">](https://github.com/udoprog/musli)
+//! [<img alt="crates.io" src="https://img.shields.io/crates/v/musli-ws.svg?style=for-the-badge&color=fc8d62&logo=rust" height="20">](https://crates.io/crates/musli-ws)
+//! [<img alt="docs.rs" src="https://img.shields.io/badge/docs.rs-musli--ws-66c2a5?style=for-the-badge&logoColor=white&logo=data:image/svg+xml;base64,PHN2ZyByb2xlPSJpbWciIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDUxMiA1MTIiPjxwYXRoIGZpbGw9IiNmNWY1ZjUiIGQ9Ik00ODguNiAyNTAuMkwzOTIgMjE0VjEwNS41YzAtMTUtOS4zLTI4LjQtMjMuNC0zMy43bC0xMDAtMzcuNWMtOC4xLTMuMS0xNy4xLTMuMS0yNS4zIDBsLTEwMCAzNy41Yy0xNC4xIDUuMy0yMy40IDE4LjctMjMuNCAzMy43VjIxNGwtOTYuNiAzNi4yQzkuMyAyNTUuNSAwIDI2OC45IDAgMjgzLjlWMzk0YzAgMTMuNiA3LjcgMjYuMSAxOS45IDMyLjJsMTAwIDUwYzEwLjEgNS4xIDIyLjEgNS4xIDMyLjIgMGwxMDMuOS01MiAxMDMuOSA1MmMxMC4xIDUuMSAyMi4xIDUuMSAzMi4yIDBsMTAwLTUwYzEyLjItNi4xIDE5LjktMTguNiAxOS45LTMyLjJWMjgzLjljMC0xNS05LjMtMjguNC0yMy40LTMzLjd6TTM1OCAyMTQuOGwtODUgMzEuOXYtNjguMmw4NS0zN3Y3My4zek0xNTQgMTA0LjFsMTAyLTM4LjIgMTAyIDM4LjJ2LjZsLTEwMiA0MS40LTEwMi00MS40di0uNnptODQgMjkxLjFsLTg1IDQyLjV2LTc5LjFsODUtMzguOHY3NS40em0wLTExMmwtMTAyIDQxLjQtMTAyLTQxLjR2LS42bDEwMi0zOC4yIDEwMiAzOC4ydi42em0yNDAgMTEybC04NSA0Mi41di03OS4xbDg1LTM4Ljh2NzUuNHptMC0xMTJsLTEwMiA0MS40LTEwMi00MS40di0uNmwxMDItMzguMiAxMDIgMzguMnYuNnoiPjwvcGF0aD48L3N2Zz4K" height="20">](https://docs.rs/musli-ws)
+//!
+//! This crate provides a set of utilities for working with [Axum] and [Müsli].
+//!
+//! [Axum]: https://github.com/tokio-rs/axum
+//! [Müsli]: https://github.com/udoprog/musli
+
+#![no_std]
+
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+#[cfg(all(feature = "json", feature = "alloc"))]
+mod json;
+#[cfg(all(feature = "json", feature = "alloc"))]
+pub use self::json::Json;
+
+#[cfg(feature = "api")]
+pub mod api;
+
+#[cfg(feature = "yew")]
+pub mod yew;
+
+#[cfg(all(feature = "ws", feature = "api", feature = "alloc"))]
+pub mod ws;

--- a/crates/musli-ws/src/ws.rs
+++ b/crates/musli-ws/src/ws.rs
@@ -1,0 +1,448 @@
+#[cfg(feature = "axum")]
+mod axum;
+#[cfg(feature = "axum")]
+pub use axum::AxumServer;
+
+use core::fmt::{self, Write};
+use core::future::Future;
+
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use bytes::Bytes;
+use musli::alloc::System;
+use musli::mode::Binary;
+use musli::reader::SliceReader;
+use musli::{Decode, Encode};
+use rand::prelude::*;
+use rand::rngs::SmallRng;
+use tokio::time::Duration;
+
+use crate::api;
+
+const MAX_CAPACITY: usize = 1048576;
+
+mod sealed {
+    pub trait Sealed {}
+
+    #[cfg(feature = "axum")]
+    impl Sealed for super::axum::AxumServer {}
+    #[cfg(feature = "axum")]
+    impl Sealed for axum::extract::ws::WebSocket {}
+}
+
+/// A websocket message.
+pub(crate) enum Message {
+    /// A text message.
+    Text,
+    /// A binary message.
+    Binary(Bytes),
+    /// A ping message.
+    Ping(Bytes),
+    /// A pong message.
+    Pong(Bytes),
+    /// A close message.
+    Close,
+}
+
+#[allow(async_fn_in_trait)]
+pub(crate) trait Socket: self::sealed::Sealed {
+    #[doc(hidden)]
+    type Error;
+
+    #[doc(hidden)]
+    type Message;
+
+    #[doc(hidden)]
+    async fn next(&mut self) -> Option<Result<Message, Self::Error>>;
+
+    #[doc(hidden)]
+    async fn send(&mut self, message: Self::Message) -> Result<(), Self::Error>;
+}
+
+/// The implementation of a server.
+pub trait ServerImplementation: self::sealed::Sealed {
+    #[doc(hidden)]
+    type Error;
+
+    #[doc(hidden)]
+    type Message;
+
+    #[doc(hidden)]
+    #[allow(private_bounds)]
+    type Socket: Socket<Message = Self::Message, Error = Self::Error>;
+
+    #[doc(hidden)]
+    fn ping(data: Bytes) -> Self::Message;
+
+    #[doc(hidden)]
+    fn pong(data: Bytes) -> Self::Message;
+
+    #[doc(hidden)]
+    fn binary(data: Bytes) -> Self::Message;
+
+    #[doc(hidden)]
+    fn close(code: u16, reason: &str) -> Self::Message;
+}
+
+enum OneOf<E> {
+    Error(Error),
+    Handler(E),
+}
+
+impl<E> From<Error> for OneOf<E> {
+    #[inline]
+    fn from(error: Error) -> Self {
+        Self::Error(error)
+    }
+}
+
+impl<E> From<musli::storage::Error> for OneOf<E> {
+    #[inline]
+    fn from(error: musli::storage::Error) -> Self {
+        Self::Error(Error::from(error))
+    }
+}
+
+impl<E> fmt::Display for OneOf<E>
+where
+    E: fmt::Display,
+{
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OneOf::Error(error) => error.fmt(f),
+            OneOf::Handler(error) => error.fmt(f),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum ErrorKind {
+    Axum { error: axum_core::Error },
+    Musli { error: musli::storage::Error },
+    UnknownRequest { kind: Box<str> },
+    FormatError,
+}
+
+#[derive(Debug)]
+pub struct Error {
+    kind: ErrorKind,
+}
+
+impl Error {
+    const fn new(kind: ErrorKind) -> Self {
+        Self { kind }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.kind {
+            ErrorKind::Axum { .. } => write!(f, "Error in axum"),
+            ErrorKind::Musli { .. } => write!(f, "Error in musli"),
+            ErrorKind::UnknownRequest { kind } => {
+                write!(f, "Unknown request kind: {kind}")
+            }
+            ErrorKind::FormatError => write!(f, "Error formatting error response"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match &self.kind {
+            ErrorKind::Axum { error } => Some(error),
+            ErrorKind::Musli { error } => Some(error),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(feature = "ws")]
+impl From<axum_core::Error> for Error {
+    #[inline]
+    fn from(error: axum_core::Error) -> Self {
+        Self::new(ErrorKind::Axum { error })
+    }
+}
+
+impl From<musli::storage::Error> for Error {
+    #[inline]
+    fn from(error: musli::storage::Error) -> Self {
+        Self::new(ErrorKind::Musli { error })
+    }
+}
+
+type Result<T, E = Error> = core::result::Result<T, E>;
+
+/// A handler for incoming requests.
+pub trait Handler: Send + Sync {
+    /// Error returned by handler.
+    type Error: 'static + Send + Sync + fmt::Display;
+
+    /// Handle a request.
+    fn handle<'this>(
+        &'this mut self,
+        incoming: &'this mut Incoming<'_>,
+        outgoing: &'this mut Outgoing<'_>,
+        kind: &'this str,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'this;
+}
+
+/// The server side of the websocket connection.
+pub struct Server<S, H>
+where
+    S: ServerImplementation,
+{
+    buf: Buf,
+    error: String,
+    socket: S::Socket,
+    handler: H,
+}
+
+impl<S, H> Server<S, H>
+where
+    S: ServerImplementation,
+{
+    /// Construct a new server with the specified handler.
+    #[inline]
+    pub fn new(socket: S::Socket, handler: H) -> Self {
+        Self {
+            buf: Buf::default(),
+            error: String::new(),
+            socket,
+            handler,
+        }
+    }
+}
+
+impl<S, H> Server<S, H>
+where
+    S: ServerImplementation,
+    Error: From<S::Error>,
+    H: Handler,
+{
+    /// Run the server.
+    pub async fn run(&mut self) -> Result<(), Error> {
+        tracing::trace!("Accepted");
+
+        const CLOSE_NORMAL: u16 = 1000;
+        const CLOSE_PROTOCOL_ERROR: u16 = 1002;
+        const CLOSE_TIMEOUT: Duration = Duration::from_secs(30);
+        const PING_TIMEOUT: Duration = Duration::from_secs(10);
+
+        let mut last_ping = None::<u32>;
+        let mut rng = SmallRng::seed_from_u64(0x404241112);
+        let mut close_interval = tokio::time::interval(CLOSE_TIMEOUT);
+        close_interval.reset();
+
+        let mut ping_interval = tokio::time::interval(PING_TIMEOUT);
+        ping_interval.reset();
+
+        let close_here = loop {
+            tokio::select! {
+                _ = close_interval.tick() => {
+                    break Some((CLOSE_NORMAL, "connection timed out"));
+                }
+                _ = ping_interval.tick() => {
+                    let payload = rng.random::<u32>();
+                    last_ping = Some(payload);
+                    let data = payload.to_ne_bytes().into_iter().collect::<Vec<_>>();
+                    tracing::trace!(data = ?&data[..], "Sending ping");
+                    self.socket.send(S::ping(data.to_vec().into())).await?;
+                    ping_interval.reset();
+                }
+                message = self.socket.next() => {
+                    let Some(message) = message else {
+                        break None;
+                    };
+
+                    match message? {
+                        Message::Text => break Some((CLOSE_PROTOCOL_ERROR, "unsupported message")),
+                        Message::Binary(bytes) => {
+                            let mut reader = SliceReader::new(&bytes);
+
+                            let header = match musli::storage::decode(&mut reader) {
+                                Ok(header) => header,
+                                Err(error) => {
+                                    tracing::warn!(?error, "Failed to decode request header");
+                                    break Some((CLOSE_PROTOCOL_ERROR, "invalid request"));
+                                }
+                            };
+
+                            match self.handle_request(reader, header).await {
+                                Ok(()) => {
+                                    self.flush().await?;
+                                },
+                                Err(error) => {
+                                    if write!(self.error, "{error}").is_err() {
+                                        return Err(Error::new(ErrorKind::FormatError));
+                                    }
+
+                                    self.buf.buffer.clear();
+
+                                    self.buf.write(api::ResponseHeader {
+                                        index: header.index,
+                                        serial: header.serial,
+                                        broadcast: None,
+                                        error: Some(self.error.as_str()),
+                                    })?;
+
+                                    self.flush().await?;
+                                }
+                            }
+                        },
+                        Message::Ping(payload) => {
+                            self.socket.send(S::pong(payload)).await?;
+                            continue;
+                        },
+                        Message::Pong(data) => {
+                            tracing::trace!(data = ?&data[..], "Pong");
+
+                            let Some(expected) = last_ping else {
+                                continue;
+                            };
+
+                            if expected.to_ne_bytes()[..] != data[..] {
+                                continue;
+                            }
+
+                            close_interval.reset();
+                            ping_interval.reset();
+                            last_ping = None;
+                        },
+                        Message::Close => break None,
+                    }
+                }
+            }
+        };
+
+        if let Some((code, reason)) = close_here {
+            tracing::trace!(code, reason, "Closing websocket with reason");
+
+            self.socket.send(S::close(code, reason)).await?;
+        } else {
+            tracing::trace!("Closing websocket");
+        };
+
+        Ok(())
+    }
+
+    async fn flush(&mut self) -> Result<()> {
+        self.socket
+            .send(S::binary(self.buf.buffer.to_vec().into()))
+            .await?;
+        self.error.clear();
+        self.buf.buffer.clear();
+        self.buf.buffer.shrink_to(MAX_CAPACITY);
+        Ok(())
+    }
+
+    async fn handle_request(
+        &mut self,
+        reader: SliceReader<'_>,
+        header: api::RequestHeader<'_>,
+    ) -> Result<(), OneOf<H::Error>> {
+        tracing::trace!("Got request: {header:?}");
+
+        self.buf.write(api::ResponseHeader {
+            index: header.index,
+            serial: header.serial,
+            broadcast: None,
+            error: None,
+        })?;
+
+        let mut incoming = Incoming {
+            error: None,
+            reader,
+        };
+
+        let mut outgoing = Outgoing {
+            error: None,
+            written: false,
+            buf: &mut self.buf,
+        };
+
+        if let Err(error) = self
+            .handler
+            .handle(&mut incoming, &mut outgoing, header.kind)
+            .await
+        {
+            return Err(OneOf::Handler(error));
+        }
+
+        if let Some(error) = incoming.error.take() {
+            return Err(OneOf::Error(Error::new(ErrorKind::Musli { error })));
+        }
+
+        if !outgoing.written {
+            return Err(OneOf::Error(Error::new(ErrorKind::UnknownRequest {
+                kind: header.kind.into(),
+            })));
+        }
+
+        Ok(())
+    }
+}
+
+/// An incoming request.
+pub struct Incoming<'de> {
+    error: Option<musli::storage::Error>,
+    reader: SliceReader<'de>,
+}
+
+impl<'de> Incoming<'de> {
+    /// Read a request.
+    #[inline]
+    pub fn read<T>(&mut self) -> Option<T>
+    where
+        T: Decode<'de, Binary, System>,
+    {
+        match musli::storage::decode(&mut self.reader) {
+            Ok(value) => Some(value),
+            Err(error) => {
+                self.error = Some(error);
+                None
+            }
+        }
+    }
+}
+
+/// Handler for an outgoing buffer.
+pub struct Outgoing<'a> {
+    error: Option<musli::storage::Error>,
+    written: bool,
+    buf: &'a mut Buf,
+}
+
+impl Outgoing<'_> {
+    /// Write a response.
+    pub fn write<T>(&mut self, value: T)
+    where
+        T: Encode<Binary>,
+    {
+        if let Err(error) = self.buf.write(value) {
+            self.error = Some(error);
+        } else {
+            self.written = true;
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct Buf {
+    buffer: Vec<u8>,
+}
+
+impl Buf {
+    fn write<T>(&mut self, value: T) -> Result<(), musli::storage::Error>
+    where
+        T: Encode<Binary>,
+    {
+        musli::storage::to_writer(&mut self.buffer, &value)?;
+        Ok(())
+    }
+}

--- a/crates/musli-ws/src/ws/axum.rs
+++ b/crates/musli-ws/src/ws/axum.rs
@@ -1,0 +1,72 @@
+use bytes::Bytes;
+use tokio_stream::StreamExt;
+
+use axum::extract::ws::{CloseFrame, Message, WebSocket};
+use axum_core::Error;
+
+use super::{Server, ServerImplementation, Socket};
+
+impl<H> Server<AxumServer, H> {
+    /// Construct a new axum server with the specified handler.
+    #[inline]
+    pub fn axum(socket: axum::extract::ws::WebSocket, handler: H) -> Self {
+        Self::new(socket, handler)
+    }
+}
+
+#[non_exhaustive]
+pub enum AxumServer {}
+
+impl Socket for WebSocket {
+    type Error = Error;
+    type Message = Message;
+
+    #[inline]
+    #[allow(private_interfaces)]
+    async fn next(&mut self) -> Option<Result<super::Message, Self::Error>> {
+        let result = StreamExt::next(self).await?;
+
+        match result {
+            Ok(Message::Text(..)) => Some(Ok(super::Message::Text)),
+            Ok(Message::Binary(data)) => Some(Ok(super::Message::Binary(data))),
+            Ok(Message::Ping(data)) => Some(Ok(super::Message::Ping(data))),
+            Ok(Message::Pong(data)) => Some(Ok(super::Message::Pong(data))),
+            Ok(Message::Close(..)) => Some(Ok(super::Message::Close)),
+            Err(err) => Some(Err(err)),
+        }
+    }
+
+    #[inline]
+    async fn send(&mut self, message: Self::Message) -> super::Result<(), Self::Error> {
+        WebSocket::send(self, message).await
+    }
+}
+
+impl ServerImplementation for AxumServer {
+    type Error = Error;
+    type Message = Message;
+    type Socket = WebSocket;
+
+    #[inline]
+    fn ping(data: Bytes) -> Self::Message {
+        Message::Ping(data)
+    }
+
+    #[inline]
+    fn pong(data: Bytes) -> Self::Message {
+        Message::Pong(data)
+    }
+
+    #[inline]
+    fn binary(data: Bytes) -> Self::Message {
+        Message::Binary(data)
+    }
+
+    #[inline]
+    fn close(code: u16, reason: &str) -> Self::Message {
+        Message::Close(Some(CloseFrame {
+            code,
+            reason: reason.into(),
+        }))
+    }
+}

--- a/crates/musli-ws/src/yew.rs
+++ b/crates/musli-ws/src/yew.rs
@@ -1,0 +1,736 @@
+//! Client side implementation for Yew.
+
+use core::cell::{Cell, RefCell};
+use core::fmt;
+use core::marker::PhantomData;
+use core::mem::take;
+
+use alloc::boxed::Box;
+use alloc::format;
+use alloc::rc::Rc;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+use std::collections::{hash_map, HashMap};
+
+use gloo::timers::callback::Timeout;
+use slab::Slab;
+use wasm_bindgen::closure::Closure;
+use wasm_bindgen::{JsCast, JsValue};
+use web_sys::js_sys::{ArrayBuffer, Uint8Array};
+use web_sys::{window, BinaryType, CloseEvent, ErrorEvent, MessageEvent, WebSocket};
+use yew::html::ImplicitClone;
+use yew::{Component, Context};
+
+use crate::api;
+
+const MAX_CAPACITY: usize = 1048576;
+
+/// The state of the connection.
+///
+/// A listener for state changes can be set up through
+/// [`Handle::state_changes`].
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[non_exhaustive]
+pub enum State {
+    /// The connection is open.
+    Open,
+    /// The connection is closed.
+    Closed,
+}
+
+/// Error type for the WebSocket service.
+#[derive(Debug)]
+pub struct Error {
+    kind: ErrorKind,
+}
+
+#[derive(Debug)]
+enum ErrorKind {
+    Message(String),
+    Storage(musli::storage::Error),
+    Overflow(usize, usize),
+}
+
+impl Error {
+    #[inline]
+    fn new(kind: ErrorKind) -> Self {
+        Self { kind }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.kind {
+            ErrorKind::Message(message) => write!(f, "{message}"),
+            ErrorKind::Storage(error) => write!(f, "Encoding error: {error}"),
+            ErrorKind::Overflow(at, len) => {
+                write!(f, "Internal packet overflow, {at} not in range 0-{len}")
+            }
+        }
+    }
+}
+
+impl core::error::Error for Error {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match &self.kind {
+            ErrorKind::Storage(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+impl From<musli::storage::Error> for Error {
+    fn from(error: musli::storage::Error) -> Self {
+        Self::new(ErrorKind::Storage(error))
+    }
+}
+
+impl From<JsValue> for Error {
+    fn from(error: JsValue) -> Self {
+        Self::new(ErrorKind::Message(format!("{error:?}")))
+    }
+}
+
+impl From<&str> for Error {
+    fn from(error: &str) -> Self {
+        Self::new(ErrorKind::Message(error.to_string()))
+    }
+}
+
+type Result<T, E = Error> = core::result::Result<T, E>;
+
+const INITIAL_TIMEOUT: u32 = 250;
+const MAX_TIMEOUT: u32 = 16000;
+
+struct ClientRequest<'a> {
+    header: api::RequestHeader<'a>,
+    body: Vec<u8>,
+}
+
+enum MsgKind {
+    Reconnect,
+    Open,
+    Close(CloseEvent),
+    Message(MessageEvent),
+    Error(ErrorEvent),
+    ClientRequest(ClientRequest<'static>),
+}
+
+/// A message passed into the WebSocket service.
+pub struct Msg {
+    kind: MsgKind,
+}
+
+impl Msg {
+    #[inline]
+    const fn new(kind: MsgKind) -> Self {
+        Self { kind }
+    }
+}
+
+/// The WebSocket service.
+pub struct Service<C> {
+    shared: Rc<Shared>,
+    socket: Option<WebSocket>,
+    opened: Option<Opened>,
+    state: State,
+    buffer: Vec<ClientRequest<'static>>,
+    output: Vec<u8>,
+    timeout: u32,
+    on_open: Closure<dyn Fn()>,
+    on_close: Closure<dyn Fn(CloseEvent)>,
+    on_message: Closure<dyn Fn(MessageEvent)>,
+    on_error: Closure<dyn Fn(ErrorEvent)>,
+    _timeout: Option<Timeout>,
+    _ping_timeout: Option<Timeout>,
+    _marker: PhantomData<C>,
+}
+
+impl<C> Service<C>
+where
+    C: Component,
+    C::Message: From<Msg> + From<Error>,
+{
+    /// Construct a new websocket service, and return it and an associated
+    /// handle to it.
+    pub fn new(ctx: &Context<C>) -> (Self, Handle) {
+        let link = ctx.link().clone();
+
+        let shared = Rc::new(Shared {
+            serial: Cell::new(0),
+            onmessage: Box::new(move |request| {
+                link.send_message(Msg::new(MsgKind::ClientRequest(request)))
+            }),
+            requests: RefCell::new(Slab::new()),
+            broadcasts: RefCell::new(HashMap::new()),
+            state_changes: RefCell::new(Slab::new()),
+        });
+
+        let on_open = {
+            let link = ctx.link().clone();
+
+            let cb: Box<dyn Fn()> = Box::new(move || {
+                link.send_message(Msg::new(MsgKind::Open));
+            });
+
+            Closure::wrap(cb)
+        };
+
+        let on_close = {
+            let link = ctx.link().clone();
+
+            let cb: Box<dyn Fn(CloseEvent)> = Box::new(move |e: CloseEvent| {
+                link.send_message(Msg::new(MsgKind::Close(e)));
+            });
+
+            Closure::wrap(cb)
+        };
+
+        let on_message = {
+            let link = ctx.link().clone();
+
+            let cb: Box<dyn Fn(MessageEvent)> = Box::new(move |e: MessageEvent| {
+                link.send_message(Msg::new(MsgKind::Message(e)));
+            });
+
+            Closure::wrap(cb)
+        };
+
+        let on_error = {
+            let link = ctx.link().clone();
+
+            let cb: Box<dyn Fn(ErrorEvent)> = Box::new(move |e: ErrorEvent| {
+                link.send_message(Msg::new(MsgKind::Error(e)));
+            });
+
+            Closure::wrap(cb)
+        };
+
+        let this = Self {
+            shared: shared.clone(),
+            socket: None,
+            opened: None,
+            state: State::Closed,
+            buffer: Vec::new(),
+            output: Vec::new(),
+            timeout: INITIAL_TIMEOUT,
+            on_open,
+            on_close,
+            on_message,
+            on_error,
+            _timeout: None,
+            _ping_timeout: None,
+            _marker: PhantomData,
+        };
+
+        let handle = Handle { shared };
+
+        (this, handle)
+    }
+
+    /// Send a client message.
+    fn send_client_request(&mut self, request: ClientRequest<'_>) -> Result<()> {
+        let Some(socket) = &self.socket else {
+            return Err("Socket is not connected".into());
+        };
+
+        self.output.clear();
+        musli::storage::to_writer(&mut self.output, &request.header)?;
+        self.output.extend_from_slice(request.body.as_slice());
+        socket.send_with_u8_array(&self.output)?;
+        self.output.shrink_to(MAX_CAPACITY);
+        Ok(())
+    }
+
+    fn message(&mut self, e: MessageEvent) -> Result<()> {
+        let Ok(array_buffer) = e.data().dyn_into::<ArrayBuffer>() else {
+            return Err("Expected message as ArrayBuffer".into());
+        };
+
+        let body = Rc::from(Uint8Array::new(&array_buffer).to_vec());
+        let mut reader = musli::reader::SliceReader::new(&body);
+
+        let header: api::ResponseHeader<'_> = musli::storage::decode(&mut reader)?;
+
+        match header.broadcast {
+            Some(kind) => {
+                let broadcasts = self.shared.broadcasts.borrow();
+                let at = body.len() - reader.remaining();
+
+                if let Some(broadcasts) = broadcasts.get(kind) {
+                    let mut it = broadcasts.iter();
+
+                    let last = it.next_back();
+                    let raw = RawPacket {
+                        body: body.clone(),
+                        at,
+                    };
+
+                    for (_, callback) in it {
+                        (callback)(raw.clone());
+                    }
+
+                    if let Some((_, callback)) = last {
+                        (callback)(raw);
+                    }
+                }
+            }
+            None => {
+                log::trace!(
+                    "Got response: index={}, serial={}",
+                    header.index,
+                    header.serial
+                );
+
+                let requests = self.shared.requests.borrow();
+
+                let Some(pending) = requests.get(header.index as usize) else {
+                    return Err("Header index out of bound".into());
+                };
+
+                if pending.serial == header.serial {
+                    if let Some(error) = header.error {
+                        (pending.callback)(Err(Error::from(error)));
+                    } else {
+                        let at = body.len() - reader.remaining();
+                        let raw = RawPacket { body, at };
+                        (pending.callback)(Ok(raw));
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn set_open(&mut self) {
+        log::trace!("Set open");
+        self.opened = Some(Opened { at: now() });
+        self.emit_state_change(State::Open);
+    }
+
+    fn is_open_for_a_while(&self) -> bool {
+        let Some(opened) = self.opened else {
+            return false;
+        };
+
+        let Some(at) = opened.at else {
+            return false;
+        };
+
+        let Some(now) = now() else {
+            return false;
+        };
+
+        (now - at) >= 250.0
+    }
+
+    fn set_closed(&mut self, ctx: &Context<C>) {
+        log::trace!(
+            "Set closed timeout={}, opened={:?}",
+            self.timeout,
+            self.opened
+        );
+
+        if !self.is_open_for_a_while() {
+            if self.timeout < MAX_TIMEOUT {
+                self.timeout *= 2;
+            }
+        } else {
+            self.timeout = INITIAL_TIMEOUT;
+        }
+
+        self.opened = None;
+        self.reconnect(ctx);
+        self.emit_state_change(State::Closed);
+    }
+
+    fn emit_state_change(&mut self, state: State) {
+        if self.state != state {
+            let callbacks = self.shared.state_changes.borrow();
+
+            for (_, callback) in callbacks.iter() {
+                callback(state);
+            }
+
+            self.state = state;
+        }
+    }
+
+    /// Handle an update message.
+    pub fn update(&mut self, ctx: &Context<C>, message: Msg) {
+        match message.kind {
+            MsgKind::Reconnect => {
+                log::trace!("Reconnect");
+
+                if let Err(error) = self.inner_connect() {
+                    ctx.link().send_message(error);
+                    self.inner_reconnect(ctx);
+                }
+            }
+            MsgKind::Open => {
+                log::trace!("Open");
+                self.set_open();
+
+                let buffer = take(&mut self.buffer);
+
+                for request in buffer {
+                    if let Err(error) = self.send_client_request(request) {
+                        ctx.link().send_message(error);
+                    }
+                }
+            }
+            MsgKind::Close(e) => {
+                log::trace!("Close: {} ({})", e.code(), e.reason());
+                self.set_closed(ctx);
+            }
+            MsgKind::Message(e) => {
+                if let Err(error) = self.message(e) {
+                    ctx.link().send_message(error);
+                }
+            }
+            MsgKind::Error(e) => {
+                log::error!("{}", e.message());
+                self.set_closed(ctx);
+            }
+            MsgKind::ClientRequest(request) => {
+                if self.opened.is_none() {
+                    self.buffer.push(request);
+                    return;
+                }
+
+                if let Err(error) = self.send_client_request(request) {
+                    ctx.link().send_message(error);
+                }
+            }
+        }
+    }
+
+    pub(crate) fn reconnect(&mut self, ctx: &Context<C>) {
+        if let Some(old) = self.socket.take() {
+            if let Err(error) = old.close() {
+                ctx.link().send_message(Error::from(error));
+            }
+        }
+
+        let link = ctx.link().clone();
+
+        self._timeout = Some(Timeout::new(self.timeout, move || {
+            link.send_message(Msg::new(MsgKind::Reconnect));
+        }));
+    }
+
+    /// Attempt to establish a websocket connection.
+    pub fn connect(&mut self, ctx: &Context<C>) {
+        if let Err(error) = self.inner_connect() {
+            ctx.link().send_message(error);
+            self.inner_reconnect(ctx);
+        }
+    }
+
+    fn inner_connect(&mut self) -> Result<()> {
+        let window = window().ok_or("No window")?;
+        let port = window.location().port()?;
+        let url = format!("ws://127.0.0.1:{port}/ws");
+        let ws = WebSocket::new(&url)?;
+
+        ws.set_binary_type(BinaryType::Arraybuffer);
+        ws.set_onopen(Some(self.on_open.as_ref().unchecked_ref()));
+        ws.set_onclose(Some(self.on_close.as_ref().unchecked_ref()));
+        ws.set_onmessage(Some(self.on_message.as_ref().unchecked_ref()));
+        ws.set_onerror(Some(self.on_error.as_ref().unchecked_ref()));
+
+        if let Some(old) = self.socket.replace(ws) {
+            old.close()?;
+        }
+
+        Ok(())
+    }
+
+    fn inner_reconnect(&mut self, ctx: &Context<C>) {
+        let link = ctx.link().clone();
+
+        self._timeout = Some(Timeout::new(1000, move || {
+            link.send_message(Msg::new(MsgKind::Reconnect));
+        }));
+    }
+}
+
+/// The handle for a pending request. Dropping this handle cancels the request.
+pub struct Request<T> {
+    inner: Option<(Rc<Shared>, u32)>,
+    _marker: PhantomData<T>,
+}
+
+impl<T> Request<T> {
+    /// An empty request handler.
+    #[inline]
+    pub fn empty() -> Self {
+        Self::default()
+    }
+}
+
+impl<T> Default for Request<T> {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            inner: None,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T> Drop for Request<T> {
+    #[inline]
+    fn drop(&mut self) {
+        if let Some((shared, index)) = self.inner.take() {
+            shared.requests.borrow_mut().try_remove(index as usize);
+        }
+    }
+}
+
+/// The handle for a pending request. Dropping this handle cancels the request.
+pub struct Listener<T> {
+    kind: &'static str,
+    index: usize,
+    shared: Rc<Shared>,
+    _marker: PhantomData<T>,
+}
+
+impl<T> Drop for Listener<T> {
+    #[inline]
+    fn drop(&mut self) {
+        let mut broadcast = self.shared.broadcasts.borrow_mut();
+
+        if let hash_map::Entry::Occupied(mut e) = broadcast.entry(self.kind) {
+            e.get_mut().try_remove(self.index);
+
+            if e.get().is_empty() {
+                e.remove();
+            }
+        }
+    }
+}
+
+/// The handle for state change listening. Dropping this handle cancels the request.
+pub struct StateListener {
+    index: usize,
+    shared: Rc<Shared>,
+}
+
+impl Drop for StateListener {
+    #[inline]
+    fn drop(&mut self) {
+        self.shared
+            .state_changes
+            .borrow_mut()
+            .try_remove(self.index);
+    }
+}
+
+#[derive(Clone)]
+struct RawPacket {
+    body: Rc<[u8]>,
+    at: usize,
+}
+
+/// A packet of data.
+pub struct Packet<T>
+where
+    T: api::Marker,
+{
+    raw: RawPacket,
+    _marker: PhantomData<T>,
+}
+
+impl<T> Packet<T>
+where
+    T: api::Marker,
+{
+    /// Handle a broadcast packet.
+    pub fn decode<C, F>(&self, ctx: &Context<C>, f: F)
+    where
+        F: FnOnce(T::Type<'_>),
+        C: Component,
+        C::Message: From<Error>,
+    {
+        let Some(bytes) = self.raw.body.get(self.raw.at..) else {
+            ctx.link()
+                .send_message(C::Message::from(Error::new(ErrorKind::Overflow(
+                    self.raw.at,
+                    self.raw.body.len(),
+                ))));
+            return;
+        };
+
+        match musli::storage::from_slice(bytes) {
+            Ok(value) => {
+                f(value);
+            }
+            Err(error) => {
+                ctx.link()
+                    .send_message(C::Message::from(Error::from(error)));
+            }
+        }
+    }
+}
+
+/// A handle to the WebSocket service.
+#[derive(Clone)]
+pub struct Handle {
+    shared: Rc<Shared>,
+}
+
+impl Handle {
+    /// Send a request of type `T`.
+    ///
+    /// Returns a handle for the request.
+    ///
+    /// If the handle is dropped, the request is cancelled.
+    pub fn request<C, T>(&self, ctx: &Context<C>, request: T) -> Request<T::Marker>
+    where
+        C: Component,
+        C::Message: From<Packet<T::Marker>> + From<Error>,
+        T: api::Request,
+    {
+        let body = match musli::storage::to_vec(&request) {
+            Ok(body) => body,
+            Err(error) => {
+                ctx.link()
+                    .send_message(C::Message::from(Error::from(error)));
+                return Request::default();
+            }
+        };
+
+        let mut requests = self.shared.requests.borrow_mut();
+        let serial = self.shared.serial.get();
+        self.shared.serial.set(serial.wrapping_add(1));
+
+        let link = ctx.link().clone();
+
+        let pending = Pending {
+            serial,
+            callback: Box::new(move |result| {
+                let raw = match result {
+                    Ok(raw) => raw,
+                    Err(error) => {
+                        link.send_message(C::Message::from(error));
+                        return;
+                    }
+                };
+
+                link.send_message(C::Message::from(Packet {
+                    raw,
+                    _marker: PhantomData,
+                }));
+            }),
+        };
+
+        let index = requests.insert(pending) as u32;
+
+        (self.shared.onmessage)(ClientRequest {
+            header: api::RequestHeader {
+                index,
+                serial,
+                kind: T::KIND,
+            },
+            body,
+        });
+
+        Request {
+            inner: Some((self.shared.clone(), index)),
+            _marker: PhantomData,
+        }
+    }
+
+    /// List for broadcasts of type `T`.
+    ///
+    /// Returns a handle for the broadcasts.
+    ///
+    /// If the handle is dropped, the listener is cancelled.
+    pub fn listen<C, T>(&self, ctx: &Context<C>) -> Listener<T>
+    where
+        C: Component,
+        C::Message: From<Packet<T>> + From<Error>,
+        T: api::Broadcast,
+    {
+        let mut broadcasts = self.shared.broadcasts.borrow_mut();
+
+        let slots = broadcasts.entry(T::KIND).or_default();
+        let link = ctx.link().clone();
+
+        let index = slots.insert(Box::new(move |raw| {
+            link.send_message(C::Message::from(Packet {
+                raw,
+                _marker: PhantomData,
+            }));
+        }));
+
+        Listener {
+            kind: T::KIND,
+            index,
+            shared: self.shared.clone(),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Listen for state changes to the underlying connection.
+    pub fn state_changes<C>(&self, ctx: &Context<C>) -> StateListener
+    where
+        C: Component,
+        C::Message: From<State>,
+    {
+        let link = ctx.link().clone();
+        let mut state = self.shared.state_changes.borrow_mut();
+
+        let index = state.insert(Box::new(move |state| {
+            link.send_message(C::Message::from(state))
+        }));
+
+        StateListener {
+            index,
+            shared: self.shared.clone(),
+        }
+    }
+}
+
+impl ImplicitClone for Handle {
+    #[inline]
+    fn implicit_clone(&self) -> Self {
+        self.clone()
+    }
+}
+
+impl PartialEq for Handle {
+    #[inline]
+    fn eq(&self, _: &Self) -> bool {
+        true
+    }
+}
+
+fn now() -> Option<f64> {
+    Some(window()?.performance()?.now())
+}
+
+struct Pending {
+    serial: u32,
+    callback: Box<dyn Fn(Result<RawPacket>)>,
+}
+
+type Broadcasts = HashMap<&'static str, Slab<Box<dyn Fn(RawPacket)>>>;
+type OnMessageCallback = dyn Fn(ClientRequest<'static>);
+type StateCallback = dyn Fn(State);
+
+struct Shared {
+    serial: Cell<u32>,
+    onmessage: Box<OnMessageCallback>,
+    requests: RefCell<Slab<Pending>>,
+    broadcasts: RefCell<Broadcasts>,
+    state_changes: RefCell<Slab<Box<StateCallback>>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Opened {
+    at: Option<f64>,
+}


### PR DESCRIPTION
This adds support for binary communication over a websocket with musli-axum using the storage serialization, alongside convenience types for JSON responses through an axum-powered API.

It also adds the necessary yew component that allows for setting up and communicating over a websocket.