### PR TITLE
Rename `System` allocator to `Global`

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ The tradeoffs we will be showcasing to achieve speed here are:
 * *Use a packed format*. This doesn't allow for any upgrades, but we avoid
   paying the overhead of serializing field identifiers.
 * *Use the [`Slice` allocator]*. This avoids all heap allocations using the
-  system allocator. While the system allocator is quite efficient and
+  global allocator. While the global allocator is quite efficient and
   normally shouldn't be avoided, the slice allocator is a fixed-slab
   allocator. The tradeoff here is that we will error in case we run out of
   memory, but we only need to use the allocator if the types being
@@ -350,7 +350,7 @@ The tradeoffs we will be showcasing to achieve speed here are:
 We achieve this through the following methods:
 
 ```rust
-use musli::alloc::{Allocator, System};
+use musli::alloc::{Allocator, Global};
 use musli::context::{self, ErrorMarker as Error};
 use musli::options::{self, Float, Integer, Width, Options};
 use musli::storage::Encoding;

--- a/asm/src/lib.rs
+++ b/asm/src/lib.rs
@@ -188,7 +188,7 @@ pub mod generic {
 
 #[cfg(feature = "musli")]
 pub mod musli {
-    use musli::alloc::System;
+    use musli::alloc::Global;
     use musli::context::{self, ErrorMarker as Error};
     use musli::options::{self, Options};
     use musli::storage::Encoding;
@@ -221,7 +221,7 @@ pub mod musli {
     #[inline(always)]
     pub fn decode<'buf, T>(buf: &'buf [u8]) -> Result<T, Error>
     where
-        T: Decode<'buf, Packed, System>,
+        T: Decode<'buf, Packed, Global>,
     {
         let cx = context::new();
         ENCODING.from_slice_with(&cx, buf)

--- a/crates/musli-core/src/alloc/allocator.rs
+++ b/crates/musli-core/src/alloc/allocator.rs
@@ -4,19 +4,19 @@ use super::{Alloc, AllocError};
 ///
 /// # Safety
 ///
-/// Setting `IS_SYSTEM` to `true` has safety implications, since it determines
+/// Setting `IS_GLOBAL` to `true` has safety implications, since it determines
 /// whether the allocation can be safely converted into a standard container or
 /// not.
 pub unsafe trait Allocator: Copy {
     /// Whether the allocations returned by this allocatore is backed by the
-    /// system allocator or not.
+    /// global allocator or not.
     ///
     /// # Safety
     ///
     /// Setting this to `true` has safety implications, since it determines
     /// whether the allocation can be safely converted into a standard container
     /// or not.
-    const IS_SYSTEM: bool;
+    const IS_GLOBAL: bool;
 
     /// A raw allocation from the allocator.
     type Alloc<T>: Alloc<T>;

--- a/crates/musli-core/src/alloc/disabled.rs
+++ b/crates/musli-core/src/alloc/disabled.rs
@@ -66,8 +66,8 @@ impl Default for Disabled {
 
 unsafe impl Allocator for Disabled {
     /// We can set this to `true` because the disabled allocator returns
-    /// dangling pointers which are valid in a system allocation.
-    const IS_SYSTEM: bool = true;
+    /// dangling pointers which are valid in a global allocation.
+    const IS_GLOBAL: bool = true;
 
     type Alloc<T> = EmptyBuf<T>;
 

--- a/crates/musli-core/src/alloc/mod.rs
+++ b/crates/musli-core/src/alloc/mod.rs
@@ -17,10 +17,20 @@ mod allocator;
 pub use self::allocator::Allocator;
 
 #[cfg(feature = "alloc")]
-mod system;
+mod global;
 #[cfg(feature = "alloc")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
-pub use self::system::{System, SystemAlloc};
+pub use self::global::{Global, GlobalAlloc};
+
+#[doc(hidden)]
+#[cfg(feature = "alloc")]
+#[deprecated = "`System` has been renamed to `Global`"]
+pub type System = Global;
+
+#[doc(hidden)]
+#[cfg(feature = "alloc")]
+#[deprecated = "`SystemAlloc` has been renamed to `GlobalAlloc`"]
+pub type SystemAlloc<T> = GlobalAlloc<T>;
 
 mod disabled;
 #[doc(inline)]

--- a/crates/musli-core/src/alloc/string.rs
+++ b/crates/musli-core/src/alloc/string.rs
@@ -12,7 +12,7 @@ use crate::de::UnsizedVisitor;
 use crate::{Context, Decode, Decoder, Encode, Encoder};
 
 #[cfg(feature = "alloc")]
-use super::System;
+use super::Global;
 use super::{AllocError, Allocator, Vec};
 
 /// Collect a string into a string buffer.
@@ -622,7 +622,7 @@ impl_eq! { String<A>, &'a str }
 impl_eq! { Cow<'a, str>, String<A> }
 
 /// Conversion from a std [`String`][std-string] to a Müsli-allocated [`String`]
-/// in the [`System`] allocator.
+/// in the [`Global`] allocator.
 ///
 /// [std-string]: rust_alloc::string::String
 ///
@@ -636,7 +636,7 @@ impl_eq! { Cow<'a, str>, String<A> }
 /// ```
 #[cfg(feature = "alloc")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
-impl From<rust_alloc::string::String> for String<System> {
+impl From<rust_alloc::string::String> for String<Global> {
     #[inline]
     fn from(value: rust_alloc::string::String) -> Self {
         Self {

--- a/crates/musli-core/src/alloc/vec.rs
+++ b/crates/musli-core/src/alloc/vec.rs
@@ -10,7 +10,7 @@ use crate::de::{DecodeBytes, UnsizedVisitor};
 use crate::{Context, Decoder};
 
 #[cfg(feature = "alloc")]
-use super::System;
+use super::Global;
 use super::{Alloc, AllocError, Allocator, Disabled};
 
 /// A Müsli-allocated contiguous growable array type, written as `Vec<T>`, short
@@ -73,7 +73,7 @@ where
     /// Coerce into a std vector.
     #[cfg(feature = "alloc")]
     pub fn into_std(self) -> Result<rust_alloc::vec::Vec<T>, Self> {
-        if !A::IS_SYSTEM {
+        if !A::IS_GLOBAL {
             return Err(self);
         }
 
@@ -760,7 +760,7 @@ where
 }
 
 /// Conversion from a std [`Vec`][std-vec] to a Müsli-allocated [`Vec`] in the
-/// [`System`] allocator.
+/// [`Global`] allocator.
 ///
 /// [std-vec]: rust_alloc::vec::Vec
 ///
@@ -774,20 +774,20 @@ where
 /// ```
 #[cfg(feature = "alloc")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
-impl<T> From<rust_alloc::vec::Vec<T>> for Vec<T, System> {
+impl<T> From<rust_alloc::vec::Vec<T>> for Vec<T, Global> {
     #[inline]
     fn from(value: rust_alloc::vec::Vec<T>) -> Self {
         use core::ptr::NonNull;
 
         // SAFETY: We know that the vector was allocated as expected using the
-        // system allocator.
+        // global allocator.
         unsafe {
             let mut value = ManuallyDrop::new(value);
             let ptr = NonNull::new_unchecked(value.as_mut_ptr());
             let len = value.len();
             let cap = value.capacity();
 
-            let buf = System::slice_from_raw_parts(ptr, cap);
+            let buf = Global::slice_from_raw_parts(ptr, cap);
             Vec::from_raw_parts(buf, len)
         }
     }

--- a/crates/musli-web/src/api.rs
+++ b/crates/musli-web/src/api.rs
@@ -1,6 +1,6 @@
 //! Shared traits for defining API types.
 
-use musli::alloc::System;
+use musli::alloc::Global;
 use musli::mode::Binary;
 use musli::{Decode, Encode};
 
@@ -100,7 +100,7 @@ pub trait Endpoint {
     const KIND: &'static str;
 
     /// The response type related to the endpoint.
-    type Response<'de>: Decode<'de, Binary, System>;
+    type Response<'de>: Decode<'de, Binary, Global>;
 }
 
 pub trait Listener {
@@ -123,7 +123,7 @@ where
 /// A broadcast type marker.
 pub trait Broadcast<'de>
 where
-    Self: Encode<Binary> + Decode<'de, Binary, System>,
+    Self: Encode<Binary> + Decode<'de, Binary, Global>,
 {
     /// The endpoint related to the broadcast.
     type Endpoint: Listener<Broadcast<'de> = Self>;

--- a/crates/musli-web/src/json.rs
+++ b/crates/musli-web/src/json.rs
@@ -10,7 +10,7 @@ use bytes::{BufMut, Bytes, BytesMut};
 use http::header::{self, HeaderValue};
 use http::{HeaderMap, StatusCode};
 use musli::Encode;
-use musli::alloc::System;
+use musli::alloc::Global;
 use musli::context::ErrorMarker;
 use musli::de::DecodeOwned;
 use musli::json::Encoding;
@@ -87,7 +87,7 @@ pub struct Json<T>(pub T);
 #[cfg(feature = "axum-core05")]
 impl<T, S> extract05::FromRequest<S> for Json<T>
 where
-    T: DecodeOwned<Text, System>,
+    T: DecodeOwned<Text, Global>,
     S: Send + Sync,
 {
     type Rejection = JsonRejection;
@@ -163,7 +163,7 @@ where
 
 impl<T> Json<T>
 where
-    T: DecodeOwned<Text, System>,
+    T: DecodeOwned<Text, Global>,
 {
     #[inline]
     fn from_bytes(bytes: &[u8]) -> Result<Self, JsonRejection> {

--- a/crates/musli-web/src/ws.rs
+++ b/crates/musli-web/src/ws.rs
@@ -7,7 +7,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 use bytes::Bytes;
-use musli::alloc::System;
+use musli::alloc::Global;
 use musli::mode::Binary;
 use musli::reader::SliceReader;
 use musli::storage;
@@ -508,7 +508,7 @@ impl<'de> Incoming<'de> {
     #[inline]
     pub fn read<T>(&mut self) -> Option<T>
     where
-        T: Decode<'de, Binary, System>,
+        T: Decode<'de, Binary, Global>,
     {
         match storage::decode(&mut self.reader) {
             Ok(value) => Some(value),

--- a/crates/musli/README.md
+++ b/crates/musli/README.md
@@ -336,7 +336,7 @@ The tradeoffs we will be showcasing to achieve speed here are:
 * *Use a packed format*. This doesn't allow for any upgrades, but we avoid
   paying the overhead of serializing field identifiers.
 * *Use the [`Slice` allocator]*. This avoids all heap allocations using the
-  system allocator. While the system allocator is quite efficient and
+  global allocator. While the global allocator is quite efficient and
   normally shouldn't be avoided, the slice allocator is a fixed-slab
   allocator. The tradeoff here is that we will error in case we run out of
   memory, but we only need to use the allocator if the types being
@@ -350,7 +350,7 @@ The tradeoffs we will be showcasing to achieve speed here are:
 We achieve this through the following methods:
 
 ```rust
-use musli::alloc::{Allocator, System};
+use musli::alloc::{Allocator, Global};
 use musli::context::{self, ErrorMarker as Error};
 use musli::options::{self, Float, Integer, Width, Options};
 use musli::storage::Encoding;

--- a/crates/musli/src/alloc/default.rs
+++ b/crates/musli/src/alloc/default.rs
@@ -1,10 +1,10 @@
 use core::marker::PhantomData;
 
 use super::{Alloc, AllocError, Allocator};
+#[cfg(feature = "alloc")]
+use super::{Global, GlobalAlloc};
 #[cfg(not(feature = "alloc"))]
 use super::{Slice, SliceAlloc};
-#[cfg(feature = "alloc")]
-use super::{System, SystemAlloc};
 
 /// The default stack buffer size for the default allocator provided through
 /// [`default()`].
@@ -54,7 +54,7 @@ macro_rules! implement {
 }
 
 #[cfg(feature = "alloc")]
-implement!(DefaultAllocator, System, SystemAlloc<T>, SystemAlloc<T>);
+implement!(DefaultAllocator, Global, SystemAlloc<T>, GlobalAlloc<T>);
 
 #[cfg(not(feature = "alloc"))]
 implement!(
@@ -66,10 +66,10 @@ implement!(
 
 unsafe impl<'a, const BUF: usize> Allocator for &'a DefaultAllocator<'_, BUF> {
     #[cfg(feature = "alloc")]
-    const IS_SYSTEM: bool = true;
+    const IS_GLOBAL: bool = true;
 
     #[cfg(not(feature = "alloc"))]
-    const IS_SYSTEM: bool = false;
+    const IS_GLOBAL: bool = false;
 
     type Alloc<T> = DefaultAlloc<'a, T, BUF>;
 

--- a/crates/musli/src/alloc/mod.rs
+++ b/crates/musli/src/alloc/mod.rs
@@ -1,8 +1,7 @@
 //! Allocation support for [Müsli].
 //!
 //! This crate contains two types of allocators:
-//! * The [`System`] allocator, which uses the system allocation facilities.
-//!   Particularly [`std::alloc::System`].
+//! * The [`Global`] allocator, which uses the global allocation facilities.
 //! * The [`Slice`] allocator, which can allocate buffers from a fixed-size
 //!   slice.
 //!
@@ -75,7 +74,6 @@
 //! ```
 //!
 //! [Müsli]: <https://docs.rs/musli>
-//! [`std::alloc::System`]: https://doc.rust-lang.org/std/alloc/struct.System.html
 
 #[cfg(test)]
 mod tests;
@@ -90,7 +88,8 @@ pub use musli_core::alloc::{Alloc, AllocError, Allocator, Box, Disabled, String,
 #[cfg(feature = "alloc")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 #[doc(inline)]
-pub use musli_core::alloc::{System, SystemAlloc};
+#[expect(deprecated)]
+pub use musli_core::alloc::{Global, GlobalAlloc, System, SystemAlloc};
 
 mod slice;
 #[doc(inline)]
@@ -107,7 +106,7 @@ pub use self::slice_buffer::SliceBuffer;
 /// This is useful if you want to write application which are agnostic to
 /// whether the `alloc` feature is or isn't enabled.
 ///
-/// * If the `alloc` feature is enabled, this is the [`System`] allocator.
+/// * If the `alloc` feature is enabled, this is the [`Global`] allocator.
 /// * If the `alloc` feature is disabled, this is the [`Slice`] allocator with
 ///   [`DEFAULT_ARRAY_BUFFER`] bytes allocated on the stack. The second
 ///   parameters allows for this to be tweaked.
@@ -195,7 +194,7 @@ pub fn with_buffer<const BUF: usize, O>(body: impl FnOnce(&DefaultAllocator<'_, 
 fn default_allocator_impl<const BUF: usize, O>(
     body: impl FnOnce(&DefaultAllocator<'_, BUF>) -> O,
 ) -> O {
-    let alloc = DefaultAllocator::new(System::new());
+    let alloc = DefaultAllocator::new(Global::new());
     body(&alloc)
 }
 

--- a/crates/musli/src/alloc/slice.rs
+++ b/crates/musli/src/alloc/slice.rs
@@ -175,7 +175,7 @@ impl<'a> Slice<'a> {
 }
 
 unsafe impl<'a> Allocator for &'a Slice<'_> {
-    const IS_SYSTEM: bool = false;
+    const IS_GLOBAL: bool = false;
 
     type Alloc<T> = SliceAlloc<'a, T>;
 

--- a/crates/musli/src/alloc/tests.rs
+++ b/crates/musli/src/alloc/tests.rs
@@ -1,10 +1,10 @@
-use super::{Allocator, ArrayBuffer, Slice, System, Vec};
+use super::{Allocator, ArrayBuffer, Global, Slice, Vec};
 
 macro_rules! test_for_each {
-    ($system:ident, $stack:ident, $inner:ident) => {
+    ($global:ident, $stack:ident, $inner:ident) => {
         #[test]
-        fn $system() {
-            let alloc = System::new();
+        fn $global() {
+            let alloc = Global::new();
             $inner(alloc);
         }
 
@@ -105,6 +105,6 @@ where
     assert_eq!(a.as_slice(), b.as_slice());
 }
 
-test_for_each!(system_basic, stack_basic, basic_allocations);
-test_for_each!(system_grow, stack_grow, grow_allocations);
-test_for_each!(system_zst, stack_zst, zst_allocations);
+test_for_each!(global_basic, stack_basic, basic_allocations);
+test_for_each!(global_grow, stack_grow, grow_allocations);
+test_for_each!(global_zst, stack_zst, zst_allocations);

--- a/crates/musli/src/context/default_context.rs
+++ b/crates/musli/src/context/default_context.rs
@@ -2,7 +2,7 @@ use core::error::Error;
 use core::fmt;
 
 #[cfg(feature = "alloc")]
-use crate::alloc::System;
+use crate::alloc::Global;
 use crate::{Allocator, Context};
 
 use super::{
@@ -13,11 +13,11 @@ use super::{
 /// The default context which uses an allocator to track the location of errors.
 ///
 /// This is typically constructed using [`new`] and by default uses the
-/// [`System`] allocator to allocate memory. To customized the allocator to use
+/// [`Global`] allocator to allocate memory. To customized the allocator to use
 /// [`new_in`] can be used during construction.
 ///
 /// The default constructor is only available when the `alloc` feature is
-/// enabled, and will use the [`System`] allocator.
+/// enabled, and will use the [`Global`] allocator.
 ///
 /// [`new`]: super::new
 /// [`new_in`]: super::new_in
@@ -32,12 +32,12 @@ where
 }
 
 #[cfg(feature = "alloc")]
-impl DefaultContext<System, NoTrace, Ignore> {
-    /// Construct the default context which uses the [`System`] allocator for
+impl DefaultContext<Global, NoTrace, Ignore> {
+    /// Construct the default context which uses the [`Global`] allocator for
     /// memory.
     #[inline]
     pub(super) fn new() -> Self {
-        Self::new_in(System::new())
+        Self::new_in(Global::new())
     }
 }
 
@@ -59,7 +59,7 @@ where
 }
 
 #[cfg(feature = "alloc")]
-impl Default for DefaultContext<System, NoTrace, Ignore> {
+impl Default for DefaultContext<Global, NoTrace, Ignore> {
     #[inline]
     fn default() -> Self {
         Self::new()
@@ -106,7 +106,7 @@ where
     ///
     /// ```
     /// use musli::{Decode, Encode};
-    /// use musli::alloc::System;
+    /// use musli::alloc::Global;
     /// use musli::context;
     /// use musli::json::{Encoding, Error};
     ///
@@ -154,7 +154,7 @@ where
     ///
     /// ```
     /// use musli::{Decode, Encode};
-    /// use musli::alloc::System;
+    /// use musli::alloc::Global;
     /// use musli::context;
     /// use musli::json::{Encoding, Error};
     ///

--- a/crates/musli/src/context/mod.rs
+++ b/crates/musli/src/context/mod.rs
@@ -26,10 +26,10 @@ mod context_error;
 pub use self::context_error::ContextError;
 
 #[cfg(feature = "alloc")]
-use crate::alloc::System;
+use crate::alloc::Global;
 use crate::Allocator;
 
-/// Construct a new default context using the [`System`] allocator.
+/// Construct a new default context using the [`Global`] allocator.
 ///
 /// # Examples
 ///
@@ -48,7 +48,7 @@ use crate::Allocator;
 #[cfg(feature = "alloc")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 #[inline]
-pub fn new() -> DefaultContext<System, NoTrace, Ignore> {
+pub fn new() -> DefaultContext<Global, NoTrace, Ignore> {
     DefaultContext::new()
 }
 

--- a/crates/musli/src/descriptive/encoding.rs
+++ b/crates/musli/src/descriptive/encoding.rs
@@ -1,7 +1,7 @@
 use core::marker;
 
 #[cfg(feature = "alloc")]
-use crate::alloc::System;
+use crate::alloc::Global;
 use crate::mode::Binary;
 use crate::options;
 use crate::{Context, Decode, Encode, IntoReader, IntoWriter, Options};

--- a/crates/musli/src/json/encoding.rs
+++ b/crates/musli/src/json/encoding.rs
@@ -6,7 +6,7 @@ use rust_alloc::string::String;
 use rust_alloc::vec::Vec;
 
 #[cfg(feature = "alloc")]
-use crate::alloc::System;
+use crate::alloc::Global;
 use crate::mode::Text;
 use crate::{Context, Decode, Encode, IntoWriter};
 
@@ -87,7 +87,7 @@ where
 #[inline]
 pub fn from_str<'de, T>(string: &'de str) -> Result<T, Error>
 where
-    T: Decode<'de, Text, System>,
+    T: Decode<'de, Text, Global>,
 {
     DEFAULT.from_str(string)
 }
@@ -232,7 +232,7 @@ where
     /// ```
     /// use musli::{Decode, Encode};
     /// use musli::json;
-    /// use musli::alloc::System;
+    /// use musli::alloc::Global;
     /// # use musli::json::Error;
     ///
     /// const ENCODING: json::Encoding = json::Encoding::new();

--- a/crates/musli/src/lib.rs
+++ b/crates/musli/src/lib.rs
@@ -347,7 +347,7 @@
 //! * *Use a packed format*. This doesn't allow for any upgrades, but we avoid
 //!   paying the overhead of serializing field identifiers.
 //! * *Use the [`Slice` allocator]*. This avoids all heap allocations using the
-//!   system allocator. While the system allocator is quite efficient and
+//!   global allocator. While the global allocator is quite efficient and
 //!   normally shouldn't be avoided, the slice allocator is a fixed-slab
 //!   allocator. The tradeoff here is that we will error in case we run out of
 //!   memory, but we only need to use the allocator if the types being
@@ -361,7 +361,7 @@
 //! We achieve this through the following methods:
 //!
 //! ```
-//! use musli::alloc::{Allocator, System};
+//! use musli::alloc::{Allocator, Global};
 //! use musli::context::{self, ErrorMarker as Error};
 //! use musli::options::{self, Float, Integer, Width, Options};
 //! use musli::storage::Encoding;

--- a/crates/musli/src/macros/internal.rs
+++ b/crates/musli/src/macros/internal.rs
@@ -237,7 +237,7 @@ macro_rules! bare_encoding {
         pub fn decode<'de, R, T>(reader: R) -> Result<T, Error>
         where
             R: $reader_trait<'de>,
-            T: Decode<'de, $mode, System>,
+            T: Decode<'de, $mode, Global>,
         {
             $default.decode(reader)
         }
@@ -273,7 +273,7 @@ macro_rules! bare_encoding {
         #[inline]
         pub fn from_slice<'de, T>(bytes: &'de [u8]) -> Result<T, Error>
         where
-            T: Decode<'de, $mode, System>,
+            T: Decode<'de, $mode, Global>,
         {
             $default.from_slice(bytes)
         }
@@ -552,7 +552,7 @@ macro_rules! encoding_impls {
         pub fn decode<'de, R, T>(self, reader: R) -> Result<T, Error>
         where
             R: $reader_trait<'de>,
-            T: Decode<'de, $mode, System>,
+            T: Decode<'de, $mode, Global>,
         {
             let cx = $crate::context::new().with_error();
             self.decode_with(&cx, reader)
@@ -591,7 +591,7 @@ macro_rules! encoding_impls {
         #[inline]
         pub fn from_slice<'de, T>(self, bytes: &'de [u8]) -> Result<T, Error>
         where
-            T: Decode<'de, $mode, System>,
+            T: Decode<'de, $mode, Global>,
         {
             let cx = $crate::context::new().with_error();
             self.from_slice_with(&cx, bytes)
@@ -607,7 +607,7 @@ macro_rules! encoding_impls {
         #[inline]
         pub fn from_str<'de, T>(self, string: &'de str) -> Result<T, Error>
         where
-            T: Decode<'de, M, System>,
+            T: Decode<'de, M, Global>,
         {
             self.from_slice(string.as_bytes())
         }
@@ -625,7 +625,7 @@ macro_rules! encoding_impls {
         ///
         /// ```
         /// use musli::{Decode, Encode};
-        /// use musli::alloc::System;
+        /// use musli::alloc::Global;
         /// use musli::context;
         #[doc = concat!("use musli::", stringify!($what), "::Encoding;")]
         #[doc = concat!("# use musli::", stringify!($what), "::Error;")]
@@ -678,7 +678,7 @@ macro_rules! encoding_impls {
         ///
         /// ```
         /// use musli::{Decode, Encode};
-        /// use musli::alloc::System;
+        /// use musli::alloc::Global;
         /// use musli::context;
         #[doc = concat!("use musli::", stringify!($what), "::Encoding;")]
         #[doc = concat!("# use musli::", stringify!($what), "::Error;")]
@@ -736,7 +736,7 @@ macro_rules! encoding_impls {
         ///
         /// ```
         /// use musli::{Decode, Encode};
-        /// use musli::alloc::System;
+        /// use musli::alloc::Global;
         /// use musli::context;
         #[doc = concat!("use musli::", stringify!($what), "::Encoding;")]
         #[doc = concat!("# use musli::", stringify!($what), "::Error;")]
@@ -785,7 +785,7 @@ macro_rules! encoding_impls {
         ///
         /// ```
         /// use musli::{Decode, Encode, FixedBytes};
-        /// use musli::alloc::System;
+        /// use musli::alloc::Global;
         /// use musli::context;
         #[doc = concat!("use musli::", stringify!($what), "::Encoding;")]
         #[doc = concat!("# use musli::", stringify!($what), "::Error;")]
@@ -834,7 +834,7 @@ macro_rules! encoding_impls {
         ///
         /// ```
         /// use musli::{Decode, Encode};
-        /// use musli::alloc::System;
+        /// use musli::alloc::Global;
         /// use musli::context;
         #[doc = concat!("use musli::", stringify!($what), "::Encoding;")]
         #[doc = concat!("# use musli::", stringify!($what), "::Error;")]
@@ -886,7 +886,7 @@ macro_rules! encoding_impls {
         ///
         /// ```
         /// use musli::{Decode, Encode};
-        /// use musli::alloc::System;
+        /// use musli::alloc::Global;
         /// use musli::context;
         #[doc = concat!("use musli::", stringify!($what), "::Encoding;")]
         #[doc = concat!("# use musli::", stringify!($what), "::Error;")]
@@ -936,7 +936,7 @@ macro_rules! encoding_impls {
         ///
         /// ```
         /// use musli::{Decode, Encode};
-        /// use musli::alloc::System;
+        /// use musli::alloc::Global;
         /// use musli::context;
         #[doc = concat!("use musli::", stringify!($what), "::Encoding;")]
         #[doc = concat!("# use musli::", stringify!($what), "::Error;")]
@@ -998,7 +998,7 @@ macro_rules! implement_error {
     ) => {
         $(#[$($meta)*])*
         #[cfg(feature = "alloc")]
-        pub struct $id<A = $crate::alloc::System>
+        pub struct $id<A = $crate::alloc::Global>
         where
             A: $crate::Allocator,
         {
@@ -1112,7 +1112,7 @@ macro_rules! implement_error {
         #[cfg(feature = "alloc")]
         const _: () = {
             const fn assert_send_sync<T: Send + Sync>() {}
-            assert_send_sync::<$id<$crate::alloc::System>>();
+            assert_send_sync::<$id<$crate::alloc::Global>>();
         };
     };
 }

--- a/crates/musli/src/macros/test.rs
+++ b/crates/musli/src/macros/test.rs
@@ -16,7 +16,7 @@ macro_rules! test_fns {
         #[cfg(feature = "alloc")]
         pub fn rt<T, M>(value: T) -> T
         where
-            T: $crate::en::Encode<M> + $crate::de::DecodeOwned<M, $crate::alloc::System>,
+            T: $crate::en::Encode<M> + $crate::de::DecodeOwned<M, $crate::alloc::Global>,
             T: ::core::fmt::Debug + ::core::cmp::PartialEq,
             M: 'static,
         {
@@ -100,7 +100,7 @@ macro_rules! test_fns {
         where
             T: $crate::en::Encode<M>,
             T: ::core::fmt::Debug + ::core::cmp::PartialEq,
-            U: $crate::de::Decode<'de, M, $crate::alloc::System>,
+            U: $crate::de::Decode<'de, M, $crate::alloc::Global>,
             U: ::core::fmt::Debug + ::core::cmp::PartialEq,
             M: 'static,
         {
@@ -445,7 +445,7 @@ pub use __test_matrix;
 pub mod support {
     pub use rust_alloc::vec::Vec;
 
-    use crate::alloc::System;
+    use crate::alloc::Global;
     use crate::mode::Binary;
     use crate::value::{self, Value};
     use crate::{Decode, Encode};
@@ -453,7 +453,7 @@ pub mod support {
     #[track_caller]
     pub fn musli_value_rt<T>(expected: T)
     where
-        T: Encode<Binary> + for<'de> Decode<'de, Binary, System>,
+        T: Encode<Binary> + for<'de> Decode<'de, Binary, Global>,
         T: PartialEq + core::fmt::Debug,
     {
         let value: Value<_> = value::encode(&expected).expect("value: Encoding should succeed");

--- a/crates/musli/src/packed/encoding.rs
+++ b/crates/musli/src/packed/encoding.rs
@@ -1,7 +1,7 @@
 use core::marker;
 
 #[cfg(feature = "alloc")]
-use crate::alloc::System;
+use crate::alloc::Global;
 use crate::mode::Binary;
 use crate::options;
 use crate::{Context, Decode, Encode, IntoReader, IntoWriter, Options};

--- a/crates/musli/src/storage/encoding.rs
+++ b/crates/musli/src/storage/encoding.rs
@@ -1,7 +1,7 @@
 use core::marker;
 
 #[cfg(feature = "alloc")]
-use crate::alloc::System;
+use crate::alloc::Global;
 use crate::mode::Binary;
 use crate::options;
 use crate::{Context, Decode, Encode, IntoReader, IntoWriter, Options};

--- a/crates/musli/src/tests/loom.rs
+++ b/crates/musli/src/tests/loom.rs
@@ -1,4 +1,4 @@
-use crate::alloc::{System, Vec};
+use crate::alloc::{Global, Vec};
 
 const BIG1: &[u8] = &[
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
@@ -7,7 +7,7 @@ const BIG2: &[u8] = &[
     0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f,
 ];
 
-fn work(alloc: System) {
+fn work(alloc: Global) {
     let mut buf1 = Vec::new_in(alloc);
     let mut buf2 = Vec::new_in(alloc);
 
@@ -21,7 +21,7 @@ fn work(alloc: System) {
 #[test]
 fn test_concurrent_allocator() {
     loom::model(|| {
-        let alloc = System::new();
+        let alloc = Global::new();
         loom::thread::spawn(move || work(alloc));
         work(alloc);
     });

--- a/crates/musli/src/value/mod.rs
+++ b/crates/musli/src/value/mod.rs
@@ -26,7 +26,7 @@ pub use error::Error;
 
 use crate::alloc::Allocator;
 #[cfg(feature = "alloc")]
-use crate::alloc::System;
+use crate::alloc::Global;
 #[cfg(feature = "alloc")]
 use crate::mode::Binary;
 #[cfg(feature = "alloc")]
@@ -41,7 +41,7 @@ const OPTIONS: Options = crate::options::new().build();
 /// mode.
 #[cfg(feature = "alloc")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
-pub fn encode<T>(value: T) -> Result<Value<System>, Error>
+pub fn encode<T>(value: T) -> Result<Value<Global>, Error>
 where
     T: Encode<Binary>,
 {
@@ -59,7 +59,7 @@ where
 #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 pub fn decode<'de, T>(value: &'de Value<impl Allocator>) -> Result<T, Error>
 where
-    T: Decode<'de, Binary, System>,
+    T: Decode<'de, Binary, Global>,
 {
     use crate::de::Decoder;
     let cx = crate::context::new().with_error();

--- a/crates/musli/src/value/value.rs
+++ b/crates/musli/src/value/value.rs
@@ -3,7 +3,7 @@ use core::fmt;
 use core::marker::PhantomData;
 
 #[cfg(feature = "alloc")]
-use crate::alloc::{AllocError, System};
+use crate::alloc::{AllocError, Global};
 use crate::alloc::{Box, String, Vec};
 use crate::de::{AsDecoder, Decode, Decoder, Visitor};
 use crate::de::{
@@ -666,12 +666,12 @@ where
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
-impl TryFrom<&str> for Value<System> {
+impl TryFrom<&str> for Value<Global> {
     type Error = AllocError;
 
     #[inline]
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        let mut string = String::new_in(System::new());
+        let mut string = String::new_in(Global::new());
         string.push_str(value)?;
         Ok(Value::String(string))
     }
@@ -679,7 +679,7 @@ impl TryFrom<&str> for Value<System> {
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
-impl From<rust_alloc::string::String> for Value<System> {
+impl From<rust_alloc::string::String> for Value<Global> {
     #[inline]
     fn from(value: rust_alloc::string::String) -> Self {
         Value::String(String::from(value))
@@ -688,21 +688,21 @@ impl From<rust_alloc::string::String> for Value<System> {
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
-impl From<rust_alloc::vec::Vec<Value<System>>> for Value<System> {
+impl From<rust_alloc::vec::Vec<Value<Global>>> for Value<Global> {
     #[inline]
-    fn from(value: rust_alloc::vec::Vec<Value<System>>) -> Self {
+    fn from(value: rust_alloc::vec::Vec<Value<Global>>) -> Self {
         Value::Sequence(Vec::from(value))
     }
 }
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
-impl TryFrom<&[u8]> for Value<System> {
+impl TryFrom<&[u8]> for Value<Global> {
     type Error = AllocError;
 
     #[inline]
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        let mut string = Vec::new_in(System::new());
+        let mut string = Vec::new_in(Global::new());
         string.extend_from_slice(value)?;
         Ok(Value::Bytes(string))
     }
@@ -710,7 +710,7 @@ impl TryFrom<&[u8]> for Value<System> {
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
-impl<const N: usize> TryFrom<&[u8; N]> for Value<System> {
+impl<const N: usize> TryFrom<&[u8; N]> for Value<Global> {
     type Error = AllocError;
 
     #[inline]
@@ -721,7 +721,7 @@ impl<const N: usize> TryFrom<&[u8; N]> for Value<System> {
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
-impl<const N: usize> TryFrom<[u8; N]> for Value<System> {
+impl<const N: usize> TryFrom<[u8; N]> for Value<Global> {
     type Error = AllocError;
 
     #[inline]

--- a/crates/musli/src/wire/encoding.rs
+++ b/crates/musli/src/wire/encoding.rs
@@ -1,7 +1,7 @@
 use core::marker;
 
 #[cfg(feature = "alloc")]
-use crate::alloc::System;
+use crate::alloc::Global;
 use crate::mode::Binary;
 use crate::options;
 use crate::{Context, Decode, Encode, IntoReader, IntoWriter, Options};

--- a/crates/musli/tests/recursive_models.rs
+++ b/crates/musli/tests/recursive_models.rs
@@ -10,7 +10,7 @@
 //!  = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`recursive_models`)
 //! ```
 
-use musli::alloc::System;
+use musli::alloc::Global;
 use musli::de::DecodeOwned;
 use musli::mode::Binary;
 use musli::{Decode, Encode};
@@ -24,7 +24,7 @@ where
 
 pub(crate) fn decode<T>(buf: &[u8]) -> musli::storage::Result<T>
 where
-    T: DecodeOwned<Binary, System>,
+    T: DecodeOwned<Binary, Global>,
 {
     musli::storage::from_slice(buf)
 }

--- a/crates/musli/tests/serde_compat.rs
+++ b/crates/musli/tests/serde_compat.rs
@@ -27,7 +27,7 @@ where
     T: DeserializeOwned;
 
 mod value {
-    use musli::alloc::System;
+    use musli::alloc::Global;
 
     use super::*;
 
@@ -38,7 +38,7 @@ mod value {
             + fmt::Debug
             + Generate
             + Encode<Binary>
-            + DecodeOwned<Binary, System>
+            + DecodeOwned<Binary, Global>
             + Serialize
             + DeserializeOwned,
     {
@@ -51,7 +51,7 @@ mod value {
         T: Eq
             + fmt::Debug
             + Encode<Binary>
-            + DecodeOwned<Binary, System>
+            + DecodeOwned<Binary, Global>
             + Serialize
             + DeserializeOwned,
     {
@@ -106,14 +106,14 @@ mod value {
 macro_rules! tester {
     ($module:ident, $mode:ty $(,)?) => {
         mod $module {
-            use musli::alloc::System;
+            use musli::alloc::Global;
 
             use super::*;
 
             #[track_caller]
             pub(super) fn random<T>(module: &str)
             where
-                T: Encode<$mode> + DecodeOwned<$mode, System>,
+                T: Encode<$mode> + DecodeOwned<$mode, Global>,
                 T: Eq + fmt::Debug + Generate + Serialize + DeserializeOwned,
             {
                 guided(module, <T as Generate>::generate);
@@ -122,7 +122,7 @@ macro_rules! tester {
             #[track_caller]
             pub(super) fn guided<T>(module: &str, value: fn(&mut Rng) -> T)
             where
-                T: Encode<$mode> + DecodeOwned<$mode, System>,
+                T: Encode<$mode> + DecodeOwned<$mode, Global>,
                 T: Eq + fmt::Debug + Serialize + DeserializeOwned,
             {
                 macro_rules! do_try {

--- a/crates/musli/tests/storage_trace.rs
+++ b/crates/musli/tests/storage_trace.rs
@@ -1,6 +1,6 @@
 #![allow(unused)]
 
-use musli::alloc::System;
+use musli::alloc::Global;
 use musli::context;
 use musli::{Decode, Encode};
 

--- a/crates/musli/tests/trace_collection.rs
+++ b/crates/musli/tests/trace_collection.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use musli::alloc::System;
+use musli::alloc::Global;
 use musli::context;
 use musli::{Decode, Encode};
 

--- a/crates/musli/tests/trace_complex.rs
+++ b/crates/musli/tests/trace_complex.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use musli::alloc::System;
+use musli::alloc::Global;
 use musli::context;
 use musli::{Decode, Encode};
 

--- a/crates/musli/tests/ui/context_error_hint_error.stderr
+++ b/crates/musli/tests/ui/context_error_hint_error.stderr
@@ -2,7 +2,7 @@ error[E0277]: `ContextError` must be implemented for `MyError`, or any error typ
   --> tests/ui/context_error_hint_error.rs:15:45
    |
 15 |     let _cx = context::new().with_capture::<MyError>();
-   |                              ------------   ^^^^^^^ the trait `ContextError<musli::alloc::System>` is not implemented for `MyError`
+   |                              ------------   ^^^^^^^ the trait `ContextError<musli::alloc::Global>` is not implemented for `MyError`
    |                              |
    |                              required by a bound introduced by this call
    |

--- a/crates/musli/tests/visitors.rs
+++ b/crates/musli/tests/visitors.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use musli::alloc::System;
+use musli::alloc::Global;
 use musli::de::UnsizedVisitor;
 use musli::value::Value;
 use musli::{Allocator, Context, Decode, Decoder};
@@ -56,7 +56,7 @@ fn bytes_reference() {
         }
     );
 
-    let value: Value<System> = Value::Number(42u32.into());
+    let value: Value<Global> = Value::Number(42u32.into());
 
     assert_eq!(
         musli::value::decode::<BytesReference>(&value)
@@ -115,7 +115,7 @@ fn string_reference() {
         StringReference { data: "Hello!" }
     );
 
-    let value: Value<System> = Value::Number(42u32.into());
+    let value: Value<Global> = Value::Number(42u32.into());
 
     assert_eq!(
         musli::value::decode::<StringReference>(&value)

--- a/tests/src/utils/musli.rs
+++ b/tests/src/utils/musli.rs
@@ -3,7 +3,7 @@
 pub mod musli_json {
     use alloc::vec::Vec;
 
-    use musli::alloc::System;
+    use musli::alloc::Global;
     use musli::json::Encoding;
     use musli::json::Error;
     use musli::mode::Text;
@@ -29,7 +29,7 @@ pub mod musli_json {
 
     pub fn decode<'buf, T>(buffer: &'buf [u8]) -> Result<T, Error>
     where
-        T: Decode<'buf, Text, System>,
+        T: Decode<'buf, Text, Global>,
     {
         ENCODING.from_slice(buffer)
     }
@@ -41,7 +41,7 @@ pub mod musli_packed {
     use alloc::vec;
     use alloc::vec::Vec;
 
-    use musli::alloc::System;
+    use musli::alloc::Global;
     use musli::context::{self, ErrorMarker as Error};
     use musli::options::{self, Options};
     use musli::storage::Encoding;
@@ -69,7 +69,7 @@ pub mod musli_packed {
 
     pub fn decode<'buf, T>(buf: &'buf [u8]) -> Result<T, Error>
     where
-        T: Decode<'buf, Packed, System>,
+        T: Decode<'buf, Packed, Global>,
     {
         let cx = context::new();
         ENCODING.from_slice_with(&cx, buf)
@@ -81,7 +81,7 @@ pub mod musli_packed {
 pub mod musli_storage {
     use alloc::vec::Vec;
 
-    use musli::alloc::System;
+    use musli::alloc::Global;
     use musli::mode::Binary;
     use musli::options::{self, Options};
     use musli::storage::{Encoding, Error};
@@ -108,7 +108,7 @@ pub mod musli_storage {
 
     pub fn decode<'buf, T>(buf: &'buf [u8]) -> Result<T, Error>
     where
-        T: Decode<'buf, Binary, System>,
+        T: Decode<'buf, Binary, Global>,
     {
         ENCODING.from_slice(buf)
     }
@@ -119,7 +119,7 @@ pub mod musli_storage {
 pub mod musli_wire {
     use alloc::vec::Vec;
 
-    use musli::alloc::System;
+    use musli::alloc::Global;
     use musli::mode::Binary;
     use musli::wire::Encoding;
     use musli::wire::Error;
@@ -145,7 +145,7 @@ pub mod musli_wire {
 
     pub fn decode<'buf, T>(buf: &'buf [u8]) -> Result<T, Error>
     where
-        T: Decode<'buf, Binary, System>,
+        T: Decode<'buf, Binary, Global>,
     {
         ENCODING.from_slice(buf)
     }
@@ -156,7 +156,7 @@ pub mod musli_wire {
 pub mod musli_descriptive {
     use alloc::vec::Vec;
 
-    use musli::alloc::System;
+    use musli::alloc::Global;
     use musli::descriptive::Encoding;
     use musli::descriptive::Error;
     use musli::mode::Binary;
@@ -182,7 +182,7 @@ pub mod musli_descriptive {
 
     pub fn decode<'buf, T>(buf: &'buf [u8]) -> Result<T, Error>
     where
-        T: Decode<'buf, Binary, System>,
+        T: Decode<'buf, Binary, Global>,
     {
         ENCODING.from_slice(buf)
     }
@@ -191,21 +191,21 @@ pub mod musli_descriptive {
 #[cfg(feature = "musli-value")]
 #[crate::benchmarker(as_bytes_disabled)]
 pub mod musli_value {
-    use musli::alloc::System;
+    use musli::alloc::Global;
     use musli::mode::Binary;
     use musli::value::Value;
     use musli::{Decode, Encode};
 
-    pub fn encode<T>(value: &T) -> Result<Value<System>, musli::value::Error>
+    pub fn encode<T>(value: &T) -> Result<Value<Global>, musli::value::Error>
     where
         T: Encode<Binary>,
     {
         musli::value::encode(value)
     }
 
-    pub fn decode<T>(buf: &Value<System>) -> Result<T, musli::value::Error>
+    pub fn decode<T>(buf: &Value<Global>) -> Result<T, musli::value::Error>
     where
-        for<'a> T: Decode<'a, Binary, System>,
+        for<'a> T: Decode<'a, Binary, Global>,
     {
         musli::value::decode(buf)
     }


### PR DESCRIPTION
## Issue

The documentation says that `musli::alloc::System` uses the `std::alloc::System` when in fact it uses the free function api in `alloc::alloc` which use the global allocator.

The `System` allocator *can* be the global allocator but it doesn't have to be. As per the `std::alloc` documentation:

> Currently the default global allocator is unspecified. Libraries, however,
> like `cdylib`s and `staticlib`s are guaranteed to use the [`System`] by
> default.

and the global allocator can be configured using the `#[global_allocator]` attribute.

The code is correct in using the global allocator, that's how `musli::alloc::Vec::into_std` is sound since `Vec` also uses the global allocator. The `std::alloc::System` allocator wouldn't be available for `#![no_std]` anyway.

It's just the documentation and naming that is misleading.

## Solution

In this PR I have renamed `System(Alloc)` to `Global(Alloc)` and the associated constant `IS_SYSTEM` to `IS_GLOBAL`. I have updated the documentation to mention "the global allocator" instead of `std::alloc::System`. Technically there is `std::alloc::Global`, but I've opted for "the global allocator" since `Global` is unstable and the std documentation also just uses "the global allocator".

I ran 
- `cargo clippy --tests --benches --all-features`, 
- `cargo test --all-features`, 
- `cargo doc --all-features`
- `cargo +nightly check -p no-std` 

after every commit with no related issues.

I have added `#[deprecated]` aliases for `System(Alloc)` to help with migration.

If this is too big of change out of the blue I understand 😅