### PR TITLE
Add invariant for `Ref`s to always reference a valid `Layout`

### DIFF
--- a/crates/musli-zerocopy/src/error.rs
+++ b/crates/musli-zerocopy/src/error.rs
@@ -216,6 +216,7 @@ pub(crate) enum ErrorKind {
     StackOverflow {
         capacity: usize,
     },
+    InvalidLayout,
     #[cfg(feature = "alloc")]
     CapacityError,
     #[cfg(feature = "alloc")]
@@ -292,6 +293,9 @@ impl fmt::Display for ErrorKind {
                 write!(f, "Stack with capacity {capacity} overflowed")
             }
             ErrorKind::Utf8Error { error } => error.fmt(f),
+            ErrorKind::InvalidLayout => {
+                write!(f, "Invalid layout")
+            }
             #[cfg(feature = "alloc")]
             ErrorKind::CapacityError => {
                 write!(f, "Out of capacity")

--- a/crates/musli-zerocopy/src/error.rs
+++ b/crates/musli-zerocopy/src/error.rs
@@ -227,10 +227,10 @@ impl fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ErrorKind::InvalidOffsetRange { offset, max } => {
-                write!(f, "Offset {offset} not in legal range 0-{max}",)
+                write!(f, "Offset {offset} not in valid range 0-{max}")
             }
             ErrorKind::InvalidMetadataRange { metadata, max } => {
-                write!(f, "Metadata {metadata} not in legal range 0-{max}")
+                write!(f, "Metadata {metadata} not in valid range 0-{max}")
             }
             ErrorKind::LengthOverflow { len, size } => {
                 write!(

--- a/crates/musli-zerocopy/src/mem/maybe_uninit.rs
+++ b/crates/musli-zerocopy/src/mem/maybe_uninit.rs
@@ -1,3 +1,4 @@
+use core::alloc::Layout;
 use core::fmt;
 use core::mem::{ManuallyDrop, size_of};
 use core::ptr::NonNull;
@@ -128,7 +129,7 @@ where
     }
 
     #[inline]
-    fn pointee_size<E: crate::ByteOrder, O: Size>(metadata: Self::Stored<O>) -> usize {
-        T::pointee_size::<E, O>(metadata)
+    fn pointee_layout<E: crate::ByteOrder, O: Size>(metadata: Self::Stored<O>) -> Option<Layout> {
+        T::pointee_layout::<E, O>(metadata)
     }
 }

--- a/crates/musli-zerocopy/src/mem/maybe_uninit.rs
+++ b/crates/musli-zerocopy/src/mem/maybe_uninit.rs
@@ -126,4 +126,9 @@ where
     {
         T::try_from_metadata(metadata)
     }
+
+    #[inline]
+    fn pointee_size<E: crate::ByteOrder, O: Size>(metadata: Self::Stored<O>) -> usize {
+        T::pointee_size::<E, O>(metadata)
+    }
 }

--- a/crates/musli-zerocopy/src/mem/maybe_uninit.rs
+++ b/crates/musli-zerocopy/src/mem/maybe_uninit.rs
@@ -1,9 +1,10 @@
-use core::alloc::Layout;
+use core::alloc::{Layout, LayoutError};
 use core::fmt;
 use core::mem::{ManuallyDrop, size_of};
 use core::ptr::NonNull;
 use core::slice;
 
+use crate::ByteOrder;
 use crate::buf;
 use crate::pointer::{Pointee, Size};
 use crate::traits::ZeroCopy;
@@ -129,7 +130,11 @@ where
     }
 
     #[inline]
-    fn pointee_layout<E: crate::ByteOrder, O: Size>(metadata: Self::Stored<O>) -> Option<Layout> {
+    fn pointee_layout<E, O>(metadata: Self::Stored<O>) -> Result<Layout, LayoutError>
+    where
+        E: ByteOrder,
+        O: Size,
+    {
         T::pointee_layout::<E, O>(metadata)
     }
 }

--- a/crates/musli-zerocopy/src/pointer/pointee.rs
+++ b/crates/musli-zerocopy/src/pointer/pointee.rs
@@ -50,7 +50,7 @@ pub trait Pointee: self::sealed::Sealed {
     where
         O: Size;
 
-    /// Will return `usize::MAX` as an invalid size.
+    /// The layout of `T` with the given stored metadata.
     #[doc(hidden)]
     fn pointee_layout<E: ByteOrder, O: Size>(metadata: Self::Stored<O>) -> Option<Layout>;
 }

--- a/crates/musli-zerocopy/src/pointer/pointee.rs
+++ b/crates/musli-zerocopy/src/pointer/pointee.rs
@@ -1,10 +1,10 @@
 use core::alloc::Layout;
 use core::fmt;
 
+use crate::ByteOrder;
 use crate::error::IntoRepr;
 use crate::pointer::Size;
 use crate::traits::ZeroCopy;
-use crate::ByteOrder;
 
 mod sealed {
     use crate::mem::MaybeUninit;

--- a/crates/musli-zerocopy/src/pointer/pointee.rs
+++ b/crates/musli-zerocopy/src/pointer/pointee.rs
@@ -1,4 +1,4 @@
-use core::alloc::Layout;
+use core::alloc::{Layout, LayoutError};
 use core::fmt;
 
 use crate::ByteOrder;
@@ -52,7 +52,10 @@ pub trait Pointee: self::sealed::Sealed {
 
     /// The layout of `T` with the given stored metadata.
     #[doc(hidden)]
-    fn pointee_layout<E: ByteOrder, O: Size>(metadata: Self::Stored<O>) -> Option<Layout>;
+    fn pointee_layout<E, O>(metadata: Self::Stored<O>) -> Result<Layout, LayoutError>
+    where
+        E: ByteOrder,
+        O: Size;
 }
 
 impl<T> Pointee for T
@@ -74,8 +77,12 @@ where
     }
 
     #[inline(always)]
-    fn pointee_layout<E: ByteOrder, O: Size>((): Self::Stored<O>) -> Option<Layout> {
-        Some(Layout::new::<T>())
+    fn pointee_layout<E, O>((): Self::Stored<O>) -> Result<Layout, LayoutError>
+    where
+        E: ByteOrder,
+        O: Size,
+    {
+        Ok(Layout::new::<T>())
     }
 }
 
@@ -98,9 +105,13 @@ where
     }
 
     #[inline(always)]
