### PR TITLE
Remove default! allocator macro

### DIFF
--- a/crates/musli-core/src/alloc/allocator.rs
+++ b/crates/musli-core/src/alloc/allocator.rs
@@ -18,7 +18,7 @@ pub trait Allocator {
     ///
     /// let values: [u32; 4] = [1, 2, 3, 4];
     ///
-    /// musli::alloc::default!(|alloc| {
+    /// musli::alloc::default(|alloc| {
     ///     let mut buf = alloc.new_raw_vec::<u32>();
     ///     let mut len = 0;
     ///

--- a/crates/musli-core/src/alloc/raw_vec.rs
+++ b/crates/musli-core/src/alloc/raw_vec.rs
@@ -9,7 +9,7 @@
 ///
 /// let values: [u32; 4] = [1, 2, 3, 4];
 ///
-/// musli::alloc::default!(|alloc| {
+/// musli::alloc::default(|alloc| {
 ///     let mut buf = alloc.new_raw_vec::<u32>();
 ///     let mut len = 0;
 ///

--- a/crates/musli/src/alloc/default.rs
+++ b/crates/musli/src/alloc/default.rs
@@ -1,0 +1,99 @@
+use core::marker::PhantomData;
+
+#[cfg(not(feature = "alloc"))]
+use super::Slice;
+#[cfg(feature = "alloc")]
+use super::System;
+use super::{Allocator, RawVec};
+
+/// The default stack buffer size for the default allocator provided through
+/// [`default!`].
+pub const DEFAULT_ARRAY_BUFFER: usize = 4096;
+
+macro_rules! implement {
+    ($id:ident, $ty:ty) => {
+        /// Alias for the default allocator implementation.
+        ///
+        /// The exact type of this differs depending on whether the `alloc` feature is
+        /// enabled.
+        #[repr(transparent)]
+        pub struct $id<'buf, const BUF: usize> {
+            inner: $ty,
+            _marker: PhantomData<&'buf mut [u8]>,
+        }
+
+        /// Alias for the default raw vector implementation.
+        ///
+        /// The exact type of this differs depending on whether the `alloc` feature is
+        /// enabled.
+        pub struct DefaultRawVec<'a, 'buf: 'a, T, const BUF: usize>
+        where
+            T: 'a,
+        {
+            inner: <$ty as Allocator>::RawVec<'a, T>,
+            _marker: PhantomData<&'buf mut [u8]>,
+        }
+
+        impl<'buf, const BUF: usize> $id<'buf, BUF> {
+            #[inline]
+            #[cfg_attr(feature = "alloc", allow(clippy::needless_lifetimes))]
+            pub(super) fn new<'a>(alloc: &'a $ty) -> &'a Self {
+                // SAFETY: The type is repr(transparent) over the interior value.
+                unsafe { &*(alloc as *const $ty).cast::<Self>() }
+            }
+        }
+    };
+}
+
+#[cfg(feature = "alloc")]
+implement!(DefaultAllocator, System);
+
+#[cfg(not(feature = "alloc"))]
+implement!(DefaultAllocator, Slice<'buf>);
+
+impl<'buf, const BUF: usize> Allocator for DefaultAllocator<'buf, BUF> {
+    type RawVec<'this, T>
+        = DefaultRawVec<'this, 'buf, T, BUF>
+    where
+        Self: 'this,
+        T: 'this;
+
+    #[inline]
+    fn new_raw_vec<'a, T>(&'a self) -> Self::RawVec<'a, T>
+    where
+        T: 'a,
+    {
+        DefaultRawVec {
+            inner: self.inner.new_raw_vec(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, T, const BUF: usize> RawVec<T> for DefaultRawVec<'a, '_, T, BUF>
+where
+    T: 'a,
+{
+    #[inline]
+    fn resize(&mut self, len: usize, additional: usize) -> bool {
+        self.inner.resize(len, additional)
+    }
+
+    #[inline]
+    fn as_ptr(&self) -> *const T {
+        self.inner.as_ptr()
+    }
+
+    #[inline]
+    fn as_mut_ptr(&mut self) -> *mut T {
+        self.inner.as_mut_ptr()
+    }
+
+    #[inline]
+    fn try_merge<B>(&mut self, this_len: usize, other: B, other_len: usize) -> Result<(), B>
+    where
+        B: RawVec<T>,
+    {
+        self.inner.try_merge(this_len, other, other_len)
+    }
+}

--- a/crates/musli/src/alloc/vec.rs
+++ b/crates/musli/src/alloc/vec.rs
@@ -34,7 +34,7 @@ where
     /// ```
     /// use musli::alloc::Vec;
     ///
-    /// musli::alloc::default!(|alloc| {
+    /// musli::alloc::default(|alloc| {
     ///     let mut a = Vec::new_in(alloc);
     ///
     ///     a.push(String::from("Hello"));
@@ -63,7 +63,7 @@ where
     /// ```
     /// use musli::alloc::Vec;
     ///
-    /// musli::alloc::default!(|alloc| {
+    /// musli::alloc::default(|alloc| {
     ///     let mut a = Vec::new_in(alloc);
     ///
     ///     assert_eq!(a.len(), 0);
@@ -82,7 +82,7 @@ where
     /// ```
     /// use musli::alloc::Vec;
     ///
-    /// musli::alloc::default!(|alloc| {
+    /// musli::alloc::default(|alloc| {
     ///     let mut a = Vec::new_in(alloc);
     ///
     ///     assert!(a.is_empty());
@@ -105,7 +105,7 @@ where
     /// ```
     /// use musli::alloc::Vec;
     ///
-    /// musli::alloc::default!(|alloc| {
+    /// musli::alloc::default(|alloc| {
     ///     let mut a = Vec::new_in(alloc);
     ///
     ///     a.push(b'H');
@@ -141,7 +141,7 @@ where
     /// ```
     /// use musli::alloc::Vec;
     ///
-    /// musli::alloc::default!(|alloc| {
+    /// musli::alloc::default(|alloc| {
     ///     let mut a = Vec::new_in(alloc);
     ///
     ///     a.push(String::from("foo"));
@@ -172,7 +172,7 @@ where
     /// ```
     /// use musli::alloc::Vec;
     ///
-    /// musli::alloc::default!(|alloc| {
+    /// musli::alloc::default(|alloc| {
     ///     let mut a = Vec::new_in(alloc);
     ///
     ///     a.push(b'H');
@@ -199,7 +199,7 @@ where
     /// ```
     /// use musli::alloc::Vec;
     ///
-    /// musli::alloc::default!(|alloc| {
+    /// musli::alloc::default(|alloc| {
     ///     let mut a = Vec::new_in(alloc);
     ///     assert_eq!(a.as_slice(), b"");
     ///     a.write(b"Hello");
@@ -238,7 +238,7 @@ where
     /// ```
     /// use musli::alloc::Vec;
     ///
-    /// musli::alloc::default!(|alloc| {
+    /// musli::alloc::default(|alloc| {
     ///     let mut a = Vec::new_in(alloc);
     ///     assert_eq!(a.len(), 0);
     ///     a.write(b"Hello");
@@ -272,7 +272,7 @@ where
     /// ```
     /// use musli::alloc::Vec;
     ///
-    /// musli::alloc::default!(|alloc| {
+    /// musli::alloc::default(|alloc| {
     ///     let mut a = Vec::new_in(alloc);
     ///     let mut b = Vec::new_in(alloc);
     ///
@@ -307,14 +307,15 @@ where
 ///
 /// use musli::alloc::Vec;
 ///
-/// musli::alloc::default!(|alloc| {
+/// musli::alloc::default(|alloc| {
 ///     let mut a = Vec::new_in(alloc);
 ///     let world = "World";
 ///
 ///     write!(a, "Hello {world}")?;
 ///
 ///     assert_eq!(a.as_slice(), b"Hello World");
-/// });
+///     Ok(())
+/// })?;
 /// # Ok::<(), core::fmt::Error>(())
 /// ```
 impl<'a, A> fmt::Write for Vec<'a, u8, A>

--- a/crates/musli/src/context/mod.rs
+++ b/crates/musli/src/context/mod.rs
@@ -43,12 +43,13 @@ use crate::alloc::System;
 /// ```
 /// use musli::context;
 ///
-/// musli::alloc::default!(|alloc| {
+/// musli::alloc::default(|alloc| {
 ///     let cx = context::with_alloc(alloc);
 ///     let encoding = musli::json::Encoding::new();
 ///     let string = encoding.to_string_with(&cx, &42)?;
 ///     assert_eq!(string, "42");
-/// });
+///     Ok(())
+/// })?;
 /// # Ok::<(), musli::context::ErrorMarker>(())
 /// ```
 ///
@@ -84,12 +85,13 @@ where
 /// ```
 /// use musli::context;
 ///
-/// musli::alloc::default!(|alloc| {
+/// musli::alloc::default(|alloc| {
 ///     let cx = context::new();
 ///     let encoding = musli::json::Encoding::new();
 ///     let string = encoding.to_string_with(&cx, &42)?;
 ///     assert_eq!(string, "42");
-/// });
+///     Ok(())
+/// })?;
 /// # Ok::<(), musli::context::ErrorMarker>(())
 /// ```
 #[cfg(feature = "alloc")]

--- a/crates/musli/src/int/tests.rs
+++ b/crates/musli/src/int/tests.rs
@@ -16,7 +16,7 @@ const ITER: usize = 100;
 
 #[test]
 fn basic_continuation() {
-    crate::alloc::default!(|alloc| {
+    crate::alloc::default(|alloc| {
         let cx = context::Ignore::with_marker(&alloc);
         let mut bytes = FixedBytes::<8>::new();
         c::encode(&cx, &mut bytes, 5000u32).unwrap();
@@ -36,7 +36,7 @@ fn test_continuation_encoding() {
     where
         T: PartialEq<T> + fmt::Debug + Unsigned,
     {
-        crate::alloc::default!(|alloc| {
+        crate::alloc::default(|alloc| {
             let mut out = Vec::new();
             let cx = crate::context::Ignore::with_marker(&alloc);
             c::encode(&cx, &mut out, expected).unwrap();
@@ -55,7 +55,7 @@ fn test_continuation_encoding() {
     where
         T: Unsigned,
     {
-        crate::alloc::default!(|alloc| {
+        crate::alloc::default(|alloc| {
             let mut out = Vec::new();
             let cx = crate::context::Same::with_marker(&alloc);
             c::encode(&cx, crate::wrap::wrap(&mut out), value).unwrap();

--- a/crates/musli/src/json/encoding.rs
+++ b/crates/musli/src/json/encoding.rs
@@ -215,7 +215,7 @@ where
     where
         T: ?Sized + Encode<M>,
     {
-        crate::alloc::default!(|alloc| {
+        crate::alloc::default(|alloc| {
             let cx = crate::context::Same::with_alloc(alloc);
             self.to_string_with(&cx, value)
         })

--- a/crates/musli/src/json/parser/tests.rs
+++ b/crates/musli/src/json/parser/tests.rs
@@ -10,7 +10,7 @@ use crate::mode::Binary;
 
 #[test]
 fn test_decode_exponent() {
-    crate::alloc::default!(|alloc| {
+    crate::alloc::default(|alloc| {
         let cx = context::Same::<Binary, Error, _>::with_alloc(alloc);
 
         macro_rules! test_number {
@@ -47,7 +47,7 @@ fn test_decode_exponent() {
 
 #[test]
 fn test_decode_unsigned() {
-    crate::alloc::default!(|alloc| {
+    crate::alloc::default(|alloc| {
         let cx = context::Same::<Binary, Error, _>::with_alloc(alloc);
 
         macro_rules! test_number {
@@ -115,7 +115,7 @@ fn test_decode_unsigned() {
 
 #[test]
 fn test_decode_signed() {
-    crate::alloc::default!(|alloc| {
+    crate::alloc::default(|alloc| {
         let cx = context::Same::<Binary, Error, _>::with_alloc(alloc);
 
         macro_rules! test_number {

--- a/crates/musli/src/macros/internal.rs
+++ b/crates/musli/src/macros/internal.rs
@@ -321,7 +321,7 @@ macro_rules! encoding_impls {
             W: $writer_trait,
             T: ?Sized + $crate::Encode<$mode>,
         {
-            $crate::alloc::default!(|alloc| {
+            $crate::alloc::default(|alloc| {
                 let cx = $crate::context::Same::with_alloc(alloc);
                 self.encode_with(&cx, writer, value)
             })
@@ -367,7 +367,7 @@ macro_rules! encoding_impls {
         where
             T: ?Sized + $crate::Encode<$mode>,
         {
-            $crate::alloc::default!(|alloc| {
+            $crate::alloc::default(|alloc| {
                 let cx = $crate::context::Same::with_alloc(alloc);
                 self.to_slice_with(&cx, out, value)
             })
@@ -450,7 +450,7 @@ macro_rules! encoding_impls {
         where
             T: ?Sized + $crate::Encode<$mode>,
         {
-            $crate::alloc::default!(|alloc| {
+            $crate::alloc::default(|alloc| {
                 let cx = $crate::context::Same::with_alloc(alloc);
                 self.to_fixed_bytes_with(&cx, value)
             })
@@ -542,7 +542,7 @@ macro_rules! encoding_impls {
             R: $reader_trait<'de>,
             T: $crate::Decode<'de, $mode>,
         {
-            $crate::alloc::default!(|alloc| {
+            $crate::alloc::default(|alloc| {
                 let cx = $crate::context::Same::with_alloc(alloc);
                 self.decode_with(&cx, reader)
             })
@@ -581,7 +581,7 @@ macro_rules! encoding_impls {
         where
             T: $crate::Decode<'de, $mode>,
         {
-            $crate::alloc::default!(|alloc| {
+            $crate::alloc::default(|alloc| {
                 let cx = $crate::context::Same::with_alloc(alloc);
                 self.from_slice_with(&cx, bytes)
             })

--- a/crates/musli/src/macros/test.rs
+++ b/crates/musli/src/macros/test.rs
@@ -44,7 +44,7 @@ macro_rules! test_fns {
                 }
             }
 
-            $crate::alloc::default!(|alloc| {
+            $crate::alloc::default(|alloc| {
                 let mut cx = $crate::context::with_alloc(alloc);
                 cx.include_type();
 
@@ -130,7 +130,7 @@ macro_rules! test_fns {
                 }
             }
 
-            $crate::alloc::default!(|alloc| {
+            $crate::alloc::default(|alloc| {
                 let mut cx = $crate::context::with_alloc(alloc);
                 cx.include_type();
 
@@ -178,7 +178,7 @@ macro_rules! test_fns {
 
             use ::core::any::type_name;
 
-            $crate::alloc::default!(|alloc| {
+            $crate::alloc::default(|alloc| {
                 let mut cx = $crate::context::with_alloc(alloc);
                 cx.include_type();
 

--- a/crates/musli/src/value/mod.rs
+++ b/crates/musli/src/value/mod.rs
@@ -38,7 +38,7 @@ where
 
     let mut output = Value::Unit;
 
-    alloc::default!(|alloc| {
+    alloc::default(|alloc| {
         let cx = crate::context::Same::<Binary, Error, _>::with_alloc(alloc);
         ValueEncoder::<OPTIONS, _, _>::new(&cx, &mut output).encode(value)?;
         Ok(output)
@@ -52,7 +52,7 @@ where
 {
     use crate::de::Decoder;
 
-    alloc::default!(|alloc| {
+    alloc::default(|alloc| {
         let cx = crate::context::Same::<Binary, Error, _>::with_alloc(alloc);
         value.decoder::<OPTIONS, _>(&cx).decode()
     })

--- a/crates/musli/tests/storage_trace.rs
+++ b/crates/musli/tests/storage_trace.rs
@@ -30,7 +30,7 @@ struct To {
 
 #[test]
 fn storage_trace() {
-    musli::alloc::default!(|alloc| {
+    musli::alloc::default(|alloc| {
         let cx = context::with_alloc(alloc);
 
         let from = From {

--- a/crates/musli/tests/trace_collection.rs
+++ b/crates/musli/tests/trace_collection.rs
@@ -19,7 +19,7 @@ struct Collection {
 
 #[test]
 fn trace_collection() {
-    musli::alloc::default!(|alloc| {
+    musli::alloc::default(|alloc| {
         let cx = context::with_alloc(alloc);
 
         let mut values = HashMap::new();

--- a/crates/musli/tests/trace_complex.rs
+++ b/crates/musli/tests/trace_complex.rs
@@ -33,7 +33,7 @@ struct To {
 
 #[test]
 fn trace_complex() {
-    musli::alloc::default!(|alloc| {
+    musli::alloc::default(|alloc| {
         let cx = context::with_alloc(alloc);
 
         let mut field = HashMap::new();


### PR DESCRIPTION
This replaces the `alloc::default!` macro with two functions.

* `musli::alloc::default` - which works as the macro does right now, if `alloc` is not enabled uses a static buffer with a default size.
* `musli:;alloc::with_buffer` - which works the same as the macro but allows the caller to specify the size of the static buffer **if** it is used.

Both methods require the caller to not assume which kind of environment is in use, so local lifetimes and buffer sizes are present in all signature. It also abstracts away the exact allocator used to ensure that no specialization happens over a particular allocator implementation.