### PR TITLE
musli: fix assertion

### DIFF
--- a/crates/musli/src/fixed.rs
+++ b/crates/musli/src/fixed.rs
@@ -68,7 +68,7 @@ impl<const N: usize> FixedBytes<N> {
     #[inline]
     pub fn with_capacity(capacity: usize) -> Self {
         assert!(
-            capacity < N,
+            capacity <= N,
             "Requested capacity {capacity} is larger than {N}"
         );
         Self::new()


### PR DESCRIPTION
In musli/crates/musli/src/fixed.rs, this assertion's message requires capacity not larger than N which means capacity <= N while predicate is capacity < N. Based on semantics and comments(Panics if the requested capacity is larger than `N` => capacity <= N), the assertion should be changed to `assert!(capacity <= N,"Requested capacity {capacity} is larger than {N}");`.
```rust
    /// # Panics
    ///
    /// Panics if the requested capacity is larger than `N`.
    ///
    /// ```should_panic
    /// use musli::fixed::FixedBytes;
    ///
    /// // This will panic
    /// let _buffer = FixedBytes::<10>::with_capacity(20);
    /// ```
    #[inline]
    pub fn with_capacity(capacity: usize) -> Self {
        assert!(
            capacity < N,
            "Requested capacity {capacity} is larger than {N}"
        );
        Self::new()
    }
```