### PR TITLE
Start moving value to use Allocator

### DIFF
--- a/crates/musli-core/src/de/decoder.rs
+++ b/crates/musli-core/src/de/decoder.rs
@@ -41,7 +41,7 @@ pub trait Decoder<'de>: Sized {
         Allocator = U::Allocator,
     >
     where
-        U: Context;
+        U: Context<Allocator = Self::Allocator>;
     /// Decoder returned by [`Decoder::decode_buffer`].
     type DecodeBuffer: AsDecoder<Cx = Self::Cx>;
     /// Decoder returned by [`Decoder::decode_option`].
@@ -76,7 +76,7 @@ pub trait Decoder<'de>: Sized {
     #[inline]
     fn with_context<U>(self, cx: U) -> Result<Self::WithContext<U>, <Self::Cx as Context>::Error>
     where
-        U: Context,
+        U: Context<Allocator = Self::Allocator>,
     {
         Err(self.cx().message(format_args!(
             "Context switch not supported, expected {}",

--- a/crates/musli-core/src/en/encoder.rs
+++ b/crates/musli-core/src/en/encoder.rs
@@ -36,7 +36,7 @@ pub trait Encoder: Sized {
     /// Constructed [`Encoder`] with a different context.
     type WithContext<U>: Encoder<Cx = U, Ok = Self::Ok, Error = U::Error, Mode = U::Mode>
     where
-        U: Context;
+        U: Context<Allocator = <Self::Cx as Context>::Allocator>;
     /// A simple pack that packs a sequence of elements.
     type EncodePack: SequenceEncoder<Cx = Self::Cx, Ok = Self::Ok>;
     /// Encoder returned when encoding an optional value which is present.
@@ -66,7 +66,7 @@ pub trait Encoder: Sized {
     /// Construct an encoder with a different context.
     fn with_context<U>(self, _: U) -> Result<Self::WithContext<U>, <Self::Cx as Context>::Error>
     where
-        U: Context,
+        U: Context<Allocator = <Self::Cx as Context>::Allocator>,
     {
         Err(self.cx().message(format_args!(
             "Context switch not supported, expected {}",

--- a/crates/musli-core/src/never.rs
+++ b/crates/musli-core/src/never.rs
@@ -108,7 +108,7 @@ where
     type WithContext<U>
         = Never<(), U>
     where
-        U: Context;
+        U: Context<Allocator = Self::Allocator>;
     type DecodeBuffer = Self;
     type DecodePack = Self;
     type DecodeSequence = Self;
@@ -126,7 +126,7 @@ where
     #[inline]
     fn with_context<U>(self, _: U) -> Result<Self::WithContext<U>, C::Error>
     where
-        U: Context,
+        U: Context<Allocator = Self::Allocator>,
     {
         match self._never {}
     }
@@ -346,7 +346,7 @@ where
     type WithContext<U>
         = Never<A, U>
     where
-        U: Context;
+        U: Context<Allocator = <Self::Cx as Context>::Allocator>;
     type EncodePack = Self;
     type EncodeSome = Self;
     type EncodeSequence = Self;
@@ -365,7 +365,7 @@ where
     #[inline]
     fn with_context<U>(self, _: U) -> Result<Self::WithContext<U>, C::Error>
     where
-        U: Context,
+        U: Context<Allocator = <Self::Cx as Context>::Allocator>,
     {
         match self._never {}
     }

--- a/crates/musli-macros/src/types.rs
+++ b/crates/musli-macros/src/types.rs
@@ -245,7 +245,7 @@ impl Types {
 
                     where_clause
                         .predicates
-                        .push(syn::parse_quote!(#u_param: #crate_path::Context));
+                        .push(syn::parse_quote!(#u_param: #crate_path::Context<Allocator = <Self::Cx as Context>::Allocator>));
 
                     generics = syn::Generics {
                         lt_token: Some(<Token![<]>::default()),

--- a/crates/musli/src/alloc/system.rs
+++ b/crates/musli/src/alloc/system.rs
@@ -43,6 +43,17 @@ impl System {
     pub const fn new() -> Self {
         Self
     }
+
+    /// Construct an allocation directly from raw parts.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure that the allocation comes from the same system
+    /// allocator and is correctly initialized per its parameters.
+    #[inline]
+    pub(crate) unsafe fn slice_from_raw_parts<T>(data: NonNull<T>, size: usize) -> SystemBuf<T> {
+        SystemBuf { data, size }
+    }
 }
 
 impl Default for System {
@@ -270,6 +281,7 @@ impl<T> SystemBuf<T> {
 }
 
 impl<T> Drop for SystemBuf<T> {
+    #[inline]
     fn drop(&mut self) {
         self.free();
     }

--- a/crates/musli/src/descriptive/en.rs
+++ b/crates/musli/src/descriptive/en.rs
@@ -67,7 +67,7 @@ where
     type WithContext<U>
         = SelfEncoder<W, OPT, U>
     where
-        U: Context;
+        U: Context<Allocator = <Self::Cx as Context>::Allocator>;
     type EncodePack = SelfPackEncoder<W, OPT, C>;
     type EncodeSome = Self;
     type EncodeSequence = Self;
@@ -85,7 +85,7 @@ where
     #[inline]
     fn with_context<U>(self, cx: U) -> Result<Self::WithContext<U>, C::Error>
     where
-        U: Context,
+        U: Context<Allocator = <Self::Cx as Context>::Allocator>,
     {
         Ok(SelfEncoder::new(cx, self.writer))
     }

--- a/crates/musli/src/json/de/key_decoder.rs
+++ b/crates/musli/src/json/de/key_decoder.rs
@@ -51,7 +51,7 @@ where
     type WithContext<U>
         = JsonKeyDecoder<P, U>
     where
-        U: Context;
+        U: Context<Allocator = Self::Allocator>;
 
     #[inline]
     fn cx(&self) -> Self::Cx {
@@ -61,7 +61,7 @@ where
     #[inline]
     fn with_context<U>(self, cx: U) -> Result<Self::WithContext<U>, C::Error>
     where
-        U: Context,
+        U: Context<Allocator = Self::Allocator>,
     {
         Ok(JsonKeyDecoder::new(cx, self.parser))
     }

--- a/crates/musli/src/json/en/mod.rs
+++ b/crates/musli/src/json/en/mod.rs
@@ -46,7 +46,7 @@ where
     type WithContext<U>
         = JsonEncoder<W, U>
     where
-        U: Context;
+        U: Context<Allocator = <Self::Cx as Context>::Allocator>;
     type EncodePack = JsonArrayEncoder<W, C>;
     type EncodeSome = Self;
     type EncodeSequence = JsonArrayEncoder<W, C>;
@@ -64,7 +64,7 @@ where
     #[inline]
     fn with_context<U>(self, cx: U) -> Result<Self::WithContext<U>, C::Error>
     where
-        U: Context,
+        U: Context<Allocator = <Self::Cx as Context>::Allocator>,
     {
         Ok(JsonEncoder::new(cx, self.writer))
     }

--- a/crates/musli/src/json/en/object_key_encoder.rs
+++ b/crates/musli/src/json/en/object_key_encoder.rs
@@ -39,7 +39,7 @@ where
     type WithContext<U>
         = JsonObjectKeyEncoder<W, U>
     where
-        U: Context;
+        U: Context<Allocator = <Self::Cx as Context>::Allocator>;
 
     #[inline]
     fn cx(&self) -> Self::Cx {
@@ -49,7 +49,7 @@ where
     #[inline]
     fn with_context<U>(self, cx: U) -> Result<Self::WithContext<U>, C::Error>
     where
-        U: Context,
+        U: Context<Allocator = <Self::Cx as Context>::Allocator>,
     {
         Ok(JsonObjectKeyEncoder::new(cx, self.writer))
     }

--- a/crates/musli/src/macros/test.rs
+++ b/crates/musli/src/macros/test.rs
@@ -69,7 +69,7 @@ macro_rules! test_fns {
 
             $crate::macros::test_include_if! {
                 $($(#[$option])*)* =>
-                let value_decode: $crate::value::Value = match encoding.from_slice_with(&cx, out.as_slice()) {
+                let value_decode: $crate::value::Value<_> = match encoding.from_slice_with(&cx, out.as_slice()) {
                     Ok(decoded) => decoded,
                     Err(..) => {
                         let out = FormatBytes(&out);
@@ -449,7 +449,7 @@ pub mod support {
         T: Encode<Binary> + for<'de> Decode<'de, Binary, System>,
         T: PartialEq + core::fmt::Debug,
     {
-        let value: Value = value::encode(&expected).expect("value: Encoding should succeed");
+        let value: Value<_> = value::encode(&expected).expect("value: Encoding should succeed");
         let actual: T = value::decode(&value).expect("value: Decoding should succeed");
         assert_eq!(
             actual, expected,

--- a/crates/musli/src/options.rs
+++ b/crates/musli/src/options.rs
@@ -310,7 +310,7 @@ pub(crate) const fn byteorder_value(opt: Options) -> ByteOrder {
     }
 }
 
-#[cfg(all(feature = "alloc", feature = "value"))]
+#[cfg(feature = "value")]
 #[inline]
 pub(crate) const fn is_map_keys_as_numbers<const OPT: Options>() -> bool {
     is_map_keys_as_numbers_value(OPT)

--- a/crates/musli/src/storage/de.rs
+++ b/crates/musli/src/storage/de.rs
@@ -60,7 +60,7 @@ where
     type WithContext<U>
         = StorageDecoder<R, OPT, U>
     where
-        U: Context;
+        U: Context<Allocator = Self::Allocator>;
     type DecodePack = Self;
     type DecodeSome = Self;
     type DecodeSequence = LimitedStorageDecoder<R, OPT, C>;
@@ -76,7 +76,7 @@ where
     #[inline]
     fn with_context<U>(self, cx: U) -> Result<Self::WithContext<U>, C::Error>
     where
-        U: Context,
+        U: Context<Allocator = Self::Allocator>,
     {
         Ok(StorageDecoder::new(cx, self.reader))
     }

--- a/crates/musli/src/storage/en.rs
+++ b/crates/musli/src/storage/en.rs
@@ -47,7 +47,7 @@ where
     type WithContext<U>
         = StorageEncoder<W, OPT, U>
     where
-        U: Context;
+        U: Context<Allocator = <Self::Cx as Context>::Allocator>;
     type EncodePack = StorageEncoder<W, OPT, C>;
     type EncodeSome = Self;
     type EncodeSequence = Self;
@@ -65,7 +65,7 @@ where
     #[inline]
     fn with_context<U>(self, cx: U) -> Result<Self::WithContext<U>, C::Error>
     where
-        U: Context,
+        U: Context<Allocator = <Self::Cx as Context>::Allocator>,
     {
         Ok(StorageEncoder::new(cx, self.writer))
     }

--- a/crates/musli/src/value/en.rs
+++ b/crates/musli/src/value/en.rs
@@ -1,56 +1,73 @@
+#![allow(clippy::type_complexity)]
+
 use core::fmt;
 
-#[cfg(feature = "alloc")]
-use rust_alloc::boxed::Box;
-#[cfg(feature = "alloc")]
-use rust_alloc::vec::Vec;
-
+use crate::alloc::{Box, String, Vec};
 use crate::en::{Encode, Encoder};
-#[cfg(feature = "alloc")]
 use crate::en::{EntriesEncoder, EntryEncoder, MapEncoder, SequenceEncoder, VariantEncoder};
-#[cfg(feature = "alloc")]
 use crate::hint::{MapHint, SequenceHint};
-#[cfg(feature = "alloc")]
 use crate::storage::en::StorageEncoder;
-#[cfg(feature = "alloc")]
 use crate::writer::BufWriter;
-use crate::{Context, Options};
+use crate::{Allocator, Context, Options};
 
 use super::value::{Number, Value};
 
 /// Insert a value into the given receiver.
-trait ValueOutput {
-    fn write(self, value: Value);
+trait ValueOutput<A>
+where
+    A: Allocator,
+{
+    /// Write a value into the receiver.
+    fn write<C>(self, cx: C, value: Value<A>) -> Result<(), C::Error>
+    where
+        C: Context<Allocator = A>;
 }
 
-impl ValueOutput for &mut Value {
+impl<A> ValueOutput<A> for &mut Value<A>
+where
+    A: Allocator,
+{
     #[inline]
-    fn write(self, value: Value) {
+    fn write<C>(self, _: C, value: Value<A>) -> Result<(), C::Error>
+    where
+        C: Context<Allocator = A>,
+    {
         *self = value;
+        Ok(())
     }
 }
 
-#[cfg(feature = "alloc")]
-impl ValueOutput for &mut Vec<Value> {
+impl<A> ValueOutput<A> for &mut Vec<Value<A>, A>
+where
+    A: Allocator,
+{
     #[inline]
-    fn write(self, value: Value) {
-        self.push(value);
+    fn write<C>(self, cx: C, value: Value<A>) -> Result<(), C::Error>
+    where
+        C: Context<Allocator = A>,
+    {
+        self.push(value).map_err(cx.map())
     }
 }
 
 /// Writer which writes an optional value that is present.
-#[cfg(feature = "alloc")]
 pub struct SomeValueWriter<O> {
     output: O,
 }
 
-#[cfg(feature = "alloc")]
-impl<O> ValueOutput for SomeValueWriter<O>
+impl<O, A> ValueOutput<A> for SomeValueWriter<O>
 where
-    O: ValueOutput,
+    O: ValueOutput<A>,
+    A: Allocator,
 {
-    fn write(self, value: Value) {
-        self.output.write(Value::Option(Some(Box::new(value))));
+    #[inline]
+    fn write<C>(self, cx: C, value: Value<A>) -> Result<(), C::Error>
+    where
+        C: Context<Allocator = A>,
+    {
+        let value = Box::new_in(value, cx.alloc()).map_err(cx.map())?;
+        self.output.write(cx, Value::Option(Some(value)))?;
+        Ok(())
     }
 }
 
@@ -70,8 +87,8 @@ impl<const OPT: Options, O, C> ValueEncoder<OPT, O, C> {
 #[crate::encoder(crate)]
 impl<const OPT: Options, O, C> Encoder for ValueEncoder<OPT, O, C>
 where
-    O: ValueOutput,
-    C: Context,
+    O: ValueOutput<C::Allocator>,
+    C: Clone + Context,
 {
     type Cx = C;
     type Error = C::Error;
@@ -80,22 +97,14 @@ where
     type WithContext<U>
         = ValueEncoder<OPT, O, U>
     where
-        U: Context;
-    #[cfg(feature = "alloc")]
+        U: Context<Allocator = <Self::Cx as Context>::Allocator>;
     type EncodeSome = ValueEncoder<OPT, SomeValueWriter<O>, C>;
-    #[cfg(feature = "alloc")]
     type EncodePack = PackValueEncoder<OPT, O, C>;
-    #[cfg(feature = "alloc")]
     type EncodeSequence = SequenceValueEncoder<OPT, O, C>;
-    #[cfg(feature = "alloc")]
     type EncodeMap = MapValueEncoder<OPT, O, C>;
-    #[cfg(feature = "alloc")]
     type EncodeMapEntries = MapValueEncoder<OPT, O, C>;
-    #[cfg(feature = "alloc")]
     type EncodeVariant = VariantValueEncoder<OPT, O, C>;
-    #[cfg(feature = "alloc")]
     type EncodeSequenceVariant = VariantSequenceEncoder<OPT, O, C>;
-    #[cfg(feature = "alloc")]
     type EncodeMapVariant = VariantStructEncoder<OPT, O, C>;
 
     #[inline]
@@ -106,7 +115,7 @@ where
     #[inline]
     fn with_context<U>(self, cx: U) -> Result<Self::WithContext<U>, C::Error>
     where
-        U: Context,
+        U: Context<Allocator = <Self::Cx as Context>::Allocator>,
     {
         Ok(ValueEncoder::new(cx, self.output))
     }
@@ -131,134 +140,139 @@ where
 
     #[inline]
     fn encode_bool(self, b: bool) -> Result<Self::Ok, C::Error> {
-        self.output.write(Value::Bool(b));
+        self.output.write(self.cx, Value::Bool(b))?;
         Ok(())
     }
 
     #[inline]
     fn encode_char(self, c: char) -> Result<Self::Ok, C::Error> {
-        self.output.write(Value::Char(c));
+        self.output.write(self.cx, Value::Char(c))?;
         Ok(())
     }
 
     #[inline]
     fn encode_u8(self, n: u8) -> Result<Self::Ok, C::Error> {
-        self.output.write(Value::Number(Number::U8(n)));
+        self.output.write(self.cx, Value::Number(Number::U8(n)))?;
         Ok(())
     }
 
     #[inline]
     fn encode_u16(self, n: u16) -> Result<Self::Ok, C::Error> {
-        self.output.write(Value::Number(Number::U16(n)));
+        self.output.write(self.cx, Value::Number(Number::U16(n)))?;
         Ok(())
     }
 
     #[inline]
     fn encode_u32(self, n: u32) -> Result<Self::Ok, C::Error> {
-        self.output.write(Value::Number(Number::U32(n)));
+        self.output.write(self.cx, Value::Number(Number::U32(n)))?;
         Ok(())
     }
 
     #[inline]
     fn encode_u64(self, n: u64) -> Result<Self::Ok, C::Error> {
-        self.output.write(Value::Number(Number::U64(n)));
+        self.output.write(self.cx, Value::Number(Number::U64(n)))?;
         Ok(())
     }
 
     #[inline]
     fn encode_u128(self, n: u128) -> Result<Self::Ok, C::Error> {
-        self.output.write(Value::Number(Number::U128(n)));
+        self.output.write(self.cx, Value::Number(Number::U128(n)))?;
         Ok(())
     }
 
     #[inline]
     fn encode_i8(self, n: i8) -> Result<Self::Ok, C::Error> {
-        self.output.write(Value::Number(Number::I8(n)));
+        self.output.write(self.cx, Value::Number(Number::I8(n)))?;
         Ok(())
     }
 
     #[inline]
     fn encode_i16(self, n: i16) -> Result<Self::Ok, C::Error> {
-        self.output.write(Value::Number(Number::I16(n)));
+        self.output.write(self.cx, Value::Number(Number::I16(n)))?;
         Ok(())
     }
 
     #[inline]
     fn encode_i32(self, n: i32) -> Result<Self::Ok, C::Error> {
-        self.output.write(Value::Number(Number::I32(n)));
+        self.output.write(self.cx, Value::Number(Number::I32(n)))?;
         Ok(())
     }
 
     #[inline]
     fn encode_i64(self, n: i64) -> Result<Self::Ok, C::Error> {
-        self.output.write(Value::Number(Number::I64(n)));
+        self.output.write(self.cx, Value::Number(Number::I64(n)))?;
         Ok(())
     }
 
     #[inline]
     fn encode_i128(self, n: i128) -> Result<Self::Ok, C::Error> {
-        self.output.write(Value::Number(Number::I128(n)));
+        self.output.write(self.cx, Value::Number(Number::I128(n)))?;
         Ok(())
     }
 
     #[inline]
     fn encode_f32(self, n: f32) -> Result<Self::Ok, C::Error> {
-        self.output.write(Value::Number(Number::F32(n)));
+        self.output.write(self.cx, Value::Number(Number::F32(n)))?;
         Ok(())
     }
 
     #[inline]
     fn encode_f64(self, n: f64) -> Result<Self::Ok, C::Error> {
-        self.output.write(Value::Number(Number::F64(n)));
+        self.output.write(self.cx, Value::Number(Number::F64(n)))?;
         Ok(())
     }
 
     #[inline]
     fn encode_usize(self, n: usize) -> Result<Self::Ok, C::Error> {
-        self.output.write(Value::Number(Number::Usize(n)));
+        self.output
+            .write(self.cx, Value::Number(Number::Usize(n)))?;
         Ok(())
     }
 
     #[inline]
     fn encode_isize(self, n: isize) -> Result<Self::Ok, C::Error> {
-        self.output.write(Value::Number(Number::Isize(n)));
+        self.output
+            .write(self.cx, Value::Number(Number::Isize(n)))?;
         Ok(())
     }
 
-    #[cfg(feature = "alloc")]
     #[inline]
     fn encode_array<const N: usize>(self, array: &[u8; N]) -> Result<Self::Ok, C::Error> {
-        self.output.write(Value::Bytes(array.into()));
+        let mut bytes =
+            Vec::with_capacity_in(array.len(), self.cx.alloc()).map_err(self.cx.map())?;
+        bytes.extend_from_slice(array).map_err(self.cx.map())?;
+        self.output.write(self.cx, Value::Bytes(bytes))?;
         Ok(())
     }
 
-    #[cfg(feature = "alloc")]
     #[inline]
-    fn encode_bytes(self, bytes: &[u8]) -> Result<Self::Ok, C::Error> {
-        self.output.write(Value::Bytes(bytes.to_vec()));
+    fn encode_bytes(self, b: &[u8]) -> Result<Self::Ok, C::Error> {
+        let mut bytes = Vec::with_capacity_in(b.len(), self.cx.alloc()).map_err(self.cx.map())?;
+        bytes.extend_from_slice(b).map_err(self.cx.map())?;
+        self.output.write(self.cx, Value::Bytes(bytes))?;
         Ok(())
     }
 
-    #[cfg(feature = "alloc")]
     #[inline]
     fn encode_bytes_vectored<I>(self, len: usize, vectors: I) -> Result<Self::Ok, C::Error>
     where
         I: IntoIterator<Item: AsRef<[u8]>>,
     {
-        let mut bytes = Vec::with_capacity(len);
+        let mut bytes = Vec::with_capacity_in(len, self.cx.alloc()).map_err(self.cx.map())?;
 
         for b in vectors {
-            bytes.extend_from_slice(b.as_ref());
+            bytes.extend_from_slice(b.as_ref()).map_err(self.cx.map())?;
         }
 
-        self.output.write(Value::Bytes(bytes));
+        self.output.write(self.cx, Value::Bytes(bytes))?;
         Ok(())
     }
 
-    #[cfg(feature = "alloc")]
     #[inline]
-    fn encode_string(self, string: &str) -> Result<Self::Ok, C::Error> {
-        self.output.write(Value::String(string.into()));
+    fn encode_string(self, s: &str) -> Result<Self::Ok, C::Error> {
+        let mut string = String::new_in(self.cx.alloc());
+        string.push_str(s).map_err(self.cx.map())?;
+        self.output.write(self.cx, Value::String(string))?;
         Ok(())
     }
 
@@ -271,7 +285,6 @@ where
         self.encode_string(buf.as_ref())
     }
 
-    #[cfg(feature = "alloc")]
     #[inline]
     fn encode_some(self) -> Result<Self::EncodeSome, C::Error> {
         Ok(ValueEncoder::new(
@@ -282,44 +295,37 @@ where
         ))
     }
 
-    #[cfg(feature = "alloc")]
     #[inline]
     fn encode_none(self) -> Result<Self::Ok, C::Error> {
-        self.output.write(Value::Option(None));
+        self.output.write(self.cx, Value::Option(None))?;
         Ok(())
     }
 
-    #[cfg(feature = "alloc")]
     #[inline]
     fn encode_pack(self) -> Result<Self::EncodePack, C::Error> {
         PackValueEncoder::new(self.cx, self.output)
     }
 
-    #[cfg(feature = "alloc")]
     #[inline]
     fn encode_sequence(self, _: &SequenceHint) -> Result<Self::EncodeSequence, C::Error> {
         Ok(SequenceValueEncoder::new(self.cx, self.output))
     }
 
-    #[cfg(feature = "alloc")]
     #[inline]
     fn encode_map(self, _: &MapHint) -> Result<Self::EncodeMap, C::Error> {
-        Ok(MapValueEncoder::new(self.cx, self.output))
+        MapValueEncoder::new(self.cx, self.output)
     }
 
-    #[cfg(feature = "alloc")]
     #[inline]
     fn encode_map_entries(self, _: &MapHint) -> Result<Self::EncodeMapEntries, C::Error> {
-        Ok(MapValueEncoder::new(self.cx, self.output))
+        MapValueEncoder::new(self.cx, self.output)
     }
 
-    #[cfg(feature = "alloc")]
     #[inline]
     fn encode_variant(self) -> Result<Self::EncodeVariant, C::Error> {
         Ok(VariantValueEncoder::new(self.cx, self.output))
     }
 
-    #[cfg(feature = "alloc")]
     #[inline]
     fn encode_unit_variant<T>(self, tag: &T) -> Result<(), C::Error>
     where
@@ -333,7 +339,6 @@ where
     }
 
     #[inline]
-    #[cfg(feature = "alloc")]
     fn encode_sequence_variant<T>(
         self,
         tag: &T,
@@ -345,15 +350,9 @@ where
         let mut variant = Value::Unit;
         ValueEncoder::<OPT, _, _>::new(self.cx, &mut variant).encode(tag)?;
 
-        Ok(VariantSequenceEncoder::new(
-            self.cx,
-            self.output,
-            variant,
-            hint.size,
-        ))
+        VariantSequenceEncoder::new(self.cx, self.output, variant, hint.size)
     }
 
-    #[cfg(feature = "alloc")]
     #[inline]
     fn encode_map_variant<T>(
         self,
@@ -366,46 +365,42 @@ where
         let mut variant = Value::Unit;
         ValueEncoder::<OPT, _, _>::new(self.cx, &mut variant).encode(tag)?;
 
-        Ok(VariantStructEncoder::new(
-            self.cx,
-            self.output,
-            variant,
-            hint.size,
-        ))
+        VariantStructEncoder::new(self.cx, self.output, variant, hint.size)
     }
 }
 
 /// A sequence encoder.
-#[cfg(feature = "alloc")]
-pub struct SequenceValueEncoder<const OPT: Options, O, C> {
+pub struct SequenceValueEncoder<const OPT: Options, O, C>
+where
+    C: Context,
+{
     cx: C,
     output: O,
-    values: Vec<Value>,
+    values: Vec<Value<C::Allocator>, C::Allocator>,
 }
 
-#[cfg(feature = "alloc")]
-impl<const OPT: Options, O, C> SequenceValueEncoder<OPT, O, C> {
+impl<const OPT: Options, O, C> SequenceValueEncoder<OPT, O, C>
+where
+    C: Context,
+{
     #[inline]
     fn new(cx: C, output: O) -> Self {
-        Self {
-            cx,
-            output,
-            values: Vec::new(),
-        }
+        let values = Vec::new_in(cx.alloc());
+
+        Self { cx, output, values }
     }
 }
 
-#[cfg(feature = "alloc")]
 impl<const OPT: Options, O, C> SequenceEncoder for SequenceValueEncoder<OPT, O, C>
 where
-    O: ValueOutput,
+    O: ValueOutput<C::Allocator>,
     C: Context,
 {
     type Cx = C;
     type Ok = ();
 
     type EncodeNext<'this>
-        = ValueEncoder<OPT, &'this mut Vec<Value>, C>
+        = ValueEncoder<OPT, &'this mut Vec<Value<C::Allocator>, C::Allocator>, C>
     where
         Self: 'this;
 
@@ -421,13 +416,12 @@ where
 
     #[inline]
     fn finish_sequence(self) -> Result<Self::Ok, C::Error> {
-        self.output.write(Value::Sequence(self.values));
+        self.output.write(self.cx, Value::Sequence(self.values))?;
         Ok(())
     }
 }
 
 /// A pack encoder.
-#[cfg(feature = "alloc")]
 pub struct PackValueEncoder<const OPT: Options, O, C>
 where
     C: Context,
@@ -437,7 +431,6 @@ where
     writer: BufWriter<C::Allocator>,
 }
 
-#[cfg(feature = "alloc")]
 impl<const OPT: Options, O, C> PackValueEncoder<OPT, O, C>
 where
     C: Context,
@@ -452,10 +445,9 @@ where
     }
 }
 
-#[cfg(feature = "alloc")]
 impl<const OPT: Options, O, C> SequenceEncoder for PackValueEncoder<OPT, O, C>
 where
-    O: ValueOutput,
+    O: ValueOutput<C::Allocator>,
     C: Context,
 {
     type Cx = C;
@@ -478,35 +470,35 @@ where
     #[inline]
     fn finish_sequence(self) -> Result<Self::Ok, C::Error> {
         let buf = self.writer.into_inner();
-        self.output.write(Value::Bytes(buf.as_slice().into()));
+        self.output.write(self.cx, Value::Bytes(buf))?;
         Ok(())
     }
 }
 
 /// A pairs encoder.
-#[cfg(feature = "alloc")]
-pub struct MapValueEncoder<const OPT: Options, O, C> {
+pub struct MapValueEncoder<const OPT: Options, O, C>
+where
+    C: Context,
+{
     cx: C,
     output: O,
-    values: Vec<(Value, Value)>,
+    values: Vec<(Value<C::Allocator>, Value<C::Allocator>), C::Allocator>,
 }
 
-#[cfg(feature = "alloc")]
-impl<const OPT: Options, O, C> MapValueEncoder<OPT, O, C> {
+impl<const OPT: Options, O, C> MapValueEncoder<OPT, O, C>
+where
+    C: Context,
+{
     #[inline]
-    fn new(cx: C, output: O) -> Self {
-        Self {
-            cx,
-            output,
-            values: Vec::new(),
-        }
+    fn new(cx: C, output: O) -> Result<Self, C::Error> {
+        let values = Vec::new_in(cx.alloc());
+        Ok(Self { cx, output, values })
     }
 }
 
-#[cfg(feature = "alloc")]
 impl<const OPT: Options, O, C> MapEncoder for MapValueEncoder<OPT, O, C>
 where
-    O: ValueOutput,
+    O: ValueOutput<C::Allocator>,
     C: Context,
 {
     type Cx = C;
@@ -528,25 +520,24 @@ where
 
     #[inline]
     fn finish_map(self) -> Result<Self::Ok, C::Error> {
-        self.output.write(Value::Map(self.values));
+        self.output.write(self.cx, Value::Map(self.values))?;
         Ok(())
     }
 }
 
-#[cfg(feature = "alloc")]
 impl<const OPT: Options, O, C> EntriesEncoder for MapValueEncoder<OPT, O, C>
 where
-    O: ValueOutput,
+    O: ValueOutput<C::Allocator>,
     C: Context,
 {
     type Cx = C;
     type Ok = ();
     type EncodeEntryKey<'this>
-        = ValueEncoder<OPT, &'this mut Value, C>
+        = ValueEncoder<OPT, &'this mut Value<C::Allocator>, C>
     where
         Self: 'this;
     type EncodeEntryValue<'this>
-        = ValueEncoder<OPT, &'this mut Value, C>
+        = ValueEncoder<OPT, &'this mut Value<C::Allocator>, C>
     where
         Self: 'this;
 
@@ -557,7 +548,9 @@ where
 
     #[inline]
     fn encode_entry_key(&mut self) -> Result<Self::EncodeEntryKey<'_>, C::Error> {
-        self.values.push((Value::Unit, Value::Unit));
+        self.values
+            .push((Value::Unit, Value::Unit))
+            .map_err(self.cx.map())?;
 
         let Some((key, _)) = self.values.last_mut() else {
             return Err(self.cx.message("Pair has not been encoded"));
@@ -577,23 +570,30 @@ where
 
     #[inline]
     fn finish_entries(self) -> Result<Self::Ok, C::Error> {
-        self.output.write(Value::Map(self.values));
+        self.output.write(self.cx, Value::Map(self.values))?;
         Ok(())
     }
 }
 
 /// A pairs encoder.
-#[cfg(feature = "alloc")]
-pub struct PairValueEncoder<'a, const OPT: Options, C> {
+pub struct PairValueEncoder<'a, const OPT: Options, C>
+where
+    C: Context,
+{
     cx: C,
-    output: &'a mut Vec<(Value, Value)>,
-    pair: (Value, Value),
+    output: &'a mut Vec<(Value<C::Allocator>, Value<C::Allocator>), C::Allocator>,
+    pair: (Value<C::Allocator>, Value<C::Allocator>),
 }
 
-#[cfg(feature = "alloc")]
-impl<'a, const OPT: Options, C> PairValueEncoder<'a, OPT, C> {
+impl<'a, const OPT: Options, C> PairValueEncoder<'a, OPT, C>
+where
+    C: Context,
+{
     #[inline]
-    fn new(cx: C, output: &'a mut Vec<(Value, Value)>) -> Self {
+    fn new(
+        cx: C,
+        output: &'a mut Vec<(Value<C::Allocator>, Value<C::Allocator>), C::Allocator>,
+    ) -> Self {
         Self {
             cx,
             output,
@@ -602,7 +602,6 @@ impl<'a, const OPT: Options, C> PairValueEncoder<'a, OPT, C> {
     }
 }
 
-#[cfg(feature = "alloc")]
 impl<const OPT: Options, C> EntryEncoder for PairValueEncoder<'_, OPT, C>
 where
     C: Context,
@@ -610,11 +609,11 @@ where
     type Cx = C;
     type Ok = ();
     type EncodeKey<'this>
-        = ValueEncoder<OPT, &'this mut Value, C>
+        = ValueEncoder<OPT, &'this mut Value<C::Allocator>, C>
     where
         Self: 'this;
     type EncodeValue<'this>
-        = ValueEncoder<OPT, &'this mut Value, C>
+        = ValueEncoder<OPT, &'this mut Value<C::Allocator>, C>
     where
         Self: 'this;
 
@@ -635,21 +634,25 @@ where
 
     #[inline]
     fn finish_entry(self) -> Result<Self::Ok, C::Error> {
-        self.output.push(self.pair);
+        self.output.push(self.pair).map_err(self.cx.map())?;
         Ok(())
     }
 }
 
 /// A pairs encoder.
-#[cfg(feature = "alloc")]
-pub struct VariantValueEncoder<const OPT: Options, O, C> {
+pub struct VariantValueEncoder<const OPT: Options, O, C>
+where
+    C: Context,
+{
     cx: C,
     output: O,
-    pair: (Value, Value),
+    pair: (Value<C::Allocator>, Value<C::Allocator>),
 }
 
-#[cfg(feature = "alloc")]
-impl<const OPT: Options, O, C> VariantValueEncoder<OPT, O, C> {
+impl<const OPT: Options, O, C> VariantValueEncoder<OPT, O, C>
+where
+    C: Context,
+{
     #[inline]
     fn new(cx: C, output: O) -> Self {
         Self {
@@ -660,20 +663,19 @@ impl<const OPT: Options, O, C> VariantValueEncoder<OPT, O, C> {
     }
 }
 
-#[cfg(feature = "alloc")]
 impl<const OPT: Options, O, C> VariantEncoder for VariantValueEncoder<OPT, O, C>
 where
-    O: ValueOutput,
+    O: ValueOutput<C::Allocator>,
     C: Context,
 {
     type Cx = C;
     type Ok = ();
     type EncodeTag<'this>
-        = ValueEncoder<OPT, &'this mut Value, C>
+        = ValueEncoder<OPT, &'this mut Value<C::Allocator>, C>
     where
         Self: 'this;
     type EncodeData<'this>
-        = ValueEncoder<OPT, &'this mut Value, C>
+        = ValueEncoder<OPT, &'this mut Value<C::Allocator>, C>
     where
         Self: 'this;
 
@@ -694,44 +696,50 @@ where
 
     #[inline]
     fn finish_variant(self) -> Result<Self::Ok, C::Error> {
-        self.output.write(Value::Variant(Box::new(self.pair)));
+        let value = Box::new_in(self.pair, self.cx.alloc()).map_err(self.cx.map())?;
+        self.output.write(self.cx, Value::Variant(value))?;
         Ok(())
     }
 }
 
 /// A variant sequence encoder.
-#[cfg(feature = "alloc")]
-pub struct VariantSequenceEncoder<const OPT: Options, O, C> {
+pub struct VariantSequenceEncoder<const OPT: Options, O, C>
+where
+    C: Context,
+{
     cx: C,
     output: O,
-    variant: Value,
-    values: Vec<Value>,
+    variant: Value<C::Allocator>,
+    values: Vec<Value<C::Allocator>, C::Allocator>,
 }
 
-#[cfg(feature = "alloc")]
-impl<const OPT: Options, O, C> VariantSequenceEncoder<OPT, O, C> {
+impl<const OPT: Options, O, C> VariantSequenceEncoder<OPT, O, C>
+where
+    C: Context,
+{
     #[inline]
-    fn new(cx: C, output: O, variant: Value, len: usize) -> Self {
-        Self {
+    fn new(cx: C, output: O, variant: Value<C::Allocator>, len: usize) -> Result<Self, C::Error> {
+        let values = Vec::with_capacity_in(len, cx.alloc()).map_err(cx.map())?;
+
+        Ok(Self {
             cx,
             output,
             variant,
-            values: Vec::with_capacity(len),
-        }
+            values,
+        })
     }
 }
 
-#[cfg(feature = "alloc")]
 impl<const OPT: Options, O, C> SequenceEncoder for VariantSequenceEncoder<OPT, O, C>
 where
-    O: ValueOutput,
+    O: ValueOutput<C::Allocator>,
     C: Context,
 {
     type Cx = C;
     type Ok = ();
 
     type EncodeNext<'this>
-        = ValueEncoder<OPT, &'this mut Vec<Value>, C>
+        = ValueEncoder<OPT, &'this mut Vec<Value<C::Allocator>, C::Allocator>, C>
     where
         Self: 'this;
 
@@ -747,40 +755,44 @@ where
 
     #[inline]
     fn finish_sequence(self) -> Result<Self::Ok, C::Error> {
-        self.output.write(Value::Variant(Box::new((
-            self.variant,
-            Value::Sequence(self.values),
-        ))));
+        let value = (self.variant, Value::Sequence(self.values));
+        let value = Box::new_in(value, self.cx.alloc()).map_err(self.cx.map())?;
+        self.output.write(self.cx, Value::Variant(value))?;
         Ok(())
     }
 }
 
 /// A variant struct encoder.
-#[cfg(feature = "alloc")]
-pub struct VariantStructEncoder<const OPT: Options, O, C> {
+pub struct VariantStructEncoder<const OPT: Options, O, C>
+where
+    C: Context,
+{
     cx: C,
     output: O,
-    variant: Value,
-    fields: Vec<(Value, Value)>,
+    variant: Value<C::Allocator>,
+    fields: Vec<(Value<C::Allocator>, Value<C::Allocator>), C::Allocator>,
 }
 
-#[cfg(feature = "alloc")]
-impl<const OPT: Options, O, C> VariantStructEncoder<OPT, O, C> {
+impl<const OPT: Options, O, C> VariantStructEncoder<OPT, O, C>
+where
+    C: Context,
+{
     #[inline]
-    fn new(cx: C, output: O, variant: Value, len: usize) -> Self {
-        Self {
+    fn new(cx: C, output: O, variant: Value<C::Allocator>, len: usize) -> Result<Self, C::Error> {
+        let fields = Vec::with_capacity_in(len, cx.alloc()).map_err(cx.map())?;
+
+        Ok(Self {
             cx,
             output,
             variant,
-            fields: Vec::with_capacity(len),
-        }
+            fields,
+        })
     }
 }
 
-#[cfg(feature = "alloc")]
 impl<const OPT: Options, O, C> MapEncoder for VariantStructEncoder<OPT, O, C>
 where
-    O: ValueOutput,
+    O: ValueOutput<C::Allocator>,
     C: Context,
 {
     type Cx = C;
@@ -803,10 +815,9 @@ where
 
     #[inline]
     fn finish_map(self) -> Result<Self::Ok, C::Error> {
-        self.output.write(Value::Variant(Box::new((
-            self.variant,
-            Value::Map(self.fields),
-        ))));
+        let value = (self.variant, Value::Map(self.fields));
+        let value = Box::new_in(value, self.cx.alloc()).map_err(self.cx.map())?;
+        self.output.write(self.cx, Value::Variant(value))?;
         Ok(())
     }
 }

--- a/crates/musli/src/value/mod.rs
+++ b/crates/musli/src/value/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! [Müsli data model]: crate::_help::data_model
 
-#![cfg(feature = "value")]
+#![cfg(any(feature = "json", feature = "descriptive", feature = "value"))]
 #![cfg_attr(doc_cfg, doc(cfg(feature = "value")))]
 
 mod de;
@@ -15,53 +15,58 @@ mod type_hint;
 mod value;
 
 /// Convenient result alias for use with `musli_value`.
+#[cfg(feature = "alloc")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 pub type Result<T, E = Error> = core::result::Result<T, E>;
 
 #[doc(inline)]
-pub use self::value::{AsValueDecoder, Value};
+pub use self::value::{AsValueDecoder, IntoValueDecoder, Value};
 #[doc(inline)]
 pub use error::Error;
 
-use crate::alloc;
+use crate::alloc::Allocator;
 #[cfg(feature = "alloc")]
 use crate::alloc::System;
+#[cfg(feature = "alloc")]
 use crate::mode::Binary;
+#[cfg(feature = "alloc")]
 use crate::value::en::ValueEncoder;
-use crate::{Decode, Encode, Options};
+#[cfg(feature = "alloc")]
+use crate::Encode;
+use crate::{Decode, Options};
 
 const OPTIONS: Options = crate::options::new().build();
 
 /// Encode something that implements [Encode] into a [Value].
-pub fn encode<T>(value: T) -> Result<Value, Error>
+#[cfg(feature = "alloc")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
+pub fn encode<T>(value: T) -> Result<Value<System>, Error>
 where
     T: Encode<Binary>,
 {
     use crate::en::Encoder;
 
     let mut output = Value::Unit;
-
-    alloc::default(|alloc| {
-        let cx = crate::context::Same::<Binary, Error, _>::with_alloc(alloc);
-        ValueEncoder::<OPTIONS, _, _>::new(&cx, &mut output).encode(value)?;
-        Ok(output)
-    })
+    let cx = crate::context::Same::<Binary, Error, _>::with_alloc(System::new());
+    ValueEncoder::<OPTIONS, _, _>::new(&cx, &mut output).encode(value)?;
+    Ok(output)
 }
 
 /// Decode a [Value] into a type which implements [Decode].
 #[cfg(feature = "alloc")]
-pub fn decode<'de, T>(value: &'de Value) -> Result<T, Error>
+#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
+pub fn decode<'de, T>(value: &'de Value<impl Allocator>) -> Result<T, Error>
 where
     T: Decode<'de, Binary, System>,
 {
     use crate::de::Decoder;
-
     let cx = crate::context::Same::<Binary, Error, _>::with_alloc(System::new());
     value.decoder::<OPTIONS, _>(&cx).decode()
 }
 
 /// Decode a [Value] into a type which implements [Decode] using a custom
 /// context.
-pub fn decode_with<'de, C, T>(cx: C, value: &'de Value) -> Result<T, C::Error>
+pub fn decode_with<'de, C, T>(cx: C, value: &'de Value<impl Allocator>) -> Result<T, C::Error>
 where
     C: crate::Context,
     T: Decode<'de, C::Mode, C::Allocator>,

--- a/crates/musli/src/value/type_hint.rs
+++ b/crates/musli/src/value/type_hint.rs
@@ -1,6 +1,5 @@
 use core::fmt;
 
-#[cfg(feature = "alloc")]
 use crate::de::SizeHint;
 
 /// A type hint.
@@ -16,22 +15,16 @@ pub(crate) enum TypeHint {
     /// The type as a number.
     Number(NumberHint),
     /// A byte array.
-    #[cfg(feature = "alloc")]
     Bytes(SizeHint),
     /// A string with the given length.
-    #[cfg(feature = "alloc")]
     String(SizeHint),
     /// A sequence with a length hint.
-    #[cfg(feature = "alloc")]
     Sequence(SizeHint),
     /// A map with a length hint.
-    #[cfg(feature = "alloc")]
     Map(SizeHint),
     /// A variant.
-    #[cfg(feature = "alloc")]
     Variant,
     /// An optional value.
-    #[cfg(feature = "alloc")]
     Option,
 }
 
@@ -42,17 +35,11 @@ impl fmt::Display for TypeHint {
             TypeHint::Bool => write!(f, "bool"),
             TypeHint::Char => write!(f, "char"),
             TypeHint::Number(number) => number.fmt(f),
-            #[cfg(feature = "alloc")]
             TypeHint::Bytes(size) => write!(f, "bytes with {size}"),
-            #[cfg(feature = "alloc")]
             TypeHint::String(size) => write!(f, "string with {size}"),
-            #[cfg(feature = "alloc")]
             TypeHint::Sequence(size) => write!(f, "sequence with {size}"),
-            #[cfg(feature = "alloc")]
             TypeHint::Map(size) => write!(f, "map with {size}"),
-            #[cfg(feature = "alloc")]
             TypeHint::Variant => write!(f, "variant"),
-            #[cfg(feature = "alloc")]
             TypeHint::Option => write!(f, "option"),
         }
     }

--- a/crates/musli/src/wire/de.rs
+++ b/crates/musli/src/wire/de.rs
@@ -213,7 +213,7 @@ where
     type WithContext<U>
         = WireDecoder<R, OPT, U>
     where
-        U: Context;
+        U: Context<Allocator = Self::Allocator>;
     type DecodePack = WireDecoder<Limit<R>, OPT, C>;
     type DecodeSome = Self;
     type DecodeSequence = RemainingWireDecoder<R, OPT, C>;
@@ -229,7 +229,7 @@ where
     #[inline]
     fn with_context<U>(self, cx: U) -> Result<Self::WithContext<U>, C::Error>
     where
-        U: Context,
+        U: Context<Allocator = Self::Allocator>,
     {
         Ok(WireDecoder::new(cx, self.reader))
     }

--- a/crates/musli/src/wire/en.rs
+++ b/crates/musli/src/wire/en.rs
@@ -93,7 +93,7 @@ where
     type WithContext<U>
         = WireEncoder<W, OPT, U>
     where
-        U: Context;
+        U: Context<Allocator = <Self::Cx as Context>::Allocator>;
     type EncodePack = WireSequenceEncoder<W, OPT, C>;
     type EncodeSome = Self;
     type EncodeSequence = Self;
@@ -111,7 +111,7 @@ where
     #[inline]
     fn with_context<U>(self, cx: U) -> Result<Self::WithContext<U>, C::Error>
     where
-        U: Context,
+        U: Context<Allocator = <Self::Cx as Context>::Allocator>,
     {
         Ok(WireEncoder::new(cx, self.writer))
     }

--- a/crates/musli/tests/test_simple_json_encoding.rs
+++ b/crates/musli/tests/test_simple_json_encoding.rs
@@ -36,7 +36,7 @@ fn test_simple_json_encoding() {
     let actual: Vec<SimpleJsonStruct<'_>> = musli::json::from_slice(out.as_bytes()).unwrap();
     assert_eq!(expected, actual);
 
-    let value: musli::value::Value = musli::json::from_slice(b"10.00001e-121").unwrap();
+    let value: musli::value::Value<_> = musli::json::from_slice(b"10.00001e-121").unwrap();
     println!("{:?}", value);
     // assert_eq!(expected, actual);
 }

--- a/crates/musli/tests/ui/context_error_hint_error.stderr
+++ b/crates/musli/tests/ui/context_error_hint_error.stderr
@@ -28,7 +28,7 @@ error[E0277]: `ContextError` must be implemented for `MyError`, or any error typ
              musli::json::Error<A>
              musli::packed::Error<A>
              musli::storage::Error<A>
-             musli::value::Error
+             musli::value::Error<A>
              musli::wire::Error<A>
              std::io::Error
              std::string::String

--- a/crates/musli/tests/visitors.rs
+++ b/crates/musli/tests/visitors.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 
+use musli::alloc::System;
 use musli::de::UnsizedVisitor;
+use musli::value::Value;
 use musli::{Allocator, Context, Decode, Decoder};
 
 #[derive(Debug, PartialEq)]
@@ -44,7 +46,7 @@ where
 
 #[test]
 fn bytes_reference() {
-    let value = musli::value::Value::Bytes(vec![0, 1, 2, 3]);
+    let value = Value::try_from(&[0u8, 1, 2, 3]).unwrap();
 
     assert_eq!(
         musli::value::decode::<BytesReference>(&value).unwrap(),
@@ -53,7 +55,7 @@ fn bytes_reference() {
         }
     );
 
-    let value = musli::value::Value::Number(42u32.into());
+    let value: Value<System> = Value::Number(42u32.into());
 
     assert_eq!(
         musli::value::decode::<BytesReference>(&value)
@@ -104,14 +106,14 @@ where
 
 #[test]
 fn string_reference() {
-    let value = musli::value::Value::String(String::from("Hello!"));
+    let value = Value::try_from("Hello!").unwrap();
 
     assert_eq!(
         musli::value::decode::<StringReference>(&value).unwrap(),
         StringReference { data: "Hello!" }
     );
 
-    let value = musli::value::Value::Number(42u32.into());
+    let value: Value<System> = Value::Number(42u32.into());
 
     assert_eq!(
         musli::value::decode::<StringReference>(&value)
@@ -147,6 +149,6 @@ where
 
 #[test]
 fn owned_fn() {
-    let value = musli::value::Value::String("A".to_string());
+    let value = Value::try_from("A").unwrap();
     assert_eq!(musli::value::decode::<OwnedFn>(&value).unwrap(), OwnedFn::A);
 }

--- a/tests/src/utils/musli.rs
+++ b/tests/src/utils/musli.rs
@@ -196,14 +196,14 @@ pub mod musli_value {
     use musli::value::Value;
     use musli::{Decode, Encode};
 
-    pub fn encode<T>(value: &T) -> Result<Value, musli::value::Error>
+    pub fn encode<T>(value: &T) -> Result<Value<System>, musli::value::Error>
     where
         T: Encode<Binary>,
     {
         musli::value::encode(value)
     }
 
-    pub fn decode<T>(buf: &Value) -> Result<T, musli::value::Error>
+    pub fn decode<T>(buf: &Value<System>) -> Result<T, musli::value::Error>
     where
         for<'a> T: Decode<'a, Binary, System>,
     {


### PR DESCRIPTION
This finally means that adjacently encoded data can be decoded in no-std environments, since they can make use of the custom allocator.