### PR TITLE
Fixes #171: Add the `core_in_error` feature

### DIFF
--- a/crates/musli-zerocopy/src/error.rs
+++ b/crates/musli-zerocopy/src/error.rs
@@ -141,6 +141,9 @@ impl std::error::Error for Error {
     }
 }
 
+#[cfg(all(not(feature = "std"), feature = "error_in_core"))]
+impl core::error::Error for Error {}
+
 #[derive(Debug)]
 #[cfg_attr(test, derive(PartialEq))]
 #[non_exhaustive]

--- a/crates/musli/Cargo.toml
+++ b/crates/musli/Cargo.toml
@@ -34,6 +34,7 @@ json = ["value", "dep:itoa", "dep:ryu"]
 parse-full = []
 value = []
 serde = ["dep:serde"]
+error_in_core = []
 
 test = ["storage", "wire", "descriptive", "json", "parse-full", "value", "serde"]
 

--- a/crates/musli/src/descriptive/error.rs
+++ b/crates/musli/src/descriptive/error.rs
@@ -55,6 +55,9 @@ impl std::error::Error for Error {
     }
 }
 
+#[cfg(all(not(feature = "std"), not(feature = "alloc"), feature = "error_in_core"))]
+impl core::error::Error for Error {}
+
 impl ContextError for Error {
     #[inline]
     #[allow(unused_variables)]

--- a/crates/musli/src/json/error.rs
+++ b/crates/musli/src/json/error.rs
@@ -42,6 +42,9 @@ impl fmt::Display for ErrorImpl {
 #[cfg(feature = "std")]
 impl std::error::Error for Error {}
 
+#[cfg(all(not(feature = "std"), feature = "error_in_core"))]
+impl core::error::Error for Error {}
+
 impl ContextError for Error {
     #[inline]
     fn custom<T>(error: T) -> Self

--- a/crates/musli/src/storage/error.rs
+++ b/crates/musli/src/storage/error.rs
@@ -42,6 +42,9 @@ impl fmt::Display for ErrorImpl {
 #[cfg(feature = "std")]
 impl std::error::Error for Error {}
 
+#[cfg(all(not(feature = "std"), feature = "error_in_core"))]
+impl core::error::Error for Error {}
+
 impl ContextError for Error {
     #[inline]
     fn custom<T>(error: T) -> Self

--- a/crates/musli/src/value/error.rs
+++ b/crates/musli/src/value/error.rs
@@ -48,6 +48,9 @@ impl fmt::Display for ErrorImpl {
 #[cfg(feature = "std")]
 impl std::error::Error for Error {}
 
+#[cfg(all(not(feature = "std"), feature = "error_in_core"))]
+impl core::error::Error for Error {}
+
 impl ContextError for Error {
     #[inline]
     fn custom<T>(error: T) -> Self

--- a/crates/musli/src/wire/error.rs
+++ b/crates/musli/src/wire/error.rs
@@ -42,6 +42,9 @@ impl fmt::Display for ErrorImpl {
 #[cfg(feature = "std")]
 impl std::error::Error for Error {}
 
+#[cfg(all(not(feature = "std"), feature = "error_in_core"))]
+impl core::error::Error for Error {}
+
 impl ContextError for Error {
     #[inline]
     fn custom<T>(error: T) -> Self


### PR DESCRIPTION
Implement `core::error` for Musli errors if the `core_in_error` feature is enabled.

This feature is automatically enabled in Rust nightly so when using Rust nightly you get this feature by default. When using stable Rust, this feature can be optionally added.