### PR TITLE
Implement is_human_readable on basis of Mode v2 (closes #154)

### DIFF
--- a/crates/musli-core/src/context.rs
+++ b/crates/musli-core/src/context.rs
@@ -12,7 +12,7 @@ use crate::{Buf, Decode, Decoder};
 /// This is used to among other things report diagnostics.
 pub trait Context {
     /// Mode of the context.
-    type Mode;
+    type Mode: 'static;
     /// Error produced by context.
     type Error: 'static;
     /// A mark during processing.

--- a/crates/musli-core/src/de/decoder.rs
+++ b/crates/musli-core/src/de/decoder.rs
@@ -19,7 +19,7 @@ pub trait Decoder<'de>: Sized {
     /// Error associated with decoding.
     type Error;
     /// Mode associated with decoding.
-    type Mode;
+    type Mode: 'static;
     /// [`Decoder`] with a different context returned by
     /// [`Decoder::with_context`]
     type WithContext<'this, U>: Decoder<'de, Cx = U, Error = U::Error, Mode = U::Mode>

--- a/crates/musli-core/src/en/encoder.rs
+++ b/crates/musli-core/src/en/encoder.rs
@@ -20,7 +20,7 @@ pub trait Encoder: Sized {
     /// Error associated with encoding.
     type Error;
     /// Mode associated with encoding.
-    type Mode;
+    type Mode: 'static;
     /// Constructed [`Encoder`] with a different context.
     type WithContext<'this, U>: Encoder<Cx = U, Ok = Self::Ok, Error = U::Error, Mode = U::Mode>
     where

--- a/crates/musli/src/context/mod.rs
+++ b/crates/musli/src/context/mod.rs
@@ -73,6 +73,7 @@ where
 impl<A, M, E> Context for Same<A, M, E>
 where
     A: Allocator,
+    M: 'static,
     E: Error,
 {
     type Mode = M;
@@ -169,9 +170,11 @@ where
     }
 }
 
-impl<A, M, E: 'static> Context for Ignore<A, M, E>
+impl<A, M, E> Context for Ignore<A, M, E>
 where
     A: Allocator,
+    M: 'static,
+    E: 'static,
 {
     type Mode = M;
     type Error = ErrorMarker;
@@ -245,6 +248,7 @@ impl<A, M, E> Context for Capture<A, M, E>
 where
     A: Allocator,
     E: Error,
+    M: 'static,
 {
     type Mode = M;
     type Error = ErrorMarker;

--- a/crates/musli/src/context/stack_context.rs
+++ b/crates/musli/src/context/stack_context.rs
@@ -147,6 +147,7 @@ where
 impl<'a, const E: usize, const P: usize, A, M> Context for StackContext<'a, E, P, A, M>
 where
     A: ?Sized + Allocator,
+    M: 'static,
 {
     type Mode = M;
     type Error = ErrorMarker;

--- a/crates/musli/src/context/system_context.rs
+++ b/crates/musli/src/context/system_context.rs
@@ -123,6 +123,7 @@ where
 impl<A, M> Context for SystemContext<A, M>
 where
     A: Allocator,
+    M: 'static,
 {
     type Mode = M;
     type Error = ErrorMarker;

--- a/crates/musli/src/descriptive/encoding.rs
+++ b/crates/musli/src/descriptive/encoding.rs
@@ -28,7 +28,10 @@ pub const DEFAULT: Encoding = Encoding::new();
 crate::macros::bare_encoding!(Binary, DEFAULT, descriptive, IntoReader);
 
 /// Setting up encoding with parameters.
-pub struct Encoding<const OPT: Options = OPTIONS, M = Binary> {
+pub struct Encoding<const OPT: Options = OPTIONS, M = Binary>
+where
+    M: 'static,
+{
     _marker: marker::PhantomData<M>,
 }
 
@@ -75,7 +78,10 @@ impl Encoding<OPTIONS, Binary> {
     }
 }
 
-impl<const OPT: Options, M> Encoding<OPT, M> {
+impl<const OPT: Options, M> Encoding<OPT, M>
+where
+    M: 'static,
+{
     /// Change the mode of the encoding.
     ///
     /// # Examples

--- a/crates/musli/src/json/encoding.rs
+++ b/crates/musli/src/json/encoding.rs
@@ -92,7 +92,10 @@ where
 }
 
 /// Setting up encoding with parameters.
-pub struct Encoding<M = Text> {
+pub struct Encoding<M = Text>
+where
+    M: 'static,
+{
     _marker: marker::PhantomData<M>,
 }
 
@@ -145,7 +148,10 @@ impl Encoding<Text> {
     }
 }
 
-impl<M> Encoding<M> {
+impl<M> Encoding<M>
+where
+    M: 'static,
+{
     /// Change the mode of the encoding.
     ///
     /// # Examples

--- a/crates/musli/src/serde/deserializer.rs
+++ b/crates/musli/src/serde/deserializer.rs
@@ -1,3 +1,4 @@
+use core::any::TypeId;
 use core::fmt;
 
 use serde::de;
@@ -6,6 +7,7 @@ use crate::de::{
     Decoder, EntriesDecoder, MapDecoder, SequenceDecoder, SizeHint, VariantDecoder, Visitor,
 };
 use crate::hint::SequenceHint;
+use crate::mode::Text;
 use crate::Context;
 
 #[cfg(feature = "alloc")]
@@ -333,6 +335,11 @@ where
     {
         self.decoder.skip()?;
         visitor.visit_unit()
+    }
+
+    #[inline]
+    fn is_human_readable(&self) -> bool {
+        TypeId::of::<D::Mode>() == TypeId::of::<Text>()
     }
 }
 

--- a/crates/musli/src/serde/serializer.rs
+++ b/crates/musli/src/serde/serializer.rs
@@ -1,7 +1,9 @@
+use core::any::TypeId;
 use core::fmt;
 
 use crate::en::{EntriesEncoder, EntryEncoder, MapEncoder, SequenceEncoder, VariantEncoder};
 use crate::hint::{MapHint, SequenceHint};
+use crate::mode::Text;
 use crate::{Context, Encoder};
 
 use serde::ser::{self, Serialize};
@@ -272,6 +274,11 @@ where
     {
         let string = self.cx.collect_string(value)?;
         self.serialize_str(string.as_ref())
+    }
+
+    #[inline]
+    fn is_human_readable(&self) -> bool {
+        TypeId::of::<E::Mode>() == TypeId::of::<Text>()
     }
 }
 

--- a/crates/musli/src/storage/encoding.rs
+++ b/crates/musli/src/storage/encoding.rs
@@ -28,7 +28,10 @@ pub const DEFAULT: Encoding = Encoding::new();
 crate::macros::bare_encoding!(Binary, DEFAULT, storage, IntoReader);
 
 /// Setting up encoding with parameters.
-pub struct Encoding<const OPT: Options = OPTIONS, M = Binary> {
+pub struct Encoding<const OPT: Options = OPTIONS, M = Binary>
+where
+    M: 'static,
+{
     _marker: marker::PhantomData<M>,
 }
 
@@ -79,7 +82,10 @@ impl Encoding<OPTIONS, Binary> {
     }
 }
 
-impl<const OPT: Options, M> Encoding<OPT, M> {
+impl<const OPT: Options, M> Encoding<OPT, M>
+where
+    M: 'static,
+{
     /// Change the mode of the encoding.
     ///
     /// # Examples

--- a/crates/musli/src/wire/encoding.rs
+++ b/crates/musli/src/wire/encoding.rs
@@ -28,7 +28,10 @@ pub const DEFAULT: Encoding = Encoding::new();
 crate::macros::bare_encoding!(Binary, DEFAULT, wire, IntoReader);
 
 /// Setting up encoding with parameters.
-pub struct Encoding<const OPT: Options = OPTIONS, M = Binary> {
+pub struct Encoding<const OPT: Options = OPTIONS, M = Binary>
+where
+    M: 'static,
+{
     _marker: marker::PhantomData<M>,
 }
 
@@ -80,7 +83,10 @@ impl Encoding<OPTIONS, Binary> {
     }
 }
 
-impl<const OPT: Options, M> Encoding<OPT, M> {
+impl<const OPT: Options, M> Encoding<OPT, M>
+where
+    M: 'static,
+{
     /// Change the mode of the encoding.
     ///
     /// # Examples

--- a/crates/musli/tests/serde_human_readable.rs
+++ b/crates/musli/tests/serde_human_readable.rs
@@ -1,0 +1,105 @@
+//! Test that `is_human_readable` is set for the `Text` mode.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use musli::{Decode, Encode};
+
+#[derive(Debug, PartialEq, Encode, Decode)]
+struct Serde {
+    #[musli(with = musli::serde)]
+    ip: IpAddr,
+}
+
+#[derive(Debug, PartialEq, Encode, Decode)]
+struct StringField {
+    ip: String,
+}
+
+#[derive(Debug, PartialEq, Encode, Decode)]
+#[musli(name_type = str)]
+enum IpRepr {
+    #[musli(name = "V4", transparent)]
+    V4([u8; 4]),
+    #[musli(name = "V6", transparent)]
+    V6([u8; 16]),
+}
+
+#[derive(Debug, PartialEq, Encode, Decode)]
+struct Musli {
+    ip: IpRepr,
+}
+
+#[test]
+fn human_readable_ip_addr() {
+    macro_rules! test_case {
+        ($variant:ident, $ty:ty, $array:expr, $human:expr, $expected:literal $(, $args:expr)*) => {
+            musli::macros::assert_decode_eq!(
+                text_mode,
+                Serde {
+                    ip: IpAddr::$variant(<$ty>::new($($args),*))
+                },
+                StringField {
+                    ip: String::from($human)
+                },
+                json = concat!(r#"{"ip":""#, $human, r#""}"#),
+            );
+
+            musli::macros::assert_decode_eq!(
+                text_mode,
+                StringField {
+                    ip: String::from($human)
+                },
+                Serde {
+                    ip: IpAddr::$variant(<$ty>::new($($args),*))
+                },
+                json = concat!(r#"{"ip":""#, $human, r#""}"#),
+            );
+
+            musli::macros::assert_decode_eq!(
+                binary_mode,
+                Serde {
+                    ip: IpAddr::$variant(<$ty>::new($($args),*))
+                },
+                Musli {
+                    ip: IpRepr::$variant($array)
+                },
+                json_binary = concat!(r#"{"0":{""#, stringify!($variant), r#"":"#, $expected, r#"}}"#),
+            );
+
+            musli::macros::assert_decode_eq!(
+                binary_mode,
+                Musli {
+                    ip: IpRepr::$variant($array)
+                },
+                Serde {
+                    ip: IpAddr::$variant(<$ty>::new($($args),*))
+                },
+                json_binary = concat!(r#"{"0":{""#, stringify!($variant), r#"":"#, $expected, r#"}}"#),
+            );
+        }
+    }
+
+    test_case! {
+        V4, Ipv4Addr,
+        [127,0,0,1],
+        "127.0.0.1",
+        "[127,0,0,1]",
+        127, 0, 0, 1
+    };
+
+    test_case! {
+        V6, Ipv6Addr,
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0xc0, 0x0a, 0x02, 0xff],
+        "::ffff:192.10.2.255",
+        "[0,0,0,0,0,0,0,0,0,0,255,255,192,10,2,255]",
+        0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2ff
+    };
+
+    test_case! {
+        V6, Ipv6Addr,
+        [0, 38, 0, 0, 1, 201, 0, 0, 0, 0, 175, 200, 0, 16, 0, 1],
+        "26:0:1c9::afc8:10:1",
+        "[0,38,0,0,1,201,0,0,0,0,175,200,0,16,0,1]",
+        0x26, 0, 0x1c9, 0, 0, 0xafc8, 0x10, 0x1
+    };
+}


### PR DESCRIPTION
This builds on #154, but uses the proposed strategy of using a `TypeId` over static modes.