### PR TITLE
zerocopy: Fix potential UB due to overflow in `Buf::swap` and `OwnedBuf::load_uninit_mut`

### DIFF
--- a/crates/musli-zerocopy/src/buf/buf.rs
+++ b/crates/musli-zerocopy/src/buf/buf.rs
@@ -884,7 +884,7 @@ impl Buf {
         }
 
         let start = a.max(b);
-        let end = start + size_of::<T>();
+        let end = start.saturating_add(size_of::<T>());
 
         if end > self.data.len() {
             return Err(Error::new(ErrorKind::OutOfRangeBounds {

--- a/crates/musli-zerocopy/src/buf/owned_buf.rs
+++ b/crates/musli-zerocopy/src/buf/owned_buf.rs
@@ -597,9 +597,12 @@ where
     {
         let at = reference.offset();
 
-        // Note: We only need this as debug assertion, because `MaybeUninit<T>`
+        // Note: We only need this as an assertion, because `MaybeUninit<T>`
         // does not implement `ZeroCopy`, so there is no way to construct.
-        assert!(at + size_of::<T>() <= self.len, "Length overflow");
+        assert!(
+            at.saturating_add(size_of::<T>()) <= self.len,
+            "Length overflow"
+        );
 
         // SAFETY: `MaybeUninit<T>` has no representation requirements and is
         // unaligned.


### PR DESCRIPTION
Both of these cases have code that boils down to:
```rust
reference.offset() + size_of::<T>() <= buf.len()
```

The code assumes that if the condition succeeds then the reference's range is inbounds. 
But when the addition overflows that's not the case. 

The fix I've implemented is replacing `+` with `.saturating_add(`. This is fine here because on overflow, the result of the addition is `usize::MAX`, a value that is guaranteed to always be greater than a buf's len (because a layout's size can't be greater than `isize::MAX`).

This has no impact on the assembly instructions when the size type is smaller than `usize`, but when it's `usize` it will add a few instructions.

Here are some tests that will fail miri on `main` if `overflow-checks` are disabled:

```rust
use musli_zerocopy::{Buf, OwnedBuf, Ref, endian::Native, mem::MaybeUninit};

#[test]
fn test_swap() {
    let mut buf = [1];
    let buf = unsafe { Buf::new_mut(&mut buf) };
    let r1 = Ref::<u8, Native, usize>::new(usize::MAX);
    let r2 = Ref::<u8, Native, usize>::new(0);
    buf.swap(r1, r2).unwrap();
}

#[test]
fn test_load_uninit() {
    let mut buf = OwnedBuf::new().with_size::<usize>();
    let r = Ref::<MaybeUninit<u8>, Native, usize>::new(usize::MAX);
    buf.load_uninit_mut(r);
}
```

I'd have added these as regression tests, but since they require you to disable `overflow-checks` I'm not sure how to test for this.

 
