### PR TITLE
zerocopy: Tests for trying to load invalid layouts

### DIFF
--- a/crates/musli-zerocopy/src/endian/mod.rs
+++ b/crates/musli-zerocopy/src/endian/mod.rs
@@ -327,6 +327,20 @@ where
     #[doc(hidden)]
     fn swap_isize(value: isize) -> isize;
 
+    /// Swap the bytes of a `u8` with the current byte order.
+    #[doc(hidden)]
+    #[inline]
+    fn swap_u8(value: u8) -> u8 {
+        value
+    }
+
+    /// Swap the bytes of a `i8` with the current byte order.
+    #[doc(hidden)]
+    #[inline]
+    fn swap_i8(value: i8) -> i8 {
+        value
+    }
+
     /// Swap the bytes of a `u16` with the current byte order.
     #[doc(hidden)]
     fn swap_u16(value: u16) -> u16;

--- a/crates/musli-zerocopy/src/pointer/ref.rs
+++ b/crates/musli-zerocopy/src/pointer/ref.rs
@@ -64,6 +64,7 @@ where
     // validly sized reference.
     const ANY_BITS: bool = false;
 
+    /// The `Ref` type is never padded.
     const PADDED: bool = const {
         debug_assert!(
             size_of::<Self>() == (size_of::<O>() + size_of::<T::Stored<O>>()),
@@ -953,9 +954,10 @@ where
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "Ref<{}, {}> {{ offset: {:?}, metadata: {:?} }}",
+            "Ref<{}, {}, {}> {{ offset: {:?}, metadata: {:?} }}",
             any::type_name::<T>(),
             E::NAME,
+            any::type_name::<O>(),
             self.offset,
             self.metadata,
         )

--- a/crates/musli-zerocopy/src/traits.rs
+++ b/crates/musli-zerocopy/src/traits.rs
@@ -414,7 +414,10 @@ unsafe impl<T: ?Sized> ZeroSized for PhantomData<T> {}
 /// assert_eq!(buf.load(ptr)?, &Custom { field: 42, ignore: () });
 /// # Ok::<_, musli_zerocopy::Error>(())
 /// ```
-pub unsafe trait ZeroCopy: Sized {
+pub unsafe trait ZeroCopy
+where
+    Self: Sized,
+{
     /// Indicates if the type can inhabit all possible bit patterns within its
     /// [`size_of::<Self>()`] bytes.
     const ANY_BITS: bool;
@@ -851,12 +854,12 @@ macro_rules! impl_number {
 
 impl_number!(usize, E::swap_usize);
 impl_number!(isize, E::swap_isize);
-impl_number!(u8, core::convert::identity);
+impl_number!(u8, E::swap_u8);
 impl_number!(u16, E::swap_u16);
 impl_number!(u32, E::swap_u32);
 impl_number!(u64, E::swap_u64);
 impl_number!(u128, E::swap_u128);
-impl_number!(i8, core::convert::identity);
+impl_number!(i8, E::swap_i8);
 impl_number!(i16, E::swap_i16);
 impl_number!(i32, E::swap_i32);
 impl_number!(i64, E::swap_i64);


### PR DESCRIPTION
Hey @bluurryy, I added some tests here for loading invalid layouts from a particular bit pattern. Since you were curious about byte swapping this might (or might not) clear things up a bit :)

The idea is to define `RawRef` and have it represent invalid bit patterns in a particular endianness, so we swap when we define it, `ByteOrder`-swapping modifies endianness if the specified order is different from native.