### PR TITLE
musli: Make sure we can encode recursive values

### DIFF
--- a/crates/musli/src/value/mod.rs
+++ b/crates/musli/src/value/mod.rs
@@ -286,7 +286,7 @@ where
     pub fn encode(&self, value: impl Encode<M>) -> Result<Value<Global>, Error> {
         let mut output = Value::new(ValueKind::Empty);
         let cx = crate::context::new().with_error();
-        ValueEncoder::<OPT, _, _, M>::new(&cx, &mut output).encode(value)?;
+        ValueEncoder::<OPT, _, _, M>::new(&cx, 0, &mut output).encode(value)?;
         Ok(output)
     }
 
@@ -330,7 +330,7 @@ where
         C: Context,
     {
         let mut output = Value::new(ValueKind::Empty);
-        ValueEncoder::<OPT, _, _, M>::new(cx, &mut output).encode(value)?;
+        ValueEncoder::<OPT, _, _, M>::new(cx, 0, &mut output).encode(value)?;
         Ok(output)
     }
 

--- a/crates/musli/tests/allocator.rs
+++ b/crates/musli/tests/allocator.rs
@@ -1,0 +1,30 @@
+use anyhow::Result;
+use musli::alloc::Global;
+use musli::value::{self, Value};
+use musli::{Allocator, Decode, Encode};
+
+#[derive(Debug, PartialEq, Encode, Decode)]
+struct Struct<A = Global>
+where
+    A: Allocator,
+{
+    value: Value<A>,
+}
+
+#[test]
+fn with_allocator() -> Result<()> {
+    assert_eq!(
+        value::encode(Value::<Global>::empty())?,
+        Value::<Global>::empty()
+    );
+
+    musli::macros::assert_roundtrip_eq! {
+        descriptive,
+        Struct::<Global> {
+            value: Value::empty(),
+        },
+        json = r#"{"value":null}"#
+    };
+
+    Ok(())
+}

--- a/crates/musli/tests/option.rs
+++ b/crates/musli/tests/option.rs
@@ -1,0 +1,35 @@
+use musli::value;
+use musli::{Decode, Encode};
+
+use anyhow::Result;
+
+#[derive(Debug, PartialEq, Encode, Decode)]
+struct Struct {
+    value: Option<Option<bool>>,
+    inner: Option<Box<Struct>>,
+}
+
+#[test]
+fn nested_option() -> Result<()> {
+    let a = value::encode(Some(Some(true)))?;
+    let b = value::encode(Some(None::<bool>))?;
+    let c = value::encode(None::<Option<bool>>)?;
+
+    assert_eq!(value::decode(&a), Ok(Some(Some(true))));
+    assert_eq!(value::decode(&b), Ok(Some(None::<bool>)));
+    assert_eq!(value::decode(&c), Ok(None::<Option<bool>>));
+
+    musli::macros::assert_roundtrip_eq! {
+        descriptive,
+        Struct {
+            value: Some(Some(true)),
+            inner: Some(Box::new(Struct {
+                value: Some(Some(true)),
+                inner: None,
+            })),
+        },
+        json = r#"{"value":true,"inner":{"value":true,"inner":null}}"#
+    };
+
+    Ok(())
+}


### PR DESCRIPTION
This fixes an issue with a recursive type being used when encoding `Value` types, specifically how `encode_some` returns a type with the signature `ValueEncoder<SomeValueEncoder<SomeValueEncoder<...>>>`.

Instead we track how many levels of optional `Some` nesting we need to construct at runtime.