### PR TITLE
Avoid another step of serialization

### DIFF
--- a/crates/musli-web/src/api.rs
+++ b/crates/musli-web/src/api.rs
@@ -144,9 +144,7 @@ where
 /// A request header.
 #[derive(Debug, Clone, Copy, Encode, Decode)]
 pub struct RequestHeader<'a> {
-    /// The index of the request.
-    pub index: u32,
-    /// The serial number of the request.
+    /// The serial of the request.
     pub serial: u32,
     /// The kind of the request.
     pub kind: &'a str,
@@ -155,11 +153,10 @@ pub struct RequestHeader<'a> {
 /// The header of a response.
 #[derive(Debug, Clone, Encode, Decode)]
 pub struct ResponseHeader<'de> {
-    /// The index of the request this is a response to.
-    pub index: u32,
-    /// The serial number of the request this is a response to.
+    /// The serial request this is a response to.
     pub serial: u32,
-    /// This is a broadcast over the specified topic.
+    /// This is a broadcast over the specified topic. If this is set, then
+    /// serial is `0`.
     #[musli(default, skip_encoding_if = Option::is_none)]
     pub broadcast: Option<&'de str>,
     /// An error message in the response.

--- a/crates/musli-web/src/ws.rs
+++ b/crates/musli-web/src/ws.rs
@@ -538,7 +538,6 @@ where
                                 this.buf.reset();
 
                                 this.buf.write(api::ResponseHeader {
-                                    index: header.index,
                                     serial: header.serial,
                                     broadcast: None,
                                     error: Some(this.error.as_str()),
@@ -605,7 +604,6 @@ where
         let this = unsafe { Pin::get_unchecked_mut(self) };
 
         this.buf.write(api::ResponseHeader {
-            index: 0,
             serial: 0,
             broadcast: Some(<T::Endpoint as api::Listener>::KIND),
             error: None,
@@ -648,7 +646,6 @@ where
         let this = unsafe { Pin::get_unchecked_mut(self) };
 
         this.buf.write(api::ResponseHeader {
-            index: header.index,
             serial: header.serial,
             broadcast: None,
             error: None,

--- a/crates/musli-web/src/yew021.rs
+++ b/crates/musli-web/src/yew021.rs
@@ -384,7 +384,7 @@ where
     fn on_raw_packet(self, f: Callback<Result<RawPacket, Error>>) -> Self;
 }
 
-impl<E> RequestBuilderExt<E> for RequestBuilder<'_, E>
+impl<E, T> RequestBuilderExt<E> for RequestBuilder<'_, E, T>
 where
     E: api::Endpoint,
 {


### PR DESCRIPTION
There's another set of allocations that can be amortized when dealing with raw packets if we add the infrastructure to recycle buffers.