### PR TITLE
Include a serde no-std example (relates #148)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,11 +57,10 @@ jobs:
       fail-fast: false
       matrix:
         os: ['windows-latest', 'ubuntu-latest']
-        example: ['json']
+        example: ['json', 'serde']
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
-      - run: cargo build
       - run: cargo +nightly run -p no-std --example ${{matrix.example}}
 
   fuzz:

--- a/no-std/Cargo.toml
+++ b/no-std/Cargo.toml
@@ -4,7 +4,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-musli = { path = "../crates/musli", default-features = false, features = ["json", "parse-full"] }
+musli = { path = "../crates/musli", default-features = false, features = ["json", "parse-full", "serde"] }
+serde = { version = "1.0.202", default-features = false, features = ["derive"] }
 
 [target.'cfg(unix)'.dependencies]
 compiler_builtins = { git = "https://github.com/rust-lang/compiler-builtins", features = ["mem"] }

--- a/no-std/examples/prelude.rs
+++ b/no-std/examples/prelude.rs
@@ -1,0 +1,23 @@
+//! Helper module to set up everything you need in a no-std environment withotu
+//! alloc support.
+
+#[cfg(all(windows, target_env = "msvc"))]
+#[link(name = "msvcrt")]
+extern "C" {}
+
+#[cfg(unix)]
+#[link(name = "c")]
+extern "C" {}
+
+#[panic_handler]
+#[lang = "panic_impl"]
+fn rust_begin_panic(_: &core::panic::PanicInfo) -> ! {
+    core::intrinsics::abort();
+}
+
+#[lang = "eh_personality"]
+extern "C" fn eh_personality() {}
+
+#[cfg(unix)]
+#[no_mangle]
+pub extern "C" fn _Unwind_Resume() {}

--- a/no-std/examples/serde.rs
+++ b/no-std/examples/serde.rs
@@ -7,11 +7,19 @@ mod prelude;
 use musli::allocator::{Stack, StackBuffer};
 use musli::context::StackContext;
 use musli::{Decode, Encode};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Serde {
+    field: u32,
+}
 
 #[derive(Debug, Encode, Decode)]
 struct Value<'a> {
     name: &'a str,
     age: u32,
+    #[musli(with = musli::serde)]
+    serde: Serde,
 }
 
 #[start]
@@ -27,6 +35,7 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
     let value = Value {
         name: "Aristotle",
         age: 61,
+        serde: Serde { field: 42 },
     };
 
     let mut w = &mut buf[..];
@@ -55,6 +64,10 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
 
     if value.age != 61 {
         return 4;
+    }
+
+    if value.serde.field != 42 {
+        return 5;
     }
 
     0


### PR DESCRIPTION
This should make sure we don't accidentally regress in our serde support for no-std environments in the future.