-    fn pointee_layout<E: ByteOrder, O: Size>(metadata: Self::Stored<O>) -> Option<Layout> {
+    fn pointee_layout<E, O>(metadata: Self::Stored<O>) -> Result<Layout, LayoutError>
+    where
+        E: ByteOrder,
+        O: Size,
+    {
         let len = metadata.as_usize::<E>();
-        Layout::array::<T>(len).ok()
+        Layout::array::<T>(len)
     }
 }
 
@@ -120,7 +131,11 @@ impl Pointee for str {
     }
 
     #[inline(always)]
-    fn pointee_layout<E: ByteOrder, O: Size>(metadata: Self::Stored<O>) -> Option<Layout> {
-        Layout::array::<u8>(metadata.as_usize::<E>()).ok()
+    fn pointee_layout<E, O>(metadata: Self::Stored<O>) -> Result<Layout, LayoutError>
+    where
+        E: ByteOrder,
+        O: Size,
+    {
+        Layout::array::<u8>(metadata.as_usize::<E>())
     }
 }

--- a/crates/musli-zerocopy/src/pointer/ref.rs
+++ b/crates/musli-zerocopy/src/pointer/ref.rs
@@ -233,6 +233,7 @@ where
     /// * Packed [`metadata()`] cannot be constructed from `T::Metadata` (reason
     ///   depends on the exact metadata).
     /// * The metadata must describe a valid `Layout`.
+    /// * The `offset` plus this layout's size must not overflow `usize::MAX`.
     ///
     /// To guarantee that this constructor will never panic, [`Ref<T, E,
     /// usize>`] can be used. This also ensures that construction is a no-op.
@@ -273,6 +274,7 @@ where
     /// * Packed [`metadata()`] cannot be constructed from `T::Metadata` (reason
     ///   depends on the exact metadata).
     /// * The metadata must describe a valid `Layout`.
+    /// * The `offset` plus this layout's size must not overflow `usize::MAX`.
     ///
     /// To guarantee that this constructor will never error, [`Ref<T, Native,
     /// usize>`] can be used. This also ensures that construction is a no-op.

--- a/crates/musli-zerocopy/src/pointer/ref.rs
+++ b/crates/musli-zerocopy/src/pointer/ref.rs
@@ -69,16 +69,20 @@ where
 
     #[inline]
     unsafe fn pad(padder: &mut Padder<'_, Self>) {
-        padder.pad::<O>();
-        padder.pad::<T::Stored<O>>();
+        unsafe {
+            padder.pad::<O>();
+            padder.pad::<T::Stored<O>>();
+        }
     }
 
     #[inline]
     unsafe fn validate(validator: &mut Validator<'_, Self>) -> Result<(), Error> {
-        let offset = *validator.field::<O>()?;
-        let metadata = *validator.field::<T::Stored<O>>()?;
-        Self::try_from_parts(offset, metadata)?;
-        Ok(())
+        unsafe {
+            let offset = *validator.field::<O>()?;
+            let metadata = *validator.field::<T::Stored<O>>()?;
+            Self::try_from_parts(offset, metadata)?;
+            Ok(())
+        }
     }
 
     #[inline]

--- a/crates/musli-zerocopy/src/pointer/ref.rs
+++ b/crates/musli-zerocopy/src/pointer/ref.rs
@@ -195,7 +195,7 @@ where
     fn from_parts(offset: O, metadata: T::Stored<O>) -> Self {
         match Self::try_from_parts(offset, metadata) {
             Ok(ok) => ok,
-            Err(_) => panic!("Offset plus Size overflows `usize`"),
+            Err(_) => panic!("Metadata describes an invalid layout"),
         }
     }
 

--- a/crates/musli-zerocopy/src/pointer/size.rs
+++ b/crates/musli-zerocopy/src/pointer/size.rs
@@ -132,11 +132,11 @@ macro_rules! impl_size {
             where
                 E: ByteOrder,
             {
-                if self > usize::MAX as $ty {
-                    usize::MAX
-                } else {
-                    $swap(self) as usize
-                }
+                debug_assert!(
+                    usize::try_from($swap(self)).is_ok(),
+                    "Value {self} cannot be represented on this platform"
+                );
+                $swap(self) as usize
             }
 
             #[inline]
@@ -149,7 +149,8 @@ macro_rules! impl_size {
 
 impl_size!(u8, core::convert::identity);
 impl_size!(u16, E::swap_u16);
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl_size!(u32, E::swap_u32);
 #[cfg(target_pointer_width = "64")]
 impl_size!(u64, E::swap_u64);
-impl_size!(usize, core::convert::identity);
+impl_size!(usize, E::swap_usize);

--- a/crates/musli-zerocopy/src/slice/packed.rs
+++ b/crates/musli-zerocopy/src/slice/packed.rs
@@ -146,11 +146,11 @@ where
         L: TryFrom<usize>,
     {
         let Some(offset) = O::try_from(offset).ok() else {
-            panic!("Offset {offset:?} not in legal range 0-{}", O::MAX);
+            panic!("Offset {offset:?} not in valid range 0-{}", O::MAX);
         };
 
         let Some(len) = L::try_from(len).ok() else {
-            panic!("Length {len:?} not in legal range 0-{}", L::MAX);
+            panic!("Length {len:?} not in valid range 0-{}", L::MAX);
         };
 
         Self {
@@ -364,10 +364,10 @@ where
 
     #[inline]
     fn load<'buf>(&self, buf: &'buf Buf) -> Result<&'buf Self::Target, Error> {
-        buf.load(Ref::<[T], Native, usize>::with_metadata(
+        buf.load(Ref::<[T], Native, usize>::try_with_metadata(
             self.offset.as_usize::<E>(),
             self.len.as_usize::<E>(),
-        ))
+        )?)
     }
 }
 

--- a/crates/musli-zerocopy/src/tests/invalid_ref.rs
+++ b/crates/musli-zerocopy/src/tests/invalid_ref.rs
@@ -1,41 +1,14 @@
 use crate::{endian::Native, Ref};
 
-#[test]
-fn test_new() {
-    Ref::<u8, Native, usize>::new(usize::MAX - 1);
-}
-
-#[test]
-#[should_panic = "overflow"]
-fn test_new_panic() {
-    Ref::<u8, Native, usize>::new(usize::MAX);
-}
-
-#[test]
-fn test_sized_with_metadata() {
-    Ref::<u8, Native, usize>::try_with_metadata(usize::MAX, ()).unwrap_err();
-    Ref::<u8, Native, usize>::try_with_metadata(usize::MAX - 1, ()).unwrap();
-
-    Ref::<u16, Native, usize>::try_with_metadata(usize::MAX, ()).unwrap_err();
-    Ref::<u16, Native, usize>::try_with_metadata(usize::MAX - 1, ()).unwrap_err();
-    Ref::<u16, Native, usize>::try_with_metadata(usize::MAX - 2, ()).unwrap();
-    Ref::<u16, Native, usize>::try_with_metadata(usize::MAX - 3, ()).unwrap();
-}
+const MAX: usize = isize::MAX as usize;
 
 #[test]
 fn test_slice_with_metadata() {
-    Ref::<[()], Native, usize>::try_with_metadata(usize::MAX, usize::MAX).unwrap();
+    Ref::<[()], Native, usize>::try_with_metadata(0, usize::MAX).unwrap();
 
-    Ref::<[u8], Native, usize>::try_with_metadata(usize::MAX, 0).unwrap();
-    Ref::<[u8], Native, usize>::try_with_metadata(usize::MAX - 1, 0).unwrap();
-    Ref::<[u8], Native, usize>::try_with_metadata(usize::MAX - 1, 1).unwrap();
-    Ref::<[u8], Native, usize>::try_with_metadata(usize::MAX - 1, 2).unwrap_err();
-    Ref::<[u8], Native, usize>::try_with_metadata(0, usize::MAX).unwrap();
-    Ref::<[u8], Native, usize>::try_with_metadata(1, usize::MAX).unwrap_err();
-    Ref::<[u8], Native, usize>::try_with_metadata(1, usize::MAX - 1).unwrap();
+    Ref::<[u8], Native, usize>::try_with_metadata(0, MAX).unwrap();
+    Ref::<[u8], Native, usize>::try_with_metadata(0, MAX + 1).unwrap_err();
 
-    Ref::<[u16], Native, usize>::try_with_metadata(usize::MAX, 0).unwrap();
-    Ref::<[u16], Native, usize>::try_with_metadata(usize::MAX - 2, 0).unwrap();
-    Ref::<[u16], Native, usize>::try_with_metadata(usize::MAX - 2, 1).unwrap();
-    Ref::<[u16], Native, usize>::try_with_metadata(usize::MAX - 2, 2).unwrap_err();
+    Ref::<[u16], Native, usize>::try_with_metadata(0, MAX / 2).unwrap();
+    Ref::<[u16], Native, usize>::try_with_metadata(0, (MAX / 2) + 1).unwrap_err();
 }

--- a/crates/musli-zerocopy/src/tests/invalid_ref.rs
+++ b/crates/musli-zerocopy/src/tests/invalid_ref.rs
@@ -1,4 +1,4 @@
-use crate::{endian::Native, Ref};
+use crate::{Ref, endian::Native};
 
 const MAX: usize = isize::MAX as usize;
 

--- a/crates/musli-zerocopy/src/tests/invalid_ref.rs
+++ b/crates/musli-zerocopy/src/tests/invalid_ref.rs
@@ -1,0 +1,41 @@
+use crate::{endian::Native, Ref};
+
+#[test]
+fn test_new() {
+    Ref::<u8, Native, usize>::new(usize::MAX - 1);
+}
+
+#[test]
+#[should_panic = "overflow"]
+fn test_new_panic() {
+    Ref::<u8, Native, usize>::new(usize::MAX);
+}
+
+#[test]
+fn test_sized_with_metadata() {
+    Ref::<u8, Native, usize>::try_with_metadata(usize::MAX, ()).unwrap_err();
+    Ref::<u8, Native, usize>::try_with_metadata(usize::MAX - 1, ()).unwrap();
+
+    Ref::<u16, Native, usize>::try_with_metadata(usize::MAX, ()).unwrap_err();
+    Ref::<u16, Native, usize>::try_with_metadata(usize::MAX - 1, ()).unwrap_err();
+    Ref::<u16, Native, usize>::try_with_metadata(usize::MAX - 2, ()).unwrap();
+    Ref::<u16, Native, usize>::try_with_metadata(usize::MAX - 3, ()).unwrap();
+}
+
+#[test]
+fn test_slice_with_metadata() {
+    Ref::<[()], Native, usize>::try_with_metadata(usize::MAX, usize::MAX).unwrap();
+
+    Ref::<[u8], Native, usize>::try_with_metadata(usize::MAX, 0).unwrap();
+    Ref::<[u8], Native, usize>::try_with_metadata(usize::MAX - 1, 0).unwrap();
+    Ref::<[u8], Native, usize>::try_with_metadata(usize::MAX - 1, 1).unwrap();
+    Ref::<[u8], Native, usize>::try_with_metadata(usize::MAX - 1, 2).unwrap_err();
+    Ref::<[u8], Native, usize>::try_with_metadata(0, usize::MAX).unwrap();
+    Ref::<[u8], Native, usize>::try_with_metadata(1, usize::MAX).unwrap_err();
+    Ref::<[u8], Native, usize>::try_with_metadata(1, usize::MAX - 1).unwrap();
+
+    Ref::<[u16], Native, usize>::try_with_metadata(usize::MAX, 0).unwrap();
+    Ref::<[u16], Native, usize>::try_with_metadata(usize::MAX - 2, 0).unwrap();
+    Ref::<[u16], Native, usize>::try_with_metadata(usize::MAX - 2, 1).unwrap();
+    Ref::<[u16], Native, usize>::try_with_metadata(usize::MAX - 2, 2).unwrap_err();
+}

--- a/crates/musli-zerocopy/src/tests/invalid_ref.rs
+++ b/crates/musli-zerocopy/src/tests/invalid_ref.rs
@@ -1,4 +1,9 @@
-use crate::{Ref, endian::Native};
+use musli_zerocopy_macros::ZeroCopy;
+
+use crate::{
+    Ref,
+    endian::{Big, Little, Native},
+};
 
 const MAX: usize = isize::MAX as usize;
 
@@ -11,4 +16,23 @@ fn test_slice_with_metadata() {
 
     Ref::<[u16], Native, usize>::try_with_metadata(0, MAX / 2).unwrap();
     Ref::<[u16], Native, usize>::try_with_metadata(0, (MAX / 2) + 1).unwrap_err();
+}
+
+#[test]
+fn test_metadata_byte_order() {
+    #[derive(ZeroCopy)]
+    #[zero_copy(crate)]
+    #[repr(C)]
+    struct BigStruct([u8; 4096]);
+
+    const BIG_MAX_LEN: usize = MAX / size_of::<BigStruct>();
+
+    Ref::<[BigStruct], Native, usize>::try_with_metadata(0, BIG_MAX_LEN).unwrap();
+    Ref::<[BigStruct], Native, usize>::try_with_metadata(0, BIG_MAX_LEN + 1).unwrap_err();
+
+    Ref::<[BigStruct], Little, usize>::try_with_metadata(0, BIG_MAX_LEN).unwrap();
+    Ref::<[BigStruct], Little, usize>::try_with_metadata(0, BIG_MAX_LEN + 1).unwrap_err();
+
+    Ref::<[BigStruct], Big, usize>::try_with_metadata(0, BIG_MAX_LEN).unwrap();
+    Ref::<[BigStruct], Big, usize>::try_with_metadata(0, BIG_MAX_LEN + 1).unwrap_err();
 }

--- a/crates/musli-zerocopy/src/tests/mod.rs
+++ b/crates/musli-zerocopy/src/tests/mod.rs
@@ -1,2 +1,3 @@
 mod enum_byte_order;
+mod invalid_ref;
 mod primitives;

--- a/crates/musli-zerocopy/tests/reject_invalid_refs.rs
+++ b/crates/musli-zerocopy/tests/reject_invalid_refs.rs
@@ -1,0 +1,21 @@
+use musli_zerocopy::endian::Native;
+use musli_zerocopy::mem::MaybeUninit;
+use musli_zerocopy::{Buf, OwnedBuf, Ref};
+
+#[test]
+#[should_panic = "Offset 18446744073709551615usize not in valid range 0-18446744073709551614usize"]
+fn test_swap() {
+    let mut buf = [1];
+    let buf = unsafe { Buf::new_mut(&mut buf) };
+    let r1 = Ref::<u8, Native, usize>::new(usize::MAX);
+    let r2 = Ref::<u8, Native, usize>::new(0);
+    buf.swap(r1, r2).unwrap();
+}
+
+#[test]
+#[should_panic = "Offset 18446744073709551615usize not in valid range 0-18446744073709551614usize"]
+fn test_load_uninit() {
+    let mut buf = OwnedBuf::new().with_size::<usize>();
+    let r = Ref::<MaybeUninit<u8>, Native, usize>::new(usize::MAX);
+    buf.load_uninit_mut(r);
+}


### PR DESCRIPTION
Discussed in
- #312

Closes #312 

In the first commit I've implemented the `usize::MAX - size` invariant. The second commit changes that to a `Layout` invariant.

The `Ref` can no longer be byte-swapped since that could break the invariant.