### PR TITLE
Change how the name container and variant attribute is parsed

### DIFF
--- a/crates/musli-core/src/mode.rs
+++ b/crates/musli-core/src/mode.rs
@@ -3,7 +3,7 @@
 /// The binary encoding mode.
 ///
 /// The key of fields and variants are encoded by their index, as if
-/// `#[musli(name_type = usize)]` was specified.
+/// `#[musli(name(type = usize))]` was specified.
 ///
 /// See [modes] for more.
 ///
@@ -13,7 +13,7 @@ pub enum Binary {}
 /// The text encoding mode.
 ///
 /// The key of fields and variants are encoded by their name, as if
-/// `#[musli(name_type = str)]` was specified.
+/// `#[musli(name(type = str))]` was specified.
 ///
 /// See [modes] for more.
 ///

--- a/crates/musli/src/descriptive/tests.rs
+++ b/crates/musli/src/descriptive/tests.rs
@@ -4,7 +4,7 @@ use super::tag::{Kind, Tag};
 use super::MAX_INLINE_LEN;
 
 #[derive(Debug, PartialEq, Encode, Decode)]
-#[musli(crate, name_type = usize)]
+#[musli(crate, name(type = usize))]
 struct From<const N: usize> {
     #[musli(name = 0)]
     prefix: Option<u32>,
@@ -15,7 +15,7 @@ struct From<const N: usize> {
 }
 
 #[derive(Debug, PartialEq, Encode, Decode)]
-#[musli(crate, name_type = usize)]
+#[musli(crate, name(type = usize))]
 struct To {
     #[musli(name = 0)]
     prefix: Option<u32>,

--- a/crates/musli/src/wire/tests/basic.rs
+++ b/crates/musli/src/wire/tests/basic.rs
@@ -3,7 +3,7 @@ use crate::wire::MAX_INLINE_LEN;
 use crate::{Decode, Encode};
 
 #[derive(Debug, PartialEq, Encode, Decode)]
-#[musli(crate, name_type = usize)]
+#[musli(crate, name(type = usize))]
 struct From<const N: usize> {
     #[musli(name = 0)]
     prefix: Option<u32>,
@@ -14,7 +14,7 @@ struct From<const N: usize> {
 }
 
 #[derive(Debug, PartialEq, Encode, Decode)]
-#[musli(crate, name_type = usize)]
+#[musli(crate, name(type = usize))]
 struct To {
     #[musli(name = 0)]
     prefix: Option<u32>,

--- a/crates/musli/tests/complex_naming.rs
+++ b/crates/musli/tests/complex_naming.rs
@@ -32,7 +32,7 @@ const CUSTOM_TAG1: FieldVariantTag = FieldVariantTag { name: "field1" };
 const CUSTOM_TAG2: FieldVariantTag = FieldVariantTag { name: "field2" };
 
 #[derive(Debug, PartialEq, Encode, Decode)]
-#[musli(name_type = FieldVariantTag)]
+#[musli(name(type = FieldVariantTag))]
 pub struct StructCustomFieldAsStruct {
     #[musli(name = CUSTOM_TAG1)]
     field1: u32,
@@ -57,7 +57,7 @@ fn custom_struct_tag() {
 }
 
 #[derive(Debug, PartialEq, Encode, Decode)]
-#[musli(name_type = Bytes<[u8; 4]>, name_format_with = BStr::new)]
+#[musli(name(type = Bytes<[u8; 4]>, format_with = BStr::new))]
 pub struct BytesName {
     #[musli(name = Bytes([1, 2, 3, 4]))]
     field1: u32,
@@ -119,7 +119,7 @@ impl fmt::Debug for UnsizedBytes {
 }
 
 #[derive(Debug, PartialEq, Encode, Decode)]
-#[musli(name_type = UnsizedBytes, name_method = "unsized")]
+#[musli(name(type = UnsizedBytes, method = "unsized"))]
 pub struct StructUnsizedBytes {
     #[musli(name = UnsizedBytes::new(&[1, 2, 3, 4]), pattern = UnsizedBytes([1, 2, 3, 4]))]
     field1: u32,
@@ -139,7 +139,7 @@ fn struct_unsized_bytes() {
 }
 
 #[derive(Debug, PartialEq, Encode, Decode)]
-#[musli(name_type = UnsizedBytes, name_method = "unsized")]
+#[musli(name(type = UnsizedBytes, method = "unsized"))]
 pub enum EnumUnsizedBytes {
     #[musli(name = UnsizedBytes::new(&[1, 2, 3, 4]), pattern = UnsizedBytes([1, 2, 3, 4]))]
     Variant1 { field1: u32 },
@@ -164,7 +164,7 @@ impl fmt::Display for CustomBytes<'_> {
 }
 
 #[derive(Debug, PartialEq, Encode, Decode)]
-#[musli(name_type = CustomBytes)]
+#[musli(name(type = CustomBytes))]
 struct StructWithCustomBytes {
     #[musli(name = CustomBytes(b"name in bytes"))]
     string: String,
@@ -181,11 +181,11 @@ fn struct_with_bytes_name() {
 }
 
 #[derive(Debug, PartialEq, Encode, Decode)]
-#[musli(name_type = CustomBytes)]
+#[musli(name(type = CustomBytes))]
 enum EnumWithCustomBytes {
     #[musli(name = CustomBytes(b"a"))]
     Variant1 { string: String },
-    #[musli(name = CustomBytes(b"b"), name_type = CustomBytes)]
+    #[musli(name = CustomBytes(b"b"), name(type = CustomBytes))]
     Variant2 {
         #[musli(name = CustomBytes(b"c"))]
         string: String,

--- a/crates/musli/tests/enum_adjacent.rs
+++ b/crates/musli/tests/enum_adjacent.rs
@@ -42,7 +42,7 @@ fn indexed() {
     macro_rules! test_case {
         ($ty:ty) => {{
             #[derive(Debug, PartialEq, Encode, Decode)]
-            #[musli(name_type = $ty, tag = 11, content = 22)]
+            #[musli(name(type = $ty), tag(value = 11, type = $ty), content(value = 22, type = $ty))]
             pub enum Indexed {
                 #[musli(name = 33, name_all = "name")]
                 Variant1 { variant1: u32 },
@@ -63,7 +63,7 @@ fn indexed() {
             };
 
             #[derive(Debug, PartialEq, Encode, Decode)]
-            #[musli(name_type = $ty, tag = 11, content = 22)]
+            #[musli(name(type = $ty), tag(value = 11, type = $ty), content(value = 22, type = $ty))]
             pub enum IndexedBounds {
                 #[musli(name = <$ty>::MAX, name_all = "name")]
                 Variant1 { variant1: u32 },

--- a/crates/musli/tests/enum_adjacent_variations.rs
+++ b/crates/musli/tests/enum_adjacent_variations.rs
@@ -1,0 +1,88 @@
+use bstr::BStr;
+use musli::{Decode, Encode};
+
+macro_rules! integer_tag {
+    ($name:ident, $name_value:ident, $ty:ty) => {
+        #[derive(Encode, Decode)]
+        #[musli(tag(value = 10, type = $ty), content(value = 20, type = $ty))]
+        pub enum $name {
+            Value,
+        }
+
+        #[derive(Encode, Decode)]
+        #[musli(tag(value = 10, type = $ty, method = "value"), content(value = 20, type = $ty, method = "value"))]
+        pub enum $name_value {
+            Value,
+        }
+    };
+}
+
+integer_tag!(U8, U8Value, u8);
+integer_tag!(U16, U16Value, u16);
+integer_tag!(U32, U32Value, u32);
+integer_tag!(U64, U64Value, u64);
+integer_tag!(U128, U128Value, u128);
+integer_tag!(I8, I8Value, i8);
+integer_tag!(I16, I16Value, i16);
+integer_tag!(I32, I32Value, i32);
+integer_tag!(I64, I64Value, i64);
+integer_tag!(I128, I128Value, i128);
+integer_tag!(Usize, UsizeValue, usize);
+integer_tag!(Isize, IsizeValue, isize);
+
+#[derive(Encode, Decode)]
+#[musli(tag(value = 10), content(value = 20))]
+pub enum Integer {
+    Value,
+}
+
+#[derive(Encode, Decode)]
+#[musli(
+    tag(value = 10, method = "value"),
+    content(value = 20, method = "value")
+)]
+pub enum IntegerValue {
+    Value,
+}
+
+#[derive(Encode, Decode)]
+#[musli(tag = "tag")]
+pub enum String {
+    Value,
+}
+
+#[derive(Encode, Decode)]
+#[musli(tag(value = "tag"), content(value = "content"))]
+pub enum StringValue {
+    Value,
+}
+
+#[derive(Encode, Decode)]
+#[musli(tag(value = "tag", type = str), content(value = "content", type = str))]
+pub enum StringValueType {
+    Value,
+}
+
+#[derive(Encode, Decode)]
+#[musli(tag(value = "tag", type = str, method = "unsized"), content(value = "content", type = str, method = "unsized"))]
+pub enum StringValueTypeUnsized {
+    Value,
+}
+
+#[derive(Encode, Decode)]
+#[musli(tag(value = b"tag", format_with = BStr::new), content(value = b"content", format_with = BStr::new))]
+pub enum BytesValue {
+    Value,
+}
+
+#[derive(Encode, Decode)]
+#[musli(tag(value = b"tag", type = [u8], format_with = BStr::new), content(value = b"content", type = [u8], format_with = BStr::new))]
+pub enum BytesValueType {
+    Value,
+}
+
+#[derive(Encode, Decode)]
+#[musli(tag(value = b"tag", type = [u8], method = "unsized_bytes", format_with = BStr::new), content(value = b"content", type = [u8], method = "unsized_bytes", format_with = BStr::new))]
+pub enum BytesValueTypeMethod {
+    Value,
+}

--- a/crates/musli/tests/enum_fallback.rs
+++ b/crates/musli/tests/enum_fallback.rs
@@ -3,7 +3,7 @@
 use musli::{Decode, Encode};
 
 #[derive(Debug, PartialEq, Encode, Decode)]
-#[musli(name_type = usize)]
+#[musli(name(type = usize))]
 pub enum Enum {
     Variant1,
     Variant2,
@@ -12,7 +12,7 @@ pub enum Enum {
 }
 
 #[derive(Debug, PartialEq, Encode, Decode)]
-#[musli(name_type = usize)]
+#[musli(name(type = usize))]
 pub enum EnumDefault {
     #[musli(name = 3)]
     Variant4,
@@ -52,7 +52,7 @@ fn enum_default() {
 }
 
 #[derive(Debug, PartialEq, Encode, Decode)]
-#[musli(name_type = usize)]
+#[musli(name(type = usize))]
 pub enum EnumPattern {
     Variant1,
     #[musli(pattern = 1..=2)]

--- a/crates/musli/tests/enum_internal.rs
+++ b/crates/musli/tests/enum_internal.rs
@@ -42,7 +42,7 @@ fn indexed() {
     macro_rules! test_case {
         ($ty:ty) => {{
             #[derive(Debug, PartialEq, Encode, Decode)]
-            #[musli(name_type = $ty, tag = 11)]
+            #[musli(name(type = $ty), tag(value = 11, type = $ty))]
             pub enum Indexed {
                 #[musli(name = 22)]
                 Variant1 { variant1: u32 },
@@ -63,7 +63,7 @@ fn indexed() {
             };
 
             #[derive(Debug, PartialEq, Encode, Decode)]
-            #[musli(name_type = $ty, tag = 11)]
+            #[musli(name(type = $ty), tag(value = 11, type = $ty))]
             pub enum IndexedBounds {
                 #[musli(name = <$ty>::MAX)]
                 Variant1 { variant1: u32 },

--- a/crates/musli/tests/enum_internal_variations.rs
+++ b/crates/musli/tests/enum_internal_variations.rs
@@ -1,0 +1,85 @@
+use bstr::BStr;
+use musli::{Decode, Encode};
+
+macro_rules! integer_tag {
+    ($name:ident, $name_value:ident, $ty:ty) => {
+        #[derive(Encode, Decode)]
+        #[musli(tag(value = 10, type = $ty))]
+        pub enum $name {
+            Value,
+        }
+
+        #[derive(Encode, Decode)]
+        #[musli(tag(value = 10, type = $ty, method = "value"))]
+        pub enum $name_value {
+            Value,
+        }
+    };
+}
+
+integer_tag!(U8, U8Value, u8);
+integer_tag!(U16, U16Value, u16);
+integer_tag!(U32, U32Value, u32);
+integer_tag!(U64, U64Value, u64);
+integer_tag!(U128, U128Value, u128);
+integer_tag!(I8, I8Value, i8);
+integer_tag!(I16, I16Value, i16);
+integer_tag!(I32, I32Value, i32);
+integer_tag!(I64, I64Value, i64);
+integer_tag!(I128, I128Value, i128);
+integer_tag!(Usize, UsizeValue, usize);
+integer_tag!(Isize, IsizeValue, isize);
+
+#[derive(Encode, Decode)]
+#[musli(tag(value = 10))]
+pub enum Integer {
+    Value,
+}
+
+#[derive(Encode, Decode)]
+#[musli(tag(value = 10, method = "value"))]
+pub enum IntegerValue {
+    Value,
+}
+
+#[derive(Encode, Decode)]
+#[musli(tag = "tag")]
+pub enum String {
+    Value,
+}
+
+#[derive(Encode, Decode)]
+#[musli(tag(value = "tag"))]
+pub enum StringValue {
+    Value,
+}
+
+#[derive(Encode, Decode)]
+#[musli(tag(value = "tag", type = str))]
+pub enum StringValueType {
+    Value,
+}
+
+#[derive(Encode, Decode)]
+#[musli(tag(value = "tag", type = str, method = "unsized"))]
+pub enum StringValueTypeUnsized {
+    Value,
+}
+
+#[derive(Encode, Decode)]
+#[musli(tag(value = b"tag", format_with = BStr::new))]
+pub enum BytesValue {
+    Value,
+}
+
+#[derive(Encode, Decode)]
+#[musli(tag(value = b"tag", type = [u8], format_with = BStr::new))]
+pub enum BytesValueType {
+    Value,
+}
+
+#[derive(Encode, Decode)]
+#[musli(tag(value = b"tag", type = [u8], method = "unsized_bytes", format_with = BStr::new))]
+pub enum BytesValueTypeMethod {
+    Value,
+}

--- a/crates/musli/tests/lifetime_name_type.rs
+++ b/crates/musli/tests/lifetime_name_type.rs
@@ -5,7 +5,7 @@ use bstr::BStr;
 use musli::{Decode, Encode};
 
 #[derive(Encode, Decode)]
-#[musli(name_type = str)]
+#[musli(name(type = str))]
 struct StructStr {
     #[musli(name = "field1")]
     field1: u32,
@@ -14,7 +14,7 @@ struct StructStr {
 }
 
 #[derive(Encode, Decode)]
-#[musli(name_type = [u8], name_format_with = BStr::new)]
+#[musli(name(type = [u8], format_with = BStr::new))]
 struct StructBytes {
     #[musli(name = &[b'f', b'i', b'e', b'l', b'd', b'1'])]
     field1: u32,
@@ -23,7 +23,7 @@ struct StructBytes {
 }
 
 #[derive(Encode, Decode)]
-#[musli(name_type = [u8], name_format_with = BStr::new)]
+#[musli(name(type = [u8], format_with = BStr::new))]
 struct StructBytesArray {
     #[musli(name = b"field1")]
     field1: u32,

--- a/crates/musli/tests/name_attribute.rs
+++ b/crates/musli/tests/name_attribute.rs
@@ -1,0 +1,10 @@
+use musli::{Decode, Encode};
+
+#[derive(Debug, PartialEq, Encode, Decode)]
+#[musli(name(type = usize, method = "value"))]
+pub struct Struct2 {
+    field1: u32,
+    field2: u32,
+    field3: u32,
+    field4: u32,
+}

--- a/crates/musli/tests/name_types.rs
+++ b/crates/musli/tests/name_types.rs
@@ -5,7 +5,7 @@ fn struct_fields() {
     macro_rules! test_case {
         ($ty:ty) => {{
             #[derive(Debug, PartialEq, Encode, Decode)]
-            #[musli(name_type = $ty)]
+            #[musli(name(type = $ty))]
             struct Struct {
                 #[musli(name = <$ty>::MIN)]
                 min: u32,
@@ -40,7 +40,7 @@ fn variant_names() {
     macro_rules! test_case {
         ($ty:ty) => {{
             #[derive(Debug, PartialEq, Encode, Decode)]
-            #[musli(name_type = $ty)]
+            #[musli(name(type = $ty))]
             enum Enum {
                 #[musli(packed, name = <$ty>::MAX)]
                 Variant1(u32),

--- a/crates/musli/tests/serde_human_readable.rs
+++ b/crates/musli/tests/serde_human_readable.rs
@@ -16,7 +16,7 @@ struct StringField {
 }
 
 #[derive(Debug, PartialEq, Encode, Decode)]
-#[musli(name_type = str)]
+#[musli(name(type = str))]
 enum IpRepr {
     #[musli(name = "V4", transparent)]
     V4([u8; 4]),

--- a/crates/musli/tests/struct_fallback.rs
+++ b/crates/musli/tests/struct_fallback.rs
@@ -3,7 +3,7 @@
 use musli::{Decode, Encode};
 
 #[derive(Debug, PartialEq, Encode, Decode)]
-#[musli(name_type = usize)]
+#[musli(name(type = usize))]
 pub struct Struct {
     field1: u32,
     field2: u32,
@@ -12,7 +12,7 @@ pub struct Struct {
 }
 
 #[derive(Debug, PartialEq, Encode, Decode)]
-#[musli(name_type = usize)]
+#[musli(name(type = usize))]
 pub struct StructPattern {
     field1: u32,
     #[musli(pattern = 1..=2)]
@@ -40,7 +40,7 @@ fn struct_pattern() {
 }
 
 #[derive(Debug, PartialEq, Encode, Decode)]
-#[musli(name_type = usize)]
+#[musli(name(type = usize))]
 pub struct StructRename {
     #[musli(name = 3)]
     field4: u32,

--- a/crates/musli/tests/struct_name.rs
+++ b/crates/musli/tests/struct_name.rs
@@ -10,7 +10,7 @@ pub struct Named {
 }
 
 #[derive(Debug, PartialEq, Encode, Decode)]
-#[musli(name_type = str)]
+#[musli(name(type = str))]
 pub struct NamedByType {
     string: String,
     number: u32,


### PR DESCRIPTION
This is the first change to make `name` attribute parsing slightly more consistent to soon allow the same treatment of `tag` and `content`, particularly so that their behavior can be customized when needed